### PR TITLE
Fix US30 TP1 pipeline by persisting R-context and gating Tp1Hit on close success

### DIFF
--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -79,15 +79,19 @@ namespace GeminiV26.Instruments.US30
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
-                    if (CheckTp1Hit(pos, rDist, tp1R))
+                    if (CheckTp1Hit(pos, ctx, rDist, tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
-                        MoveToBreakEven(pos, ctx, rDist);
+                        bool tp1Done = ExecuteTp1(pos, ctx);
 
-                        ctx.Tp1Hit = true;
+                        if (tp1Done)
+                        {
+                            MoveToBreakEven(pos, ctx, rDist);
 
-                        if (ctx.TrailingMode == TrailingMode.None)
-                            ctx.TrailingMode = TrailingMode.Normal;
+                            if (ctx.TrailingMode == TrailingMode.None)
+                                ctx.TrailingMode = TrailingMode.Normal;
+
+                            _bot.Print($"[US30 TP1 STATE] pos={pos.Id} tp1Hit={ctx.Tp1Hit} be={ctx.BePrice} trailing={ctx.TrailingMode}");
+                        }
 
                         return; // <<< KRITIKUS
                     }
@@ -106,7 +110,7 @@ namespace GeminiV26.Instruments.US30
         // =====================================================
         // TP1 CHECK
         // =====================================================
-        private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
+        private bool CheckTp1Hit(Position pos, PositionContext ctx, double rDist, double tp1R)
         {
             var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (sym == null)
@@ -120,19 +124,26 @@ namespace GeminiV26.Instruments.US30
                 ? sym.Bid
                 : sym.Ask;
 
-            return pos.TradeType == TradeType.Buy
+            bool hit = pos.TradeType == TradeType.Buy
                 ? priceNow >= tp1Price
                 : priceNow <= tp1Price;
+
+            _bot.Print(
+                $"[US30 TP1 DBG] pos={pos.Id} dir={pos.TradeType} entry={pos.EntryPrice} sl={pos.StopLoss} " +
+                $"r={rDist} tp1R={tp1R} tp1={tp1Price} bid={sym.Bid} ask={sym.Ask} tp1Hit={ctx.Tp1Hit} hit={hit}"
+            );
+
+            return hit;
         }
 
         // =====================================================
         // TP1 EXECUTION
         // =====================================================
-         private void ExecuteTp1(Position pos, PositionContext ctx)
+         private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
             var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (sym == null)
-                return;
+                return false;
 
             double frac = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
                 ? ctx.Tp1CloseFraction
@@ -142,23 +153,33 @@ namespace GeminiV26.Instruments.US30
 
             long targetUnits = (long)Math.Floor(pos.VolumeInUnits * frac);
             if (targetUnits <= 0)
-                return;
+                return false;
 
             long closeUnits = (long)sym.NormalizeVolumeInUnits(targetUnits);
 
             if (closeUnits < minUnits)
-                return;
+                return false;
 
             if (closeUnits >= pos.VolumeInUnits)
                 closeUnits = (long)(pos.VolumeInUnits - minUnits);
 
             if (closeUnits <= 0)
-                return;
+                return false;
 
-            _bot.ClosePosition(pos, closeUnits);
+            _bot.Print($"[US30 TP1 EXEC] pos={pos.Id} closeUnits={closeUnits} posVol={pos.VolumeInUnits} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}");
+
+            var closeResult = _bot.ClosePosition(pos, closeUnits);
+
+            _bot.Print($"[US30 TP1 EXEC RES] pos={pos.Id} success={closeResult.IsSuccessful} err={closeResult.Error}");
+
+            if (!closeResult.IsSuccessful)
+                return false;
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = pos.VolumeInUnits - closeUnits;
+            ctx.Tp1Hit = true;
+
+            return true;
         }
 
         // =====================================================

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -134,8 +134,21 @@ namespace GeminiV26.Instruments.US30
                 Symbol = result.Position.SymbolName,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence,
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
+
+                RiskPriceDistance = slPriceDist,
+
+                Tp1R = tp1R,
+                Tp1Ratio = tp1Ratio,
+                Tp2R = tp2R,
+                Tp2Ratio = tp2Ratio,
+                Tp1Price = tradeType == TradeType.Buy
+                    ? result.Position.EntryPrice + slPriceDist * tp1R
+                    : result.Position.EntryPrice - slPriceDist * tp1R,
+                Tp2Price = tp2Price,
 
                 Tp1Hit = false,
                 Tp1CloseFraction = tp1Ratio,
@@ -149,7 +162,19 @@ namespace GeminiV26.Instruments.US30
                     tempFinalConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
+                EntryVolumeInUnits = volumeUnits,
+                RemainingVolumeInUnits = volumeUnits,
+
             };
+
+            ctx.ComputeFinalConfidence();
+
+            _bot.Print(
+                $"[US30 CTX INIT] pos={positionKey} dir={result.Position.TradeType} " +
+                $"entry={ctx.EntryPrice} slDist={ctx.RiskPriceDistance} tp1R={ctx.Tp1R} " +
+                $"tp2R={ctx.Tp2R} tp1Frac={ctx.Tp1CloseFraction} vol={ctx.EntryVolumeInUnits} " +
+                $"entryScore={ctx.EntryScore} logic={ctx.LogicConfidence} final={ctx.FinalConfidence}"
+            );
 
             _positionContexts[positionKey] = ctx;
             _exitManager.RegisterContext(ctx);


### PR DESCRIPTION
### Motivation
- US30 trades did not execute TP1 while other instruments worked because the exit path relied on R-based context fields that were not persisted at US30 entry. 
- The exit manager was falling back to defaults and marking TP1 as hit regardless of partial-close success, which prevented BE and trailing activation.

### Description
- Populate US30 `PositionContext` at entry with `RiskPriceDistance`, `Tp1R`, `Tp1Price`, `Tp2R`, `Tp2Price`, `EntryScore`, `LogicConfidence`, `EntryVolumeInUnits` and `RemainingVolumeInUnits` and call `ctx.ComputeFinalConfidence()` immediately after creation. 
- Compute and store TP1 price in the executor using the same R-units used by the risk sizer so exit comparisons use consistent units. 
- Harden `Us30ExitManager` TP1 flow: add verbose TP1 trigger debug log, make `ExecuteTp1` return `bool`, check `ClosePosition` result and only set `ctx.Tp1Hit = true` after a successful partial close, then apply BE/trailing. 
- Add explicit debug prints at context init, TP1 check, partial-close execution/result, and TP1 state transition to aid further diagnostics.

### Testing
- No automated unit or build tests were executed because the repository contains no solution/project files (`*.sln` / `*.csproj`) in this environment, so a full build/test run could not be performed. 
- Performed repository-level validation commands and a commit: `git status` and `git commit` completed successfully, and the two modified files were committed (`Instruments/US30/Us30InstrumentExecutor.cs`, `Instruments/US30/Us30ExitManager.cs`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af0b195ff483289a193470d78c0a49)