### PR TITLE
Improve TransitionDetector v2 scoring and structural safety checks

### DIFF
--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -17,23 +17,28 @@ namespace GeminiV26.Core.Entry
             int impulseIndex = -1;
             TradeDirection impulseDirection = TradeDirection.None;
             double impulseRange = 0.0;
+            double impulseStrength = 0.0;
 
             for (int i = last; i >= Math.Max(1, last - rules.MaxImpulseAge); i--)
             {
                 double range = ctx.M5.HighPrices[i] - ctx.M5.LowPrices[i];
                 double body = Math.Abs(ctx.M5.ClosePrices[i] - ctx.M5.OpenPrices[i]);
                 double bodyRatio = range > 0 ? body / range : 0.0;
-                bool directional = Math.Abs(ctx.M5.ClosePrices[i] - ctx.M5.OpenPrices[i]) > 1e-12;
 
-                if (directional &&
-                    range > ctx.AtrM5 * rules.ImpulseMultiplier &&
-                    bodyRatio >= rules.MinImpulseBodyRatio)
-                {
-                    impulseIndex = i;
-                    impulseDirection = ctx.M5.ClosePrices[i] > ctx.M5.OpenPrices[i] ? TradeDirection.Long : TradeDirection.Short;
-                    impulseRange = range;
-                    break;
-                }
+                if (range <= ctx.AtrM5 * rules.ImpulseMultiplier || bodyRatio < rules.MinImpulseBodyRatio)
+                    continue;
+
+                bool bullishImpulse = ctx.M5.ClosePrices[i] > ctx.M5.OpenPrices[i] && ctx.M5.ClosePrices[i] > ctx.M5.HighPrices[i - 1];
+                bool bearishImpulse = ctx.M5.ClosePrices[i] < ctx.M5.OpenPrices[i] && ctx.M5.ClosePrices[i] < ctx.M5.LowPrices[i - 1];
+
+                if (!bullishImpulse && !bearishImpulse)
+                    continue;
+
+                impulseIndex = i;
+                impulseDirection = bullishImpulse ? TradeDirection.Long : TradeDirection.Short;
+                impulseRange = range;
+                impulseStrength = ctx.AtrM5 > 0 ? range / ctx.AtrM5 : 0.0;
+                break;
             }
 
             bool hasImpulse = impulseIndex >= 0;
@@ -41,15 +46,19 @@ namespace GeminiV26.Core.Entry
             if (hasImpulse && barsSinceImpulse > rules.MaxImpulseAge)
             {
                 hasImpulse = false;
+                impulseIndex = -1;
+                impulseDirection = TradeDirection.None;
+                impulseRange = 0.0;
+                impulseStrength = 0.0;
             }
 
-            double strength = hasImpulse && ctx.AtrM5 > 0 ? impulseRange / ctx.AtrM5 : 0.0;
-            ctx.Log?.Invoke($"[TRANSITION][IMPULSE] detected={hasImpulse.ToString().ToLowerInvariant()} barsSince={barsSinceImpulse} strength={strength:0.00}");
+            ctx.Log?.Invoke($"[TRANSITION][IMPULSE] detected={hasImpulse.ToString().ToLowerInvariant()} barsSince={barsSinceImpulse} strength={impulseStrength:0.00}");
 
             int pullbackStart = hasImpulse ? impulseIndex + 1 : -1;
             int pullbackEnd = -1;
             int pullbackBars = 0;
             double pullbackDepthR = 0.0;
+            double pullbackQuality = 0.0;
             bool trendAlignmentMaintained = false;
             bool hasPullback = false;
 
@@ -60,19 +69,22 @@ namespace GeminiV26.Core.Entry
 
                 if (pullbackBars > 0 && impulseRange > 0)
                 {
-                    double impulseClose = ctx.M5.ClosePrices[impulseIndex];
                     if (impulseDirection == TradeDirection.Long)
                     {
-                        double low = MinLow(ctx, pullbackStart, pullbackEnd);
-                        pullbackDepthR = Math.Max(0.0, impulseClose - low) / impulseRange;
-                        trendAlignmentMaintained = low > ctx.M5.LowPrices[impulseIndex];
+                        double pullbackLow = MinLow(ctx, pullbackStart, pullbackEnd);
+                        double impulseHigh = ctx.M5.HighPrices[impulseIndex];
+                        pullbackDepthR = Math.Abs(impulseHigh - pullbackLow) / impulseRange;
+                        trendAlignmentMaintained = pullbackLow > ctx.M5.LowPrices[impulseIndex];
                     }
                     else
                     {
-                        double high = MaxHigh(ctx, pullbackStart, pullbackEnd);
-                        pullbackDepthR = Math.Max(0.0, high - impulseClose) / impulseRange;
-                        trendAlignmentMaintained = high < ctx.M5.HighPrices[impulseIndex];
+                        double pullbackHigh = MaxHigh(ctx, pullbackStart, pullbackEnd);
+                        double impulseLow = ctx.M5.LowPrices[impulseIndex];
+                        pullbackDepthR = Math.Abs(pullbackHigh - impulseLow) / impulseRange;
+                        trendAlignmentMaintained = pullbackHigh < ctx.M5.HighPrices[impulseIndex];
                     }
+
+                    pullbackQuality = Clamp01(1.0 - pullbackDepthR);
                 }
 
                 hasPullback = pullbackBars >= rules.MinPullbackBars
@@ -86,14 +98,19 @@ namespace GeminiV26.Core.Entry
             int flagStart = pullbackEnd + 1;
             int flagBars = flagStart <= last ? (last - flagStart + 1) : 0;
             double compression = 1.0;
+            double compressionScore = 0.0;
             bool noStructureBreak = false;
             bool hasFlag = false;
+            bool flagStructureBroken = false;
 
             if (hasImpulse && hasPullback && flagBars > 0)
             {
                 double avgRange = AverageRange(ctx, flagStart, last);
                 compression = impulseRange > 0 ? avgRange / impulseRange : 1.0;
+                compressionScore = Clamp01(1.0 - compression);
+
                 noStructureBreak = ValidateNoStructureBreak(ctx, flagStart, last, impulseDirection, pullbackStart, pullbackEnd);
+                flagStructureBroken = !noStructureBreak;
 
                 hasFlag = flagBars <= rules.MaxFlagBars
                     && compression <= rules.MaxCompressionRatio
@@ -103,9 +120,24 @@ namespace GeminiV26.Core.Entry
             ctx.Log?.Invoke($"[TRANSITION][FLAG] bars={flagBars} compression={compression:0.00}");
 
             bool isValid = hasImpulse && hasPullback && hasFlag;
-            int bonus = isValid ? 10 : 0;
-            string reason = isValid ? "OK" : BuildReason(hasImpulse, hasPullback, hasFlag, pullbackDepthR, rules.MaxPullbackDepthR, compression, rules.MaxCompressionRatio);
 
+            double qualityScore = 0.0;
+            int bonus = 0;
+            if (isValid)
+            {
+                qualityScore =
+                    (impulseStrength * 0.4) +
+                    (compressionScore * 0.3) +
+                    (pullbackQuality * 0.3);
+
+                bonus = Clamp((int)(qualityScore * 10.0), 5, 18);
+            }
+
+            string reason = isValid
+                ? "OK"
+                : BuildReason(hasImpulse, hasPullback, hasFlag, flagStructureBroken, pullbackDepthR, rules.MaxPullbackDepthR, compression, rules.MaxCompressionRatio);
+
+            ctx.Log?.Invoke($"[TRANSITION][QUALITY] impulse={impulseStrength:0.00} compression={compressionScore:0.00} pullback={pullbackQuality:0.00} score={qualityScore:0.00} bonus={bonus}");
             ctx.Log?.Invoke($"[TRANSITION][DECISION] valid={isValid.ToString().ToLowerInvariant()} bonus={bonus}");
 
             return new TransitionEvaluation
@@ -117,7 +149,8 @@ namespace GeminiV26.Core.Entry
                 PullbackBars = pullbackBars,
                 FlagBars = flagBars,
                 PullbackDepthR = pullbackDepthR,
-                CompressionScore = compression,
+                CompressionScore = compressionScore,
+                QualityScore = qualityScore,
                 IsValid = isValid,
                 BonusScore = bonus,
                 Reason = reason
@@ -215,7 +248,29 @@ namespace GeminiV26.Core.Entry
             return high;
         }
 
-        private static string BuildReason(bool hasImpulse, bool hasPullback, bool hasFlag, double pullbackDepthR, double maxPullbackDepthR, double compression, double maxCompression)
+        private static int Clamp(int value, int min, int max)
+        {
+            if (value < min)
+                return min;
+
+            if (value > max)
+                return max;
+
+            return value;
+        }
+
+        private static double Clamp01(double value)
+        {
+            if (value < 0.0)
+                return 0.0;
+
+            if (value > 1.0)
+                return 1.0;
+
+            return value;
+        }
+
+        private static string BuildReason(bool hasImpulse, bool hasPullback, bool hasFlag, bool flagStructureBroken, double pullbackDepthR, double maxPullbackDepthR, double compression, double maxCompression)
         {
             if (!hasImpulse)
                 return "MissingImpulse";
@@ -230,6 +285,9 @@ namespace GeminiV26.Core.Entry
 
             if (!hasFlag)
             {
+                if (flagStructureBroken)
+                    return "FlagStructureBreak";
+
                 if (compression > maxCompression)
                     return "WeakCompression";
 

--- a/Core/Entry/TransitionEvaluation.cs
+++ b/Core/Entry/TransitionEvaluation.cs
@@ -12,6 +12,7 @@ namespace GeminiV26.Core.Entry
 
         public double PullbackDepthR { get; init; }
         public double CompressionScore { get; init; }
+        public double QualityScore { get; init; }
 
         public bool IsValid { get; init; }
         public int BonusScore { get; init; }


### PR DESCRIPTION
### Motivation
- Increase transition signal quality by scoring setup strength instead of using a fixed bonus and by rejecting impulsive spikes and broken flag structures. 
- Make pullback and compression metrics semantically meaningful (higher = better) so downstream entry engines can trust the metadata. 
- Preserve existing interfaces and backward compatibility while tightening structural validation to reduce false positives.

### Description
- Added `QualityScore` to `TransitionEvaluation` and preserved `IsValid`, `BonusScore`, `Reason`, and `TransitionValid` for compatibility, and updated returned evaluation to include the new fields (`Core/Entry/TransitionEvaluation.cs`).
- Replaced fixed bonus with a dynamic `BonusScore` computed from a weighted `QualityScore` using `impulseStrength * 0.4 + compressionScore * 0.3 + pullbackQuality * 0.3`, then `Clamp((int)(QualityScore*10), 5, 18)` when valid (`Core/Entry/TransitionDetector.cs`).
- Normalized compression into `CompressionScore = clamp(1 - (avgFlagRange/impulseRange), 0..1)` so higher means better compression, and corrected `CompressionScore` usage in the evaluation output (`Core/Entry/TransitionDetector.cs`).
- Strengthened impulse validation to require ATR/body thresholds plus directional follow-through (`close > previousHigh` for bullish and `close < previousLow` for bearish) to avoid wick/spike impulses, and ensured stale impulses are fully reset when `BarsSinceImpulse > rules.MaxImpulseAge` (`Core/Entry/TransitionDetector.cs`).
- Corrected pullback depth to use impulse-range geometry (`abs(impulseHigh - pullbackLow)/impulseRange` or the reverse for bearish) and derived a bounded `pullbackQuality = clamp01(1 - pullbackDepthR)` while retaining the `rules.MaxPullbackDepthR` rejection rule (`Core/Entry/TransitionDetector.cs`).
- Improved flag validation to explicitly detect and reject structure breaks inside the flag (`FlagStructureBreak`) and surfaced this reason in `BuildReason`, keeping existing decision logging and adding a new `[TRANSITION][QUALITY]` debug line while preserving `ctx.Log?.Invoke(...)` usage (`Core/Entry/TransitionDetector.cs`).

### Testing
- Attempted to run `dotnet build -nologo` but the `dotnet` CLI is not installed in the environment so no build/test run could be completed (build attempt failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06f625d008328abfd9bfc6d9f639a)