### PR TITLE
Add FlagBreakoutDetector confirmation filter and gate transition bonus

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -161,6 +161,9 @@ namespace GeminiV26.Core.Entry
         public bool TransitionValid { get; set; }
         public int TransitionScoreBonus { get; set; }
         public TransitionEvaluation Transition { get; set; }
+        public bool FlagBreakoutConfirmed { get; set; }
+        public double FlagHigh { get; set; }
+        public double FlagLow { get; set; }
 
         // ===== FX HTF bias (lightweight) =====
         public TradeDirection FxHtfAllowedDirection { get; set; } = TradeDirection.None;

--- a/Core/Entry/FlagBreakoutDetector.cs
+++ b/Core/Entry/FlagBreakoutDetector.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace GeminiV26.Core.Entry
+{
+    public sealed class FlagBreakoutDetector
+    {
+        private readonly Action<string> _log;
+
+        public FlagBreakoutDetector(Action<string> log)
+        {
+            _log = log;
+        }
+
+        public void Evaluate(EntryContext ctx)
+        {
+            if (ctx == null)
+                return;
+
+            ctx.FlagBreakoutConfirmed = false;
+            ctx.FlagHigh = 0.0;
+            ctx.FlagLow = 0.0;
+
+            if (!ctx.TransitionValid || ctx.Transition == null)
+                return;
+
+            if (ctx.M5 == null || ctx.M5.Count < 5 || ctx.AtrM5 <= 0)
+                return;
+
+            int flagBars = Math.Max(0, ctx.Transition.FlagBars);
+            int last = ctx.M5.Count - 2;
+            if (flagBars <= 0 || last <= 0)
+                return;
+
+            int flagEnd = last - 1;
+            int start = Math.Max(0, flagEnd - flagBars + 1);
+            if (start > flagEnd)
+                return;
+
+            double flagHigh = double.MinValue;
+            double flagLow = double.MaxValue;
+
+            for (int i = start; i <= flagEnd; i++)
+            {
+                flagHigh = Math.Max(flagHigh, ctx.M5.HighPrices[i]);
+                flagLow = Math.Min(flagLow, ctx.M5.LowPrices[i]);
+            }
+
+            double breakoutBuffer = ctx.AtrM5 * 0.10;
+            bool breakout = false;
+
+            if (ctx.TrendDirection == TradeDirection.Long)
+            {
+                breakout = ctx.M5.ClosePrices[last] > flagHigh + breakoutBuffer;
+            }
+            else if (ctx.TrendDirection == TradeDirection.Short)
+            {
+                breakout = ctx.M5.ClosePrices[last] < flagLow - breakoutBuffer;
+            }
+
+            ctx.FlagHigh = flagHigh;
+            ctx.FlagLow = flagLow;
+            ctx.FlagBreakoutConfirmed = breakout;
+
+            _log?.Invoke($"[FLAG_BREAKOUT][RANGE] high={flagHigh:0.#####} low={flagLow:0.#####} bars={flagBars}");
+            _log?.Invoke($"[FLAG_BREAKOUT][CHECK] direction={ctx.TrendDirection} breakout={breakout} buffer={breakoutBuffer:0.#####}");
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -75,6 +75,7 @@ namespace GeminiV26.Core
         private readonly EntryRouter _entryRouter;
         private readonly EntryContextBuilder _contextBuilder;
         private readonly TransitionDetector _transitionDetector;
+        private readonly FlagBreakoutDetector _flagBreakoutDetector;
         private readonly List<IEntryType> _entryTypes;
 
         private readonly TradeLogger _tradeLogger;
@@ -395,6 +396,7 @@ namespace GeminiV26.Core
             _entryRouter = new EntryRouter(_entryTypes);
             _contextBuilder = new EntryContextBuilder(bot);
             _transitionDetector = new TransitionDetector(_bot.Print);
+            _flagBreakoutDetector = new FlagBreakoutDetector(_bot.Print);
             _tradeLogger = new TradeLogger(_bot.SymbolName);
             _globalSessionGate = new GlobalSessionGate(_bot);
             _sessionMatrix = new SessionMatrix(new SessionMatrixProvider());
@@ -880,6 +882,7 @@ namespace GeminiV26.Core
             _ctx.Transition = transition;
             _ctx.TransitionValid = transition.TransitionValid;
             _ctx.TransitionScoreBonus = transition.BonusScore;
+            _flagBreakoutDetector.Evaluate(_ctx);
 
             // =========================
             // GLOBAL SESSION GATE + SESSION MATRIX
@@ -1578,7 +1581,7 @@ namespace GeminiV26.Core
 
         private void ApplyTransitionScoreBoost(EntryContext ctx, List<EntryEvaluation> symbolSignals)
         {
-            if (ctx == null || symbolSignals == null || !ctx.TransitionValid || ctx.TransitionScoreBonus <= 0)
+            if (ctx == null || symbolSignals == null || !ctx.TransitionValid || !ctx.FlagBreakoutConfirmed || ctx.TransitionScoreBonus <= 0)
                 return;
 
             foreach (var entry in symbolSignals)


### PR DESCRIPTION
### Motivation
- Prevent premature continuation entries by confirming true flag breakouts before applying the transition score bonus. 
- Keep the pipeline and architecture unchanged while adding a deterministic confirmation layer that filters fake flags. 

### Description
- Added a new confirmation module `Core/Entry/FlagBreakoutDetector.cs` that computes the flag range from the last `flagBars` provided by `TransitionDetector`, applies an ATR-based buffer (`AtrM5 * 0.10`), and sets `ctx.FlagBreakoutConfirmed`, `ctx.FlagHigh`, and `ctx.FlagLow` accordingly. 
- Integrated the detector into the pipeline in `TradeCore` so it runs immediately after `TransitionDetector` evaluation and before entry scoring. 
- Gated transition score boosting so the boost only applies when `ctx.TransitionValid && ctx.FlagBreakoutConfirmed` is true. 
- Modified files: `Core/Entry/FlagBreakoutDetector.cs` (new), `Core/Entry/EntryContext.cs` (added `FlagBreakoutConfirmed`, `FlagHigh`, `FlagLow`), and `Core/TradeCore.cs` (wired detector and gated boost). 
- Emits debug traces `[FLAG_BREAKOUT][RANGE]` and `[FLAG_BREAKOUT][CHECK]` from the new detector for observability. 

### Testing
- Verified symbol references and integration using `rg -n "FlagBreakoutDetector|FlagBreakoutConfirmed|_flagBreakoutDetector|FLAG_BREAKOUT" Core` and confirmed matches in the three modified files. 
- Inspected new file and integration points with `nl -ba Core/Entry/FlagBreakoutDetector.cs` and `sed -n '860,890p' Core/TradeCore.cs` to ensure correct placement and logging calls. 
- Performed repository diffs and content inspections to confirm the `EntryContext` additions and that the detector is invoked immediately after transition evaluation; these inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0633c437c83289916a6e1ea0567af)