### PR TITLE
Implement DST-aware GlobalSessionGate V2 with SessionCalendar and timeframe policy

### DIFF
--- a/Core/Gates/GlobalSessionGate.cs
+++ b/Core/Gates/GlobalSessionGate.cs
@@ -1,119 +1,315 @@
 ﻿using System;
-using System.Collections.Generic;
 using cAlgo.API;
 
 public class GlobalSessionGate
 {
     private readonly Robot _bot;
+    private readonly SessionCalendar _calendar;
 
     public GlobalSessionGate(Robot bot)
     {
         _bot = bot;
+        _calendar = new SessionCalendar();
     }
 
     public bool AllowEntry(string symbol)
     {
-        // =========================
-        // CRYPTO = 24/7, NO SESSION GATE
-        // =========================
-        if (IsCrypto(symbol))
-            return true;
+        return GetDecision(symbol, TimeFrame.Minute).Allow;
+    }
 
-        TimeSpan utc = _bot.Server.Time.TimeOfDay;
+    public bool AllowEntry(string symbol, TimeFrame tf)
+    {
+        return GetDecision(symbol, tf).Allow;
+    }
 
-        // =================================================
-        // 1. GLOBÁLIS FIX TILTÁSOK (EVENT AIRBAG)
-        // =================================================
+    public SessionDecision GetDecision(string symbol, TimeFrame tf)
+    {
+        DateTime utc = _bot.Server.Time;
+        bool usDst = _calendar.IsUsDst(utc);
+        bool euDst = _calendar.IsEuDst(utc);
+        TimeSpan nyOpen = _calendar.GetNyOpenUtc(utc);
+        TimeSpan nyCashOpen = _calendar.GetNyCashOpenUtc(utc);
+        TimeSpan nyClose = _calendar.GetNyCloseUtc(utc);
+        TimeSpan londonOpen = _calendar.GetLondonOpenUtc(utc);
+        TimeSpan londonClose = _calendar.GetLondonCloseUtc(utc);
+        bool isOverlap = _calendar.IsLondonNyOverlap(utc);
 
-        // NY close / Asia open chaos
-        if (IsInRange(utc, new TimeSpan(22, 0, 0), new TimeSpan(0, 30, 0)))
-            return false;
+        _bot.Print("[SESSION_CALENDAR] utc={0:o} usDst={1} euDst={2} nyOpen={3} nyCashOpen={4} nyClose={5} londonOpen={6} londonClose={7}",
+            utc, usDst, euDst, nyOpen, nyCashOpen, nyClose, londonOpen, londonClose);
 
-        // NY PRE-OPEN positioning
-        if (IsInRange(utc, new TimeSpan(13, 50, 0), new TimeSpan(14, 30, 0)))
-            return false;
-
-        // NY CASH OPEN airbag
-        if (IsInRange(utc, new TimeSpan(14, 30, 0), new TimeSpan(14, 40, 0)))
-            return false;
-
-        // NY LUNCH chop (csak FX)
-        /*if (IsFx(symbol) &&
-            IsInRange(utc, new TimeSpan(16, 30, 0), new TimeSpan(17, 30, 0)))
-            return false;
-*/
-        // =================================================
-        // 3. NEW YORK SESSION – AUD/NZD/JPY TILTÁS (LONDON SZABAD)
-        // =================================================
-        if (IsNySession(utc) && IsFx(symbol))
+        var decision = new SessionDecision
         {
-            // USDJPY kivétel marad NY-ban
-            if (symbol == "USDJPY")
-                return true;
+            Symbol = symbol,
+            Timeframe = FormatTimeFrame(tf),
+            IsUsDst = usDst,
+            IsEuDst = euDst,
+            IsOverlap = isOverlap,
+            Bucket = SessionBucket.Closed,
+            Priority = SessionPriority.Blocked,
+            Allow = false,
+            Reason = "Default blocked"
+        };
 
-            if (ContainsAny(symbol, "AUD", "NZD", "JPY"))
-                return false;
+        if (IsCrypto(symbol))
+        {
+            decision.Bucket = SessionBucket.CryptoAlwaysOn;
+            decision.Priority = SessionPriority.Medium;
+            decision.Allow = true;
+            decision.Reason = "Crypto always on";
+            LogGate(symbol, tf, GetTimeframeTier(tf), decision);
+            return decision;
         }
 
-        return true;
+        TimeframeTier tier = GetTimeframeTier(tf);
+        SessionBucket bucket = ResolveBucket(utc, nyCashOpen, nyClose);
+        decision.Bucket = bucket;
+
+        if (bucket == SessionBucket.NyPreOpen)
+        {
+            decision.Reason = "NY pre-open airbag";
+            LogGate(symbol, tf, tier, decision);
+            return decision;
+        }
+
+        if (bucket == SessionBucket.NyCashOpenAirbag)
+        {
+            decision.Reason = "NY cash-open airbag";
+            LogGate(symbol, tf, tier, decision);
+            return decision;
+        }
+
+        if (bucket == SessionBucket.NyCloseChaos)
+        {
+            decision.Reason = "NY close chaos airbag";
+            LogGate(symbol, tf, tier, decision);
+            return decision;
+        }
+
+        bool isFx = IsFx(symbol);
+        bool isIndex = IsIndex(symbol);
+        bool isMetal = IsMetal(symbol);
+
+        ApplyTimeframePolicy(tier, bucket, decision);
+
+        if (!decision.Allow)
+        {
+            LogGate(symbol, tf, tier, decision);
+            return decision;
+        }
+
+        ApplyInstrumentPriority(symbol, isFx, isIndex, isMetal, bucket, decision);
+
+        if (bucket == SessionBucket.NewYork && isFx)
+        {
+            if (string.Equals(symbol, "USDJPY", StringComparison.OrdinalIgnoreCase))
+            {
+                decision.Reason = "USDJPY exception in NY session";
+            }
+            else if (ContainsAny(symbol, "AUD", "NZD", "JPY"))
+            {
+                decision.Allow = false;
+                decision.Priority = SessionPriority.Blocked;
+                decision.Reason = "NY FX filter: AUD/NZD/JPY blocked";
+                _bot.Print("[SESSION_FILTER] symbol={0} rule=NY_FX_BLOCK allow=false", symbol);
+            }
+        }
+
+        if (string.IsNullOrEmpty(decision.Reason))
+            decision.Reason = "Session allowed";
+
+        LogGate(symbol, tf, tier, decision);
+        return decision;
     }
 
-    // =================================================
-    // SESSION DEFINÍCIÓK
-    // =================================================
-
-    private bool IsAsiaSession(TimeSpan utc)
+    private SessionBucket ResolveBucket(DateTime utc, TimeSpan nyCashOpen, TimeSpan nyClose)
     {
-        // Asia: 00:00 – 07:00 UTC
-        return utc >= TimeSpan.Zero && utc < new TimeSpan(7, 0, 0);
+        TimeSpan now = utc.TimeOfDay;
+        TimeSpan nyPreOpenStart = nyCashOpen - TimeSpan.FromMinutes(40);
+        TimeSpan nyCashAirbagEnd = nyCashOpen + TimeSpan.FromMinutes(10);
+        TimeSpan nyCloseChaosStart = nyClose - TimeSpan.FromMinutes(30);
+        TimeSpan nyCloseChaosEnd = nyClose + TimeSpan.FromMinutes(30);
+
+        if (IsInRange(now, nyPreOpenStart, nyCashOpen))
+            return SessionBucket.NyPreOpen;
+
+        if (IsInRange(now, nyCashOpen, nyCashAirbagEnd))
+            return SessionBucket.NyCashOpenAirbag;
+
+        if (IsInRange(now, nyCloseChaosStart, nyCloseChaosEnd))
+            return SessionBucket.NyCloseChaos;
+
+        if (_calendar.IsLondonNyOverlap(utc))
+            return SessionBucket.LondonNyOverlap;
+
+        if (_calendar.IsLondonSession(utc))
+            return SessionBucket.London;
+
+        if (_calendar.IsNySession(utc))
+            return SessionBucket.NewYork;
+
+        if (now >= TimeSpan.Zero && now < _calendar.GetLondonOpenUtc(utc))
+            return SessionBucket.Asia;
+
+        return SessionBucket.Closed;
     }
 
-    private bool IsLondonSession(TimeSpan utc)
+    private static void ApplyTimeframePolicy(TimeframeTier tier, SessionBucket bucket, SessionDecision decision)
     {
-        // London: 08:00 – 16:00 UTC
-        return utc >= new TimeSpan(8, 0, 0) && utc < new TimeSpan(16, 0, 0);
+        switch (tier)
+        {
+            case TimeframeTier.Scalping:
+                if (bucket == SessionBucket.London || bucket == SessionBucket.LondonNyOverlap || bucket == SessionBucket.NewYork)
+                    decision.Allow = true;
+                decision.Reason = decision.Allow ? "Scalping session allowed" : "Scalping blocks this session";
+                break;
+
+            case TimeframeTier.Intraday:
+                if (bucket == SessionBucket.London || bucket == SessionBucket.LondonNyOverlap || bucket == SessionBucket.NewYork)
+                    decision.Allow = true;
+                decision.Reason = decision.Allow ? "Intraday session allowed" : "Intraday blocks this session";
+                break;
+
+            case TimeframeTier.BroadIntraday:
+                if (bucket == SessionBucket.London || bucket == SessionBucket.LondonNyOverlap || bucket == SessionBucket.NewYork || bucket == SessionBucket.Asia)
+                    decision.Allow = true;
+                decision.Reason = decision.Allow ? "Broad intraday session allowed" : "Broad intraday blocks this session";
+                if (bucket == SessionBucket.Asia && decision.Allow)
+                    decision.Priority = SessionPriority.Low;
+                break;
+        }
     }
 
-    private bool IsNySession(TimeSpan utc)
+    private static void ApplyInstrumentPriority(string symbol, bool isFx, bool isIndex, bool isMetal, SessionBucket bucket, SessionDecision decision)
     {
-        // NY: 13:00 – 21:30 UTC
-        return utc >= new TimeSpan(13, 0, 0) && utc < new TimeSpan(21, 30, 0);
+        if (isFx)
+        {
+            if (bucket == SessionBucket.LondonNyOverlap)
+                decision.Priority = SessionPriority.Best;
+            else if (bucket == SessionBucket.London)
+                decision.Priority = SessionPriority.High;
+            else if (bucket == SessionBucket.NewYork)
+                decision.Priority = SessionPriority.Medium;
+            else if (bucket == SessionBucket.Asia && decision.Allow)
+                decision.Priority = SessionPriority.Low;
+            return;
+        }
+
+        if (isIndex)
+        {
+            if (bucket == SessionBucket.NewYork)
+                decision.Priority = SessionPriority.High;
+            else if (bucket == SessionBucket.LondonNyOverlap)
+                decision.Priority = SessionPriority.Medium;
+            else if (bucket == SessionBucket.London)
+                decision.Priority = SessionPriority.Medium;
+            else if (bucket == SessionBucket.Asia && decision.Allow)
+                decision.Priority = SessionPriority.Low;
+            return;
+        }
+
+        if (isMetal)
+        {
+            if (bucket == SessionBucket.LondonNyOverlap)
+                decision.Priority = SessionPriority.Best;
+            else if (bucket == SessionBucket.London || bucket == SessionBucket.NewYork)
+                decision.Priority = SessionPriority.High;
+            else if (bucket == SessionBucket.Asia && decision.Allow)
+                decision.Priority = SessionPriority.Low;
+            return;
+        }
+
+        if (decision.Allow && decision.Priority == SessionPriority.Blocked)
+            decision.Priority = SessionPriority.Medium;
     }
 
-    // =================================================
-    // HELPEREK
-    // =================================================
-
-    private bool IsFx(string symbol)
+    private static TimeframeTier GetTimeframeTier(TimeFrame tf)
     {
-        if (symbol.StartsWith("XAU") || symbol.StartsWith("XAG"))
+        string tfName = tf.ToString();
+
+        if (tf == TimeFrame.Minute || tfName == "Minute2" || tfName == "Minute3")
+            return TimeframeTier.Scalping;
+
+        if (tf == TimeFrame.Minute5)
+            return TimeframeTier.Intraday;
+
+        if (tf == TimeFrame.Minute15 || tf == TimeFrame.Minute30 || tf == TimeFrame.Hour)
+            return TimeframeTier.BroadIntraday;
+
+        return TimeframeTier.Intraday;
+    }
+
+    private static string FormatTimeFrame(TimeFrame tf)
+    {
+        string tfName = tf.ToString();
+        if (tf == TimeFrame.Minute) return "M1";
+        if (tfName == "Minute2") return "M2";
+        if (tfName == "Minute3") return "M3";
+        if (tf == TimeFrame.Minute5) return "M5";
+        if (tf == TimeFrame.Minute15) return "M15";
+        if (tf == TimeFrame.Minute30) return "M30";
+        if (tf == TimeFrame.Hour) return "H1";
+        return tfName;
+    }
+
+    private void LogGate(string symbol, TimeFrame tf, TimeframeTier tier, SessionDecision decision)
+    {
+        _bot.Print("[SESSION_GATE] symbol={0} tf={1} tier={2} bucket={3} priority={4} allow={5} reason={6}",
+            symbol,
+            FormatTimeFrame(tf),
+            tier,
+            decision.Bucket,
+            decision.Priority,
+            decision.Allow,
+            decision.Reason);
+    }
+
+    private static bool IsFx(string symbol)
+    {
+        if (IsMetal(symbol) || IsCrypto(symbol) || IsIndex(symbol))
             return false;
 
         return symbol.Length == 6 && char.IsLetter(symbol[0]);
     }
 
-    private bool ContainsAny(string symbol, params string[] keys)
+    private static bool IsMetal(string symbol)
     {
-        foreach (var k in keys)
-            if (symbol.Contains(k))
+        return symbol.StartsWith("XAU", StringComparison.OrdinalIgnoreCase)
+            || symbol.StartsWith("XAG", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsIndex(string symbol)
+    {
+        return symbol.StartsWith("NAS", StringComparison.OrdinalIgnoreCase)
+            || symbol.StartsWith("US30", StringComparison.OrdinalIgnoreCase)
+            || symbol.StartsWith("GER", StringComparison.OrdinalIgnoreCase)
+            || symbol.StartsWith("SPX", StringComparison.OrdinalIgnoreCase)
+            || symbol.StartsWith("US100", StringComparison.OrdinalIgnoreCase)
+            || symbol.StartsWith("DJ", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool ContainsAny(string symbol, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (symbol.IndexOf(key, StringComparison.OrdinalIgnoreCase) >= 0)
                 return true;
+        }
 
         return false;
     }
 
-    private bool IsInRange(TimeSpan now, TimeSpan from, TimeSpan to)
+    private static bool IsInRange(TimeSpan now, TimeSpan from, TimeSpan to)
     {
         if (from < to)
             return now >= from && now < to;
 
-        // over midnight
         return now >= from || now < to;
     }
 
-    private bool IsCrypto(string symbol)
+    private static bool IsCrypto(string symbol)
     {
-        return symbol.StartsWith("BTC")
-            || symbol.StartsWith("ETH")
-            || symbol.StartsWith("CRYPTO");
+        return symbol.StartsWith("BTC", StringComparison.OrdinalIgnoreCase)
+            || symbol.StartsWith("ETH", StringComparison.OrdinalIgnoreCase)
+            || symbol.StartsWith("CRYPTO", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Core/Gates/SessionCalendar.cs
+++ b/Core/Gates/SessionCalendar.cs
@@ -1,0 +1,77 @@
+using System;
+
+public class SessionCalendar
+{
+    public bool IsUsDst(DateTime utc)
+    {
+        int year = utc.Year;
+        DateTime start = NthWeekdayOfMonth(year, 3, DayOfWeek.Sunday, 2).Date.AddHours(7); // 02:00 local EST = 07:00 UTC
+        DateTime end = NthWeekdayOfMonth(year, 11, DayOfWeek.Sunday, 1).Date.AddHours(6);  // 02:00 local EDT = 06:00 UTC
+        return utc >= start && utc < end;
+    }
+
+    public bool IsEuDst(DateTime utc)
+    {
+        int year = utc.Year;
+        DateTime start = LastWeekdayOfMonth(year, 3, DayOfWeek.Sunday).Date.AddHours(1);   // 01:00 UTC
+        DateTime end = LastWeekdayOfMonth(year, 10, DayOfWeek.Sunday).Date.AddHours(1);    // 01:00 UTC
+        return utc >= start && utc < end;
+    }
+
+    public TimeSpan GetLondonOpenUtc(DateTime utc) => IsEuDst(utc) ? new TimeSpan(7, 0, 0) : new TimeSpan(8, 0, 0);
+
+    public TimeSpan GetLondonCloseUtc(DateTime utc) => IsEuDst(utc) ? new TimeSpan(15, 0, 0) : new TimeSpan(16, 0, 0);
+
+    public TimeSpan GetNyOpenUtc(DateTime utc) => IsUsDst(utc) ? new TimeSpan(12, 0, 0) : new TimeSpan(13, 0, 0);
+
+    public TimeSpan GetNyCashOpenUtc(DateTime utc) => IsUsDst(utc) ? new TimeSpan(13, 30, 0) : new TimeSpan(14, 30, 0);
+
+    public TimeSpan GetNyCloseUtc(DateTime utc) => IsUsDst(utc) ? new TimeSpan(21, 0, 0) : new TimeSpan(22, 0, 0);
+
+    public bool IsLondonSession(DateTime utc)
+    {
+        TimeSpan now = utc.TimeOfDay;
+        return now >= GetLondonOpenUtc(utc) && now < GetLondonCloseUtc(utc);
+    }
+
+    public bool IsNySession(DateTime utc)
+    {
+        TimeSpan now = utc.TimeOfDay;
+        return now >= GetNyOpenUtc(utc) && now < GetNyCloseUtc(utc);
+    }
+
+    public bool IsLondonNyOverlap(DateTime utc)
+    {
+        TimeSpan londonOpen = GetLondonOpenUtc(utc);
+        TimeSpan londonClose = GetLondonCloseUtc(utc);
+        TimeSpan nyOpen = GetNyOpenUtc(utc);
+        TimeSpan nyClose = GetNyCloseUtc(utc);
+
+        TimeSpan overlapStart = londonOpen > nyOpen ? londonOpen : nyOpen;
+        TimeSpan overlapEnd = londonClose < nyClose ? londonClose : nyClose;
+
+        if (overlapStart >= overlapEnd)
+            return false;
+
+        TimeSpan now = utc.TimeOfDay;
+        return now >= overlapStart && now < overlapEnd;
+    }
+
+    private static DateTime NthWeekdayOfMonth(int year, int month, DayOfWeek dayOfWeek, int nth)
+    {
+        DateTime first = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc);
+        int delta = ((int)dayOfWeek - (int)first.DayOfWeek + 7) % 7;
+        return first.AddDays(delta + (nth - 1) * 7);
+    }
+
+    private static DateTime LastWeekdayOfMonth(int year, int month, DayOfWeek dayOfWeek)
+    {
+        DateTime firstNextMonth = month == 12
+            ? new DateTime(year + 1, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            : new DateTime(year, month + 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        DateTime last = firstNextMonth.AddDays(-1);
+        int delta = ((int)last.DayOfWeek - (int)dayOfWeek + 7) % 7;
+        return last.AddDays(-delta);
+    }
+}

--- a/Core/Gates/SessionModels.cs
+++ b/Core/Gates/SessionModels.cs
@@ -1,0 +1,43 @@
+using System;
+
+public enum SessionBucket
+{
+    Closed,
+    Asia,
+    London,
+    LondonNyOverlap,
+    NewYork,
+    NyPreOpen,
+    NyCashOpenAirbag,
+    NyCloseChaos,
+    CryptoAlwaysOn
+}
+
+public enum SessionPriority
+{
+    Blocked = 0,
+    Low = 1,
+    Medium = 2,
+    High = 3,
+    Best = 4
+}
+
+public enum TimeframeTier
+{
+    Scalping,
+    Intraday,
+    BroadIntraday
+}
+
+public class SessionDecision
+{
+    public bool Allow { get; set; }
+    public string Symbol { get; set; }
+    public string Timeframe { get; set; }
+    public SessionBucket Bucket { get; set; }
+    public SessionPriority Priority { get; set; }
+    public bool IsUsDst { get; set; }
+    public bool IsEuDst { get; set; }
+    public bool IsOverlap { get; set; }
+    public string Reason { get; set; }
+}


### PR DESCRIPTION
### Motivation
- Fixed incorrect fixed-UTC session windows that break during US/EU DST transitions by making session boundaries DST-aware and centralized. 
- Provide timeframe-aware gating and clear decision outputs so scalping vs intraday logic can be enforced consistently. 
- Introduce prioritized London–New York overlap handling and explicit FX filters for robust trading control. 

### Description
- Added `SessionCalendar.cs` which implements US/EU DST rules, returns London/NY open/close/cash-open times, and exposes `IsLondonSession`, `IsNySession`, and `IsLondonNyOverlap`. 
- Added `SessionModels.cs` which defines `SessionBucket`, `SessionPriority`, `TimeframeTier`, and the `SessionDecision` model used to communicate gate outcomes. 
- Refactored `GlobalSessionGate.cs` to use the calendar and the new models, added `AllowEntry(string symbol, TimeFrame tf)` and `GetDecision(string symbol, TimeFrame tf)`, kept `AllowEntry(string symbol)` backward-compatible by routing it to the M1 decision path, computed dynamic airbag windows (`NyPreOpen`, `NyCashOpenAirbag`, `NyCloseChaos`), applied timeframe-tier policies (Scalping/Intraday/BroadIntraday), assigned instrument priorities (FX/index/metals/crypto), and enforced the NY FX filter with a `USDJPY` exception. 
- Added explicit debug logging tags `[SESSION_CALENDAR]`, `[SESSION_GATE]`, and `[SESSION_FILTER]` and included human-readable `Reason` in every `SessionDecision`. 

### Testing
- Ran repository static checks and diff/whitespace validation and found no issues. 
- Performed file-level inspection and syntax previews of the new/modified C# files to verify code shape and logging points. 
- No unit tests were added in this change; recommend running the project build and existing integration/CI tests to validate runtime behavior (especially DST boundary cases and overlap detection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01a388010832886172bc913d55c68)