### PR TITLE
Add passive trade stats tracker by instrument and setup type

### DIFF
--- a/Core/Analytics/TradeStatsTracker.cs
+++ b/Core/Analytics/TradeStatsTracker.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using GeminiV26.Core.Entry;
+
+namespace GeminiV26.Core.Analytics
+{
+    public sealed class TradeStatsTracker
+    {
+        public sealed class TradeStats
+        {
+            public int Total;
+            public int Wins;
+            public int Losses;
+            public double NetProfit;
+
+            public double WinRate =>
+                Total > 0 ? (double)Wins / Total : 0.0;
+        }
+
+        public sealed class InstrumentStats
+        {
+            public TradeStats All = new TradeStats();
+            public TradeStats Transition = new TradeStats();
+            public TradeStats NonTransition = new TradeStats();
+            public TradeStats Breakout = new TradeStats();
+        }
+
+        private sealed class TradeMeta
+        {
+            public string Symbol;
+            public bool Transition;
+            public bool Breakout;
+        }
+
+        private readonly Dictionary<string, InstrumentStats> _instrumentStats = new Dictionary<string, InstrumentStats>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<long, TradeMeta> _activeByPositionId = new Dictionary<long, TradeMeta>();
+        private readonly Dictionary<string, Queue<TradeMeta>> _activeBySymbol = new Dictionary<string, Queue<TradeMeta>>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly Action<string> _log;
+        private int _closedTrades;
+
+        public TradeStatsTracker(Action<string> log)
+        {
+            _log = log ?? (_ => { });
+        }
+
+        public void RegisterTradeOpen(EntryContext ctx)
+        {
+            RegisterTradeOpen(ctx, null);
+        }
+
+        public void RegisterTradeOpen(EntryContext ctx, long? positionId)
+        {
+            if (ctx == null || string.IsNullOrWhiteSpace(ctx.Symbol))
+                return;
+
+            var meta = new TradeMeta
+            {
+                Symbol = ctx.Symbol,
+                Transition = ctx.TransitionValid,
+                Breakout = ctx.FlagBreakoutConfirmed
+            };
+
+            if (positionId.HasValue && positionId.Value > 0)
+            {
+                _activeByPositionId[positionId.Value] = meta;
+                return;
+            }
+
+            if (!_activeBySymbol.TryGetValue(meta.Symbol, out var queue))
+            {
+                queue = new Queue<TradeMeta>();
+                _activeBySymbol[meta.Symbol] = queue;
+            }
+
+            queue.Enqueue(meta);
+        }
+
+        public void RegisterTradeClose(EntryContext ctx, double pnl)
+        {
+            if (ctx == null || string.IsNullOrWhiteSpace(ctx.Symbol))
+                return;
+
+            var symbol = ctx.Symbol;
+            var stats = GetOrCreateSymbolStats(symbol);
+
+            UpdateStats(stats.All, pnl);
+
+            if (ctx.TransitionValid)
+                UpdateStats(stats.Transition, pnl);
+            else
+                UpdateStats(stats.NonTransition, pnl);
+
+            if (ctx.FlagBreakoutConfirmed)
+                UpdateStats(stats.Breakout, pnl);
+
+            _closedTrades++;
+            if (_closedTrades % 20 == 0)
+                PrintSummary();
+        }
+
+        public void RegisterTradeClose(long positionId, EntryContext fallbackCtx, double pnl)
+        {
+            if (_activeByPositionId.TryGetValue(positionId, out var meta) && meta != null)
+            {
+                _activeByPositionId.Remove(positionId);
+                RegisterTradeClose(ToContext(meta), pnl);
+                return;
+            }
+
+            if (fallbackCtx != null)
+            {
+                if (_activeBySymbol.TryGetValue(fallbackCtx.Symbol, out var queue) && queue.Count > 0)
+                    queue.Dequeue();
+
+                RegisterTradeClose(fallbackCtx, pnl);
+                return;
+            }
+
+        }
+
+        public void PrintSummary()
+        {
+            _log("[TRADE_STATS]");
+
+            foreach (var kv in _instrumentStats.OrderBy(k => k.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                var symbol = kv.Key;
+                var s = kv.Value;
+
+                _log(string.Empty);
+                _log(symbol);
+                _log($"AllTrades: total={s.All.Total} winrate={FormatWinRate(s.All.WinRate)} net={Math.Round(s.All.NetProfit, 2).ToString(CultureInfo.InvariantCulture)}");
+                _log($"Transition: total={s.Transition.Total} winrate={FormatWinRate(s.Transition.WinRate)}");
+                _log($"NonTransition: total={s.NonTransition.Total} winrate={FormatWinRate(s.NonTransition.WinRate)}");
+                _log($"Breakout: total={s.Breakout.Total} winrate={FormatWinRate(s.Breakout.WinRate)}");
+            }
+        }
+
+        private static EntryContext ToContext(TradeMeta meta)
+        {
+            return new EntryContext
+            {
+                Symbol = meta.Symbol,
+                TransitionValid = meta.Transition,
+                FlagBreakoutConfirmed = meta.Breakout
+            };
+        }
+
+        private InstrumentStats GetOrCreateSymbolStats(string symbol)
+        {
+            if (!_instrumentStats.TryGetValue(symbol, out var stats))
+            {
+                stats = new InstrumentStats();
+                _instrumentStats[symbol] = stats;
+            }
+
+            return stats;
+        }
+
+        private static void UpdateStats(TradeStats stats, double pnl)
+        {
+            stats.Total++;
+            stats.NetProfit += pnl;
+
+            if (pnl > 0)
+                stats.Wins++;
+            else if (pnl < 0)
+                stats.Losses++;
+        }
+
+        private static string FormatWinRate(double winRate)
+        {
+            return winRate.ToString("0.00", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -63,6 +63,7 @@ using GeminiV26.Core;
 using GeminiV26.Core.HtfBias;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Core.Context;
+using GeminiV26.Core.Analytics;
 using System.Linq;
 
 namespace GeminiV26.Core
@@ -81,6 +82,7 @@ namespace GeminiV26.Core
         private readonly TradeLogger _tradeLogger;
         private readonly Dictionary<long, PositionContext> _positionContexts = new();
         private readonly TradeMetaStore _tradeMetaStore = new();
+        private readonly TradeStatsTracker _statsTracker;
        
         private const string BotLabel = "GeminiV26";
                 
@@ -398,6 +400,7 @@ namespace GeminiV26.Core
             _transitionDetector = new TransitionDetector(_bot.Print);
             _flagBreakoutDetector = new FlagBreakoutDetector(_bot.Print);
             _tradeLogger = new TradeLogger(_bot.SymbolName);
+            _statsTracker = new TradeStatsTracker(_bot.Print);
             _globalSessionGate = new GlobalSessionGate(_bot);
             _sessionMatrix = new SessionMatrix(new SessionMatrixProvider());
 
@@ -667,7 +670,10 @@ namespace GeminiV26.Core
                 );
 
                 if (_ctx != null)
+                {
                     _contextRegistry.RegisterEntry(pos.Id, _ctx);
+                    _statsTracker.RegisterTradeOpen(_ctx, pos.Id);
+                }
 
                 if (_positionContexts.TryGetValue(pos.Id, out var pctx))
                     _contextRegistry.RegisterPosition(pctx);
@@ -1808,6 +1814,7 @@ namespace GeminiV26.Core
 
             _tradeMetaStore.TryGet(pos.Id, out var meta);
             _positionContexts.TryGetValue(pos.Id, out var ctx);
+            var entryCtx = _contextRegistry.GetEntry(pos.Id);
 
             if (meta == null)
             {
@@ -1877,6 +1884,8 @@ namespace GeminiV26.Core
                 BeActivated = ctx?.BeActivated,
                 TrailingActivated = ctx?.TrailingActivated,
             });
+
+            _statsTracker.RegisterTradeClose(pos.Id, entryCtx, pos.NetProfit);
 
             _positionContexts.Remove(pos.Id);
             _contextRegistry.RemovePosition(pos.Id);


### PR DESCRIPTION
### Motivation
- Provide a passive analytics engine to measure trade performance per instrument and setup type (All / Transition / NonTransition / Breakout) without affecting trading logic.
- Allow easy, periodic reporting of winrate and net profit to help evaluate setup effectiveness across symbols.

### Description
- Added `Core/Analytics/TradeStatsTracker.cs` implementing `TradeStats`, `InstrumentStats`, and an internal `TradeMeta` store with `RegisterTradeOpen` and `RegisterTradeClose` methods and a periodic `PrintSummary()` that emits `[TRADE_STATS]` every 20 closed trades.
- The tracker stores minimal open-trade metadata keyed by `positionId` (and a per-symbol queue fallback) and aggregates wins/losses/net-profit on close to compute winrates.
- Integrated the tracker into `Core/TradeCore.cs` by adding a `_statsTracker` field, initializing it in the constructor, calling `_statsTracker.RegisterTradeOpen(_ctx, pos.Id)` on `Positions.Opened`, and calling `_statsTracker.RegisterTradeClose(pos.Id, entryCtx, pos.NetProfit)` in `OnPositionClosed` to record closed-trade results.
- The module is passive and does not modify Entry Engines, RiskSizer, ExitManager, Executor, TransitionDetector, or FlagBreakoutDetector behavior.

### Testing
- Verified source changes and wiring with repository inspections and grep/sed checks (file creation and integration points present); `git add`/`git commit` completed successfully.
- Confirmed the tracker prints `[TRADE_STATS]` summaries every 20 closed trades by code inspection of the `_closedTrades` counter and `PrintSummary()` invocation.
- No solution/project file was present in this environment snapshot, so a full automated build or runtime test was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b066f00428832883f90823be4e4ff6)