### PR TITLE
Add impulse strength and pullback quality filters to TransitionDetector

### DIFF
--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -38,7 +38,8 @@ namespace GeminiV26.Core.Entry
             bool impulseDirectionValid = impulseDirection != TradeDirection.None && impulseDirection == direction;
 
             double impulseStrength = GetImpulseStrength(ctx, last, impulseBarsAgo);
-            _log?.Invoke($"[TRANSITION][IMPULSE] detected={hasImpulse} barsSince={impulseBarsAgo} strength={impulseStrength:0.00} direction={impulseDirection}");
+            bool impulseStrengthValid = impulseStrength >= p.MinImpulseStrength;
+            _log?.Invoke($"[TRANSITION][IMPULSE] detected={hasImpulse} barsSince={impulseBarsAgo} strength={impulseStrength:0.00} strengthValid={impulseStrengthValid} direction={impulseDirection}");
 
             int pullbackBars = Math.Max(0, ctx.PullbackBars_M5);
             TradeDirection pullbackDirection = DetectPullbackDirection(ctx, last, pullbackBars);
@@ -46,14 +47,27 @@ namespace GeminiV26.Core.Entry
 
             double impulseRange = GetImpulseRange(ctx, impulseIndex);
             double pullbackDepthR = ComputePullbackDepthR(ctx, last, pullbackBars, impulseDirection, impulseRange);
-            bool hasPullback = pullbackBars > 0 && pullbackDepthR <= p.MaxPullbackDepthR && pullbackDirectionValid;
+            double avgPullbackBody = 0.0;
+            int pullbackStart = Math.Max(0, last - pullbackBars + 1);
+            for (int i = pullbackStart; i <= last; i++)
+            {
+                avgPullbackBody += Math.Abs(ctx.M5.ClosePrices[i] - ctx.M5.OpenPrices[i]);
+            }
+
+            avgPullbackBody /= Math.Max(1, pullbackBars);
+            bool pullbackQualityValid = avgPullbackBody <= ctx.AtrM5 * 0.6;
+            bool hasPullback =
+                pullbackBars > 0 &&
+                pullbackDepthR <= p.MaxPullbackDepthR &&
+                pullbackDirectionValid &&
+                pullbackQualityValid;
 
             if (hasPullback && p.StrictWickFilter)
             {
                 hasPullback = ctx.HasRejectionWick_M5;
             }
 
-            _log?.Invoke($"[TRANSITION][PULLBACK] depthR={pullbackDepthR:0.00} bars={pullbackBars} direction={pullbackDirection}");
+            _log?.Invoke($"[TRANSITION][PULLBACK] depthR={pullbackDepthR:0.00} bars={pullbackBars} direction={pullbackDirection} qualityValid={pullbackQualityValid}");
 
             int flagBars = EstimateFlagBars(ctx, last, p.MaxFlagBars, direction);
             double compressionScore = ComputeCompressionScore(ctx, last, flagBars, impulseRange);
@@ -66,15 +80,17 @@ namespace GeminiV26.Core.Entry
 
             _log?.Invoke($"[TRANSITION][FLAG] bars={flagBars} compression={compressionScore:0.00} directionValid={flagDirectionValid}");
 
-            bool valid = hasImpulse && impulseDirectionValid && hasPullback && hasFlag;
+            bool valid = hasImpulse && impulseDirectionValid && impulseStrengthValid && hasPullback && hasFlag;
             int bonus = valid ? 10 : 0;
 
             string reason = "OK";
             if (!hasImpulse) reason = impulseTooOld ? "ImpulseTooOld" : "NoImpulse";
             else if (!impulseDirectionValid) reason = "InvalidImpulseDirection";
+            else if (!impulseStrengthValid) reason = "WeakImpulse";
             else if (!hasPullback)
             {
                 if (!pullbackDirectionValid) reason = "InvalidPullbackDirection";
+                else if (!pullbackQualityValid) reason = "AggressivePullback";
                 else reason = pullbackDepthR > p.MaxPullbackDepthR ? "PullbackTooDeep" : "NoPullback";
             }
             else if (!hasFlag) reason = !flagDirectionValid ? "InvalidFlagDirection" : "CompressionTooLow";

--- a/Core/Entry/TransitionParams.cs
+++ b/Core/Entry/TransitionParams.cs
@@ -6,6 +6,7 @@ namespace GeminiV26.Core.Entry
         public double MaxPullbackDepthR { get; init; }
         public int MaxFlagBars { get; init; }
         public double MinCompressionScore { get; init; }
+        public double MinImpulseStrength { get; init; }
         public bool StrictWickFilter { get; init; }
 
         public static TransitionParams ForSymbol(string symbol)
@@ -20,6 +21,7 @@ namespace GeminiV26.Core.Entry
                     MaxPullbackDepthR = 0.35,
                     MaxFlagBars = 3,
                     MinCompressionScore = 0.65,
+                    MinImpulseStrength = 1.2,
                     StrictWickFilter = true
                 };
             }
@@ -32,6 +34,7 @@ namespace GeminiV26.Core.Entry
                     MaxPullbackDepthR = 0.38,
                     MaxFlagBars = 4,
                     MinCompressionScore = 0.55,
+                    MinImpulseStrength = 1.0,
                     StrictWickFilter = false
                 };
             }
@@ -42,6 +45,7 @@ namespace GeminiV26.Core.Entry
                 MaxPullbackDepthR = 0.45,
                 MaxFlagBars = 6,
                 MinCompressionScore = 0.50,
+                MinImpulseStrength = 0.8,
                 StrictWickFilter = false
             };
         }


### PR DESCRIPTION
### Motivation
- Reduce false continuation signals by requiring a sufficiently strong impulse and ensuring pullbacks are corrective (lower volatility) before allowing a flag → continuation detection.

### Description
- Added `MinImpulseStrength` to `TransitionParams` and set symbol defaults of `CRYPTO=1.2`, `INDEX=1.0`, `FX/default=0.8` via `TransitionParams.ForSymbol`.
- Enforced impulse strength in `TransitionDetector` by computing `impulseStrength`, evaluating `impulseStrengthValid = impulseStrength >= p.MinImpulseStrength`, adding `strengthValid` to the `[TRANSITION][IMPULSE]` log, including the check in the final `valid` predicate, and returning rejection reason `WeakImpulse` when it fails.
- Added pullback quality assessment by computing `avgPullbackBody` across pullback bars, validating `pullbackQualityValid = avgPullbackBody <= ctx.AtrM5 * 0.6`, incorporating it into pullback validation, adding `qualityValid` to the `[TRANSITION][PULLBACK]` log, and returning rejection reason `AggressivePullback` when it fails.
- Preserved debug log format and avoided any architectural, SL/TP/risk/volume, or execution changes; the detector remains structure-only.

### Testing
- Attempted an automated build with `dotnet build`, but the `dotnet` CLI is not available in the execution environment so the build could not be run.
- No other automated tests were executed in this environment due to the same tooling limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0621c53cc83288f1bb62c9ece5c2c)