### PR TITLE
Fix TradeStats CSV export when positions close

### DIFF
--- a/Core/Analytics/TradeStatsTracker.cs
+++ b/Core/Analytics/TradeStatsTracker.cs
@@ -35,6 +35,18 @@ namespace GeminiV26.Core.Analytics
             public bool Breakout;
         }
 
+        public sealed class TradeCloseSnapshot
+        {
+            public DateTime TimestampUtc;
+            public string Symbol;
+            public string Direction;
+            public double EntryPrice;
+            public double ExitPrice;
+            public double Profit;
+            public int? Score;
+            public int? Confidence;
+        }
+
         private readonly Dictionary<string, InstrumentStats> _instrumentStats = new Dictionary<string, InstrumentStats>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<long, TradeMeta> _activeByPositionId = new Dictionary<long, TradeMeta>();
         private readonly Dictionary<string, Queue<TradeMeta>> _activeBySymbol = new Dictionary<string, Queue<TradeMeta>>(StringComparer.OrdinalIgnoreCase);
@@ -84,6 +96,14 @@ namespace GeminiV26.Core.Analytics
             if (ctx == null || string.IsNullOrWhiteSpace(ctx.Symbol))
                 return;
 
+            RegisterTradeClose(ctx, pnl, null);
+        }
+
+        public void RegisterTradeClose(EntryContext ctx, double pnl, TradeCloseSnapshot snapshot)
+        {
+            if (ctx == null || string.IsNullOrWhiteSpace(ctx.Symbol))
+                return;
+
             var symbol = ctx.Symbol;
             var stats = GetOrCreateSymbolStats(symbol);
 
@@ -97,6 +117,18 @@ namespace GeminiV26.Core.Analytics
             if (ctx.FlagBreakoutConfirmed)
                 UpdateStats(stats.Breakout, pnl);
 
+            WriteTradeRow(snapshot ?? new TradeCloseSnapshot
+            {
+                TimestampUtc = DateTime.UtcNow,
+                Symbol = symbol,
+                Direction = string.Empty,
+                EntryPrice = 0,
+                ExitPrice = 0,
+                Profit = pnl,
+                Score = null,
+                Confidence = null
+            });
+
             _closedTrades++;
             if (_closedTrades % 20 == 0)
                 PrintSummary();
@@ -104,10 +136,15 @@ namespace GeminiV26.Core.Analytics
 
         public void RegisterTradeClose(long positionId, EntryContext fallbackCtx, double pnl)
         {
+            RegisterTradeClose(positionId, fallbackCtx, pnl, null);
+        }
+
+        public void RegisterTradeClose(long positionId, EntryContext fallbackCtx, double pnl, TradeCloseSnapshot snapshot)
+        {
             if (_activeByPositionId.TryGetValue(positionId, out var meta) && meta != null)
             {
                 _activeByPositionId.Remove(positionId);
-                RegisterTradeClose(ToContext(meta), pnl);
+                RegisterTradeClose(ToContext(meta), pnl, snapshot);
                 return;
             }
 
@@ -116,7 +153,7 @@ namespace GeminiV26.Core.Analytics
                 if (_activeBySymbol.TryGetValue(fallbackCtx.Symbol, out var queue) && queue.Count > 0)
                     queue.Dequeue();
 
-                RegisterTradeClose(fallbackCtx, pnl);
+                RegisterTradeClose(fallbackCtx, pnl, snapshot);
                 return;
             }
 
@@ -208,6 +245,44 @@ namespace GeminiV26.Core.Analytics
         private static string FormatWinRate(double winRate)
         {
             return winRate.ToString("0.00", CultureInfo.InvariantCulture);
+        }
+
+        private void WriteTradeRow(TradeCloseSnapshot snapshot)
+        {
+            if (snapshot == null || string.IsNullOrWhiteSpace(snapshot.Symbol))
+                return;
+
+            try
+            {
+                const string basePath = @"C:\Users\Administrator\Documents\GeminiV26\Data\Trades";
+                Directory.CreateDirectory(basePath);
+
+                var safeSymbol = snapshot.Symbol.Trim();
+                var filePath = Path.Combine(basePath, $"{safeSymbol}_trades.csv");
+
+                if (!File.Exists(filePath))
+                {
+                    const string header = "timestamp,symbol,direction,entryPrice,exitPrice,profit,score,confidence";
+                    File.WriteAllText(filePath, header + Environment.NewLine);
+                }
+
+                var row = string.Join(",",
+                    snapshot.TimestampUtc.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+                    safeSymbol,
+                    snapshot.Direction ?? string.Empty,
+                    snapshot.EntryPrice.ToString(CultureInfo.InvariantCulture),
+                    snapshot.ExitPrice.ToString(CultureInfo.InvariantCulture),
+                    snapshot.Profit.ToString(CultureInfo.InvariantCulture),
+                    snapshot.Score?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+                    snapshot.Confidence?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+
+                File.AppendAllText(filePath, row + Environment.NewLine);
+                _log($"[TRADESTATS] trade logged {safeSymbol}");
+            }
+            catch (Exception ex)
+            {
+                _log($"[TRADESTATS][ERROR] {ex.Message}");
+            }
         }
     }
 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1885,7 +1885,21 @@ namespace GeminiV26.Core
                 TrailingActivated = ctx?.TrailingActivated,
             });
 
-            _statsTracker.RegisterTradeClose(pos.Id, entryCtx, pos.NetProfit);
+            _statsTracker.RegisterTradeClose(
+                pos.Id,
+                entryCtx,
+                pos.NetProfit,
+                new TradeStatsTracker.TradeCloseSnapshot
+                {
+                    TimestampUtc = _bot.Server.Time.ToUniversalTime(),
+                    Symbol = pos.SymbolName,
+                    Direction = pos.TradeType.ToString(),
+                    EntryPrice = pos.EntryPrice,
+                    ExitPrice = pos.EntryPrice + pos.Pips * sym.PipSize * (pos.TradeType == TradeType.Buy ? 1 : -1),
+                    Profit = pos.NetProfit,
+                    Score = null,
+                    Confidence = meta?.Confidence
+                });
 
             _positionContexts.Remove(pos.Id);
             _contextRegistry.RemovePosition(pos.Id);


### PR DESCRIPTION
### Motivation
- The analytics exporter only flushed CSV output during periodic `PrintSummary()` runs (every 20 closes) so per-trade CSV files were not reliably created when a position closed. 
- The goal is to guarantee a per-close CSV row in the expected location `C:\Users\Administrator\Documents\GeminiV26\Data\Trades` without changing trading logic or architecture.

### Description
- Added a `TradeCloseSnapshot` type and a `WriteTradeRow` method in `TradeStatsTracker` that safely creates the base directory, creates a `{SYMBOL}_trades.csv` file with header when missing, and appends a per-trade CSV row (`timestamp,symbol,direction,entryPrice,exitPrice,profit,score,confidence`).
- Extended `RegisterTradeClose(...)` overloads to accept an optional `TradeCloseSnapshot` and to call `WriteTradeRow(...)` on every closed trade so each close writes immediately. 
- Wired `TradeCore.OnPositionClosed` to build and pass a `TradeCloseSnapshot` (timestamp, symbol, direction, entry/exit price, profit, confidence) into the tracker at the close event without changing entry/exit/risk logic. 
- Added robust logging for success (`[TRADESTATS] trade logged {symbol}`) and failures (`[TRADESTATS][ERROR] ...`) and preserved the existing periodic `PrintSummary()` exports.

### Testing
- Verified code locations and changes with search: `rg -n "RegisterTradeClose\(|WriteTradeRow|TRADESTATS" Core/Analytics/TradeStatsTracker.cs Core/TradeCore.cs`, which returned the updated usages and new method signatures and passed. 
- Inspected the modified files with `sed -n` and `nl -ba` to confirm the `WriteTradeRow` implementation and the `OnPositionClosed` snapshot wiring were inserted as intended, and those inspections succeeded. 
- Applied the patch to the repository using the project patch tool and the patch application succeeded and left the repository changes in place for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b075e9b9108328a712411cb10d43be)