### PR TITLE
Normalize impulse strength, add weak-impulse rule, and calibrate pullback quality in TransitionDetector v2

### DIFF
--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -37,7 +37,8 @@ namespace GeminiV26.Core.Entry
                 impulseIndex = i;
                 impulseDirection = bullishImpulse ? TradeDirection.Long : TradeDirection.Short;
                 impulseRange = range;
-                impulseStrength = ctx.AtrM5 > 0 ? range / ctx.AtrM5 : 0.0;
+                double normalizationAtr = ctx.AtrM5 * rules.ImpulseNormalizationAtrFactor;
+                impulseStrength = normalizationAtr > 0 ? Clamp01(range / normalizationAtr) : 0.0;
                 break;
             }
 
@@ -50,6 +51,15 @@ namespace GeminiV26.Core.Entry
                 impulseDirection = TradeDirection.None;
                 impulseRange = 0.0;
                 impulseStrength = 0.0;
+            }
+
+            bool weakImpulse = hasImpulse && impulseStrength < rules.MinImpulseStrength;
+            if (weakImpulse)
+            {
+                hasImpulse = false;
+                impulseIndex = -1;
+                impulseDirection = TradeDirection.None;
+                impulseRange = 0.0;
             }
 
             ctx.Log?.Invoke($"[TRANSITION][IMPULSE] detected={hasImpulse.ToString().ToLowerInvariant()} barsSince={barsSinceImpulse} strength={impulseStrength:0.00}");
@@ -84,7 +94,7 @@ namespace GeminiV26.Core.Entry
                         trendAlignmentMaintained = pullbackHigh < ctx.M5.HighPrices[impulseIndex];
                     }
 
-                    pullbackQuality = Clamp01(1.0 - pullbackDepthR);
+                    pullbackQuality = Clamp01(1.0 - Math.Abs(pullbackDepthR - rules.OptimalPullbackDepthR));
                 }
 
                 hasPullback = pullbackBars >= rules.MinPullbackBars
@@ -135,10 +145,10 @@ namespace GeminiV26.Core.Entry
 
             string reason = isValid
                 ? "OK"
-                : BuildReason(hasImpulse, hasPullback, hasFlag, flagStructureBroken, pullbackDepthR, rules.MaxPullbackDepthR, compression, rules.MaxCompressionRatio);
+                : BuildReason(hasImpulse, hasPullback, hasFlag, flagStructureBroken, weakImpulse, pullbackDepthR, rules.MaxPullbackDepthR, compression, rules.MaxCompressionRatio);
 
             ctx.Log?.Invoke($"[TRANSITION][QUALITY] impulse={impulseStrength:0.00} compression={compressionScore:0.00} pullback={pullbackQuality:0.00} score={qualityScore:0.00} bonus={bonus}");
-            ctx.Log?.Invoke($"[TRANSITION][DECISION] valid={isValid.ToString().ToLowerInvariant()} bonus={bonus}");
+            ctx.Log?.Invoke($"[TRANSITION][DECISION] valid={isValid.ToString().ToLowerInvariant()} bonus={bonus} reason={reason}");
 
             return new TransitionEvaluation
             {
@@ -270,8 +280,11 @@ namespace GeminiV26.Core.Entry
             return value;
         }
 
-        private static string BuildReason(bool hasImpulse, bool hasPullback, bool hasFlag, bool flagStructureBroken, double pullbackDepthR, double maxPullbackDepthR, double compression, double maxCompression)
+        private static string BuildReason(bool hasImpulse, bool hasPullback, bool hasFlag, bool flagStructureBroken, bool weakImpulse, double pullbackDepthR, double maxPullbackDepthR, double compression, double maxCompression)
         {
+            if (weakImpulse)
+                return "WeakImpulse";
+
             if (!hasImpulse)
                 return "MissingImpulse";
 

--- a/Core/Entry/TransitionRules.cs
+++ b/Core/Entry/TransitionRules.cs
@@ -5,9 +5,12 @@ namespace GeminiV26.Core.Entry
         public int MaxImpulseAge { get; init; } = 8;
         public double ImpulseMultiplier { get; init; } = 1.2;
         public double MinImpulseBodyRatio { get; init; } = 0.60;
+        public double MinImpulseStrength { get; init; } = 0.40;
+        public double ImpulseNormalizationAtrFactor { get; init; } = 2.0;
 
         public double MaxPullbackDepthR { get; init; } = 0.5;
         public int MinPullbackBars { get; init; } = 2;
+        public double OptimalPullbackDepthR { get; init; } = 0.42;
 
         public int MaxFlagBars { get; init; } = 5;
         public double MaxCompressionRatio { get; init; } = 0.75;
@@ -22,8 +25,10 @@ namespace GeminiV26.Core.Entry
                 {
                     MaxImpulseAge = 6,
                     ImpulseMultiplier = 1.4,
+                    MinImpulseStrength = 0.45,
                     MaxPullbackDepthR = 0.45,
                     MinPullbackBars = 2,
+                    OptimalPullbackDepthR = 0.40,
                     MaxFlagBars = 4,
                     MaxCompressionRatio = 0.70
                 };
@@ -35,8 +40,10 @@ namespace GeminiV26.Core.Entry
                 {
                     MaxImpulseAge = 7,
                     ImpulseMultiplier = 1.3,
+                    MinImpulseStrength = 0.40,
                     MaxPullbackDepthR = 0.5,
                     MinPullbackBars = 2,
+                    OptimalPullbackDepthR = 0.42,
                     MaxFlagBars = 5,
                     MaxCompressionRatio = 0.80
                 };


### PR DESCRIPTION
### Motivation
- Prevent unbounded impulse values from distorting `QualityScore` by normalizing impulse strength and reject weak impulses before transition evaluation.
- Improve pullback scoring so ideal-depth pullbacks get the highest quality while both too-shallow and too-deep pullbacks are penalized.
- Preserve the metadata-only detector behavior and the existing structured transition log chain for easier debugging.

### Description
- Added rule fields to `TransitionRules`: `MinImpulseStrength`, `ImpulseNormalizationAtrFactor`, and `OptimalPullbackDepthR`, with symbol-specific defaults for crypto and index buckets.
- Replaced unbounded `impulseStrength = range / Atr` with a normalized, clamped score using `range / (Atr * ImpulseNormalizationAtrFactor)` and `Clamp01(...)` in `TransitionDetector`.
- Implemented a rules-driven weak-impulse filter that invalidates the transition and sets the reason to `WeakImpulse` when `impulseStrength < MinImpulseStrength`.
- Reworked pullback quality to `Clamp01(1.0 - Abs(pullbackDepthR - OptimalPullbackDepthR))` so the score peaks at an optimal pullback depth; left flag compression window logic intact (impulse bar is excluded via `flagStart = pullbackEnd + 1`).
- Kept all existing transition logs (`[TRANSITION][IMPULSE]`, `[TRANSITION][PULLBACK]`, `[TRANSITION][FLAG]`, `[TRANSITION][QUALITY]`, `[TRANSITION][DECISION]`) and augmented the decision log to include `reason=...` for clearer rejection diagnostics.

### Testing
- Performed code inspection and diff validation to confirm logic changes and that the impulse bar is not included in the flag compression window, and verified the updated log lines are present.
- Attempted to run `dotnet build` in the environment but it failed because the SDK is not installed (`bash: command not found: dotnet`).
- No unit/CI builds were executed here due to missing SDK; changes are conservative, rules-driven, and preserve backward-compatible outputs (`IsValid`, `BonusScore`, `Reason`, `TransitionValid`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b071e286c48328a0e39cd1f4ef5cba)