### PR TITLE
Add Pullback→Flag TransitionDetector and apply continuation score boosts

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -155,6 +155,13 @@ namespace GeminiV26.Core.Entry
         // =========================
         public bool LastClosedBarInTrendDirection { get; set; }
 
+        // =========================
+        // Pullback -> Flag transition
+        // =========================
+        public bool TransitionValid { get; set; }
+        public int TransitionScoreBonus { get; set; }
+        public TransitionEvaluation Transition { get; set; }
+
         // ===== FX HTF bias (lightweight) =====
         public TradeDirection FxHtfAllowedDirection { get; set; } = TradeDirection.None;
         public double FxHtfConfidence01 { get; set; } = 0.0;

--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -1,0 +1,146 @@
+using System;
+
+namespace GeminiV26.Core.Entry
+{
+    public sealed class TransitionDetector
+    {
+        private readonly Action<string> _log;
+
+        public TransitionDetector(Action<string> log)
+        {
+            _log = log;
+        }
+
+        public TransitionEvaluation Evaluate(EntryContext ctx)
+        {
+            if (ctx == null || ctx.M5 == null || ctx.M5.Count < 25 || ctx.AtrM5 <= 0)
+            {
+                return new TransitionEvaluation
+                {
+                    Direction = "None",
+                    Reason = "InsufficientData"
+                };
+            }
+
+            var p = TransitionParams.ForSymbol(ctx.Symbol);
+            int last = ctx.M5.Count - 2;
+
+            int impulseBarsAgo = Math.Max(0, ctx.BarsSinceImpulse_M5);
+            bool hasImpulse = ctx.HasImpulse_M5 && impulseBarsAgo <= p.MaxImpulseBars;
+
+            TradeDirection direction = ctx.TrendDirection;
+            if (direction == TradeDirection.None)
+                direction = InferDirection(ctx, last);
+
+            double impulseStrength = GetImpulseStrength(ctx, last, impulseBarsAgo);
+            _log?.Invoke($"[TRANSITION][IMPULSE] detected={hasImpulse} barsSince={impulseBarsAgo} strength={impulseStrength:0.00}");
+
+            int pullbackBars = Math.Max(0, ctx.PullbackBars_M5);
+            double pullbackDepthR = Math.Max(0.0, ctx.PullbackDepthAtr_M5 / 2.0);
+            bool hasPullback = pullbackBars > 0 && pullbackDepthR <= p.MaxPullbackDepthR;
+
+            if (hasPullback && p.StrictWickFilter)
+            {
+                hasPullback = ctx.HasRejectionWick_M5;
+            }
+
+            _log?.Invoke($"[TRANSITION][PULLBACK] depthR={pullbackDepthR:0.00} bars={pullbackBars}");
+
+            int flagBars = EstimateFlagBars(ctx, last, p.MaxFlagBars, direction);
+            double compressionScore = ComputeCompressionScore(ctx, last, flagBars);
+            bool hasFlag = flagBars > 0 && flagBars <= p.MaxFlagBars && compressionScore >= p.MinCompressionScore;
+
+            _log?.Invoke($"[TRANSITION][FLAG] bars={flagBars} compression={compressionScore:0.00}");
+
+            bool valid = hasImpulse && hasPullback && hasFlag;
+            int bonus = valid ? 10 : 0;
+
+            string reason = "OK";
+            if (!hasImpulse) reason = "NoImpulse";
+            else if (!hasPullback) reason = pullbackDepthR > p.MaxPullbackDepthR ? "PullbackTooDeep" : "NoPullback";
+            else if (!hasFlag) reason = "NoFlagCompression";
+
+            _log?.Invoke($"[TRANSITION][DECISION] valid={valid} bonus={bonus} reason={reason}");
+
+            return new TransitionEvaluation
+            {
+                HasImpulse = hasImpulse,
+                HasPullback = hasPullback,
+                HasFlag = hasFlag,
+                BarsSinceImpulse = impulseBarsAgo,
+                PullbackBars = pullbackBars,
+                PullbackDepthR = pullbackDepthR,
+                FlagBars = flagBars,
+                CompressionScore = compressionScore,
+                TransitionValid = valid,
+                BonusScore = bonus,
+                Direction = direction.ToString(),
+                Reason = reason
+            };
+        }
+
+        private static TradeDirection InferDirection(EntryContext ctx, int last)
+        {
+            return ctx.M5.ClosePrices[last] >= ctx.Ema21_M5
+                ? TradeDirection.Long
+                : TradeDirection.Short;
+        }
+
+        private static double GetImpulseStrength(EntryContext ctx, int last, int barsAgo)
+        {
+            int impulseIndex = Math.Max(0, last - barsAgo);
+            double body = Math.Abs(ctx.M5.ClosePrices[impulseIndex] - ctx.M5.OpenPrices[impulseIndex]);
+            return ctx.AtrM5 > 0 ? body / ctx.AtrM5 : 0.0;
+        }
+
+        private static int EstimateFlagBars(EntryContext ctx, int last, int maxFlagBars, TradeDirection direction)
+        {
+            int bars = 0;
+            for (int i = last; i >= Math.Max(0, last - maxFlagBars + 1); i--)
+            {
+                bool overlap = i > 0 &&
+                    ctx.M5.HighPrices[i] <= ctx.M5.HighPrices[i - 1] + (ctx.AtrM5 * 0.25) &&
+                    ctx.M5.LowPrices[i] >= ctx.M5.LowPrices[i - 1] - (ctx.AtrM5 * 0.25);
+
+                bool counterSlope = direction == TradeDirection.Long
+                    ? ctx.M5.ClosePrices[i] <= ctx.M5.ClosePrices[Math.Max(0, i - 1)] + (ctx.AtrM5 * 0.10)
+                    : ctx.M5.ClosePrices[i] >= ctx.M5.ClosePrices[Math.Max(0, i - 1)] - (ctx.AtrM5 * 0.10);
+
+                if (!overlap || !counterSlope)
+                    break;
+
+                bars++;
+            }
+
+            return bars;
+        }
+
+        private static double ComputeCompressionScore(EntryContext ctx, int last, int flagBars)
+        {
+            if (flagBars <= 1)
+                return 0.0;
+
+            int start = Math.Max(0, last - flagBars + 1);
+            double hi = double.MinValue;
+            double lo = double.MaxValue;
+            double avgBody = 0.0;
+
+            for (int i = start; i <= last; i++)
+            {
+                hi = Math.Max(hi, ctx.M5.HighPrices[i]);
+                lo = Math.Min(lo, ctx.M5.LowPrices[i]);
+                avgBody += Math.Abs(ctx.M5.ClosePrices[i] - ctx.M5.OpenPrices[i]);
+            }
+
+            avgBody /= flagBars;
+            double range = hi - lo;
+            if (range <= 0 || ctx.AtrM5 <= 0)
+                return 0.0;
+
+            double rangeCompression = 1.0 - Math.Min(1.0, range / (ctx.AtrM5 * 2.0));
+            double bodyCompression = 1.0 - Math.Min(1.0, avgBody / (ctx.AtrM5 * 0.9));
+
+            return Math.Max(0.0, Math.Min(1.0, (rangeCompression * 0.6) + (bodyCompression * 0.4)));
+        }
+    }
+}

--- a/Core/Entry/TransitionEvaluation.cs
+++ b/Core/Entry/TransitionEvaluation.cs
@@ -1,0 +1,24 @@
+namespace GeminiV26.Core.Entry
+{
+    public sealed class TransitionEvaluation
+    {
+        public bool HasImpulse { get; init; }
+        public bool HasPullback { get; init; }
+        public bool HasFlag { get; init; }
+
+        public int BarsSinceImpulse { get; init; }
+
+        public int PullbackBars { get; init; }
+        public double PullbackDepthR { get; init; }
+
+        public int FlagBars { get; init; }
+        public double CompressionScore { get; init; }
+
+        public bool TransitionValid { get; init; }
+
+        public int BonusScore { get; init; }
+
+        public string Direction { get; init; }
+        public string Reason { get; init; }
+    }
+}

--- a/Core/Entry/TransitionParams.cs
+++ b/Core/Entry/TransitionParams.cs
@@ -1,0 +1,49 @@
+namespace GeminiV26.Core.Entry
+{
+    public sealed class TransitionParams
+    {
+        public int MaxImpulseBars { get; init; }
+        public double MaxPullbackDepthR { get; init; }
+        public int MaxFlagBars { get; init; }
+        public double MinCompressionScore { get; init; }
+        public bool StrictWickFilter { get; init; }
+
+        public static TransitionParams ForSymbol(string symbol)
+        {
+            string sym = (symbol ?? string.Empty).ToUpperInvariant();
+
+            if (sym.Contains("BTC") || sym.Contains("ETH") || sym.Contains("CRYPTO"))
+            {
+                return new TransitionParams
+                {
+                    MaxImpulseBars = 5,
+                    MaxPullbackDepthR = 0.35,
+                    MaxFlagBars = 3,
+                    MinCompressionScore = 0.65,
+                    StrictWickFilter = true
+                };
+            }
+
+            if (sym.Contains("NAS") || sym.Contains("USTECH") || sym.Contains("US30") || sym.Contains("GER") || sym.Contains("DAX"))
+            {
+                return new TransitionParams
+                {
+                    MaxImpulseBars = 6,
+                    MaxPullbackDepthR = 0.38,
+                    MaxFlagBars = 4,
+                    MinCompressionScore = 0.55,
+                    StrictWickFilter = false
+                };
+            }
+
+            return new TransitionParams
+            {
+                MaxImpulseBars = 12,
+                MaxPullbackDepthR = 0.45,
+                MaxFlagBars = 6,
+                MinCompressionScore = 0.50,
+                StrictWickFilter = false
+            };
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -74,6 +74,7 @@ namespace GeminiV26.Core
 
         private readonly EntryRouter _entryRouter;
         private readonly EntryContextBuilder _contextBuilder;
+        private readonly TransitionDetector _transitionDetector;
         private readonly List<IEntryType> _entryTypes;
 
         private readonly TradeLogger _tradeLogger;
@@ -393,6 +394,7 @@ namespace GeminiV26.Core
 
             _entryRouter = new EntryRouter(_entryTypes);
             _contextBuilder = new EntryContextBuilder(bot);
+            _transitionDetector = new TransitionDetector(_bot.Print);
             _tradeLogger = new TradeLogger(_bot.SymbolName);
             _globalSessionGate = new GlobalSessionGate(_bot);
             _sessionMatrix = new SessionMatrix(new SessionMatrixProvider());
@@ -874,6 +876,11 @@ namespace GeminiV26.Core
             _contextRegistry.RegisterEntry(_ctx);
             _contextRegistry.RebuildFromActivePositions(_bot.Positions, _positionContexts);
 
+            var transition = _transitionDetector.Evaluate(_ctx);
+            _ctx.Transition = transition;
+            _ctx.TransitionValid = transition.TransitionValid;
+            _ctx.TransitionScoreBonus = transition.BonusScore;
+
             // =========================
             // GLOBAL SESSION GATE + SESSION MATRIX
             // =========================
@@ -1027,6 +1034,8 @@ namespace GeminiV26.Core
                 _bot.Print("[DEBUG] NO signals for symbol");
                 return;
             }
+
+            ApplyTransitionScoreBoost(_ctx, symbolSignals);
 
             // ===== IDE TEDD =====
             _bot.Print($"[DBG ENTRY] total candidates={symbolSignals.Count}");
@@ -1564,6 +1573,53 @@ namespace GeminiV26.Core
                 if (!_ger40SessionGate.AllowEntry(gateDir)) return;
                 if (!_ger40ImpulseGate.AllowEntry(gateDir)) return;
                 _ger40Executor.ExecuteEntry(selected);
+            }
+        }
+
+        private void ApplyTransitionScoreBoost(EntryContext ctx, List<EntryEvaluation> symbolSignals)
+        {
+            if (ctx == null || symbolSignals == null || !ctx.TransitionValid || ctx.TransitionScoreBonus <= 0)
+                return;
+
+            foreach (var entry in symbolSignals)
+            {
+                if (entry == null || !entry.IsValid)
+                    continue;
+
+                int boost = GetTransitionBoost(entry.Type, ctx.TransitionScoreBonus);
+                if (boost <= 0)
+                    continue;
+
+                entry.Score += boost;
+                if (entry.Score > 100)
+                    entry.Score = 100;
+
+                entry.Reason = $"{entry.Reason} [TRANSITION+{boost}]";
+                _bot.Print($"[ENTRY][TRANSITION] score boost applied type={entry.Type} boost={boost} score={entry.Score}");
+            }
+        }
+
+        private static int GetTransitionBoost(EntryType type, int maxBonus)
+        {
+            switch (type)
+            {
+                case EntryType.FX_Flag:
+                case EntryType.FX_FlagContinuation:
+                case EntryType.Index_Flag:
+                case EntryType.Crypto_Flag:
+                case EntryType.TC_Flag:
+                case EntryType.XAU_Flag:
+                    return maxBonus;
+
+                case EntryType.FX_Pullback:
+                case EntryType.Index_Pullback:
+                case EntryType.Crypto_Pullback:
+                case EntryType.TC_Pullback:
+                case EntryType.XAU_Pullback:
+                    return Math.Min(maxBonus, 8);
+
+                default:
+                    return 0;
             }
         }
         


### PR DESCRIPTION
### Motivation
- Introduce a structural recognition module to detect high-quality Impulse → Pullback → Flag → Continuation patterns and surface metadata to entry engines without changing trade/risk responsibilities. 
- Run detection after `EntryContext` creation and before entry engines so continuation candidates can receive a prioritized score bonus while keeping SL/TP/risk/volume logic outside TradeCore.

### Description
- Add `TransitionEvaluation` model to carry phase flags, bars, compression, `Direction`, `Reason`, `BonusScore` and overall `TransitionValid` state (`Core/Entry/TransitionEvaluation.cs`).
- Add instrument-aware `TransitionParams` with defaults for FX, INDEX and CRYPTO including `MaxImpulseBars`, `MaxPullbackDepthR`, `MaxFlagBars`, `MinCompressionScore`, and `StrictWickFilter` (`Core/Entry/TransitionParams.cs`).
- Implement `TransitionDetector` to evaluate the Impulse → Pullback → Flag pipeline, compute compression/pullback metrics, and emit mandatory debug logs (`[TRANSITION][IMPULSE|PULLBACK|FLAG|DECISION]`) returning a `TransitionEvaluation` (`Core/Entry/TransitionDetector.cs`).
- Extend `EntryContext` with `Transition`, `TransitionValid` and `TransitionScoreBonus` fields (`Core/Entry/EntryContext.cs`).
- Integrate detector into `TradeCore` immediately after building `EntryContext`: instantiate `TransitionDetector`, evaluate context, attach results to `ctx`, and apply continuation-only score boosts to entry candidates (`Core/TradeCore.cs`).
- Add score-boost rules in `TradeCore`: full bonus for flag-type entries and capped bonus (`min(bonus, 8)`) for pullback entries, and log each boost with `[ENTRY][TRANSITION]`.
- Preserve architectural constraints: the detector does not open trades or compute SL/TP/risk/volume.

### Testing
- Ran `git diff --check` to verify patch formatting; check passed.
- Performed repository checks (`git status`, `rg`, file inspections) and committed the changes; commit succeeded.
- Created PR metadata (`make_pr`) summarizing the changes.
- No full compile/run was executed in this workspace because no `.csproj`/`.sln` was available, so build verification was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b057164b0c832896e6aaa31662da09)