### PR TITLE
Extend TradeStats CSV export with MFE/MAE/RMultiple, SetupType, TransitionQuality, MarketRegime

### DIFF
--- a/Core/Analytics/TradeStatsTracker.cs
+++ b/Core/Analytics/TradeStatsTracker.cs
@@ -45,6 +45,12 @@ namespace GeminiV26.Core.Analytics
             public double Profit;
             public int? Score;
             public int? Confidence;
+            public string SetupType;
+            public string MarketRegime;
+            public double MfeR;
+            public double MaeR;
+            public double RMultiple;
+            public double TransitionQuality;
         }
 
         private readonly Dictionary<string, InstrumentStats> _instrumentStats = new Dictionary<string, InstrumentStats>(StringComparer.OrdinalIgnoreCase);
@@ -126,7 +132,13 @@ namespace GeminiV26.Core.Analytics
                 ExitPrice = 0,
                 Profit = pnl,
                 Score = null,
-                Confidence = null
+                Confidence = null,
+                SetupType = string.Empty,
+                MarketRegime = string.Empty,
+                MfeR = 0,
+                MaeR = 0,
+                RMultiple = 0,
+                TransitionQuality = 0
             });
 
             _closedTrades++;
@@ -262,7 +274,7 @@ namespace GeminiV26.Core.Analytics
 
                 if (!File.Exists(filePath))
                 {
-                    const string header = "timestamp,symbol,direction,entryPrice,exitPrice,profit,score,confidence";
+                    const string header = "timestamp,symbol,direction,entryPrice,exitPrice,profit,score,confidence,SetupType,MarketRegime,MFE_R,MAE_R,RMultiple,TransitionQuality";
                     File.WriteAllText(filePath, header + Environment.NewLine);
                 }
 
@@ -274,7 +286,13 @@ namespace GeminiV26.Core.Analytics
                     snapshot.ExitPrice.ToString(CultureInfo.InvariantCulture),
                     snapshot.Profit.ToString(CultureInfo.InvariantCulture),
                     snapshot.Score?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
-                    snapshot.Confidence?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+                    snapshot.Confidence?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+                    snapshot.SetupType ?? string.Empty,
+                    snapshot.MarketRegime ?? string.Empty,
+                    snapshot.MfeR.ToString("0.####", CultureInfo.InvariantCulture),
+                    snapshot.MaeR.ToString("0.####", CultureInfo.InvariantCulture),
+                    snapshot.RMultiple.ToString("0.####", CultureInfo.InvariantCulture),
+                    snapshot.TransitionQuality.ToString("0.####", CultureInfo.InvariantCulture));
 
                 File.AppendAllText(filePath, row + Environment.NewLine);
                 _log($"[TRADESTATS] trade logged {safeSymbol}");

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1898,7 +1898,15 @@ namespace GeminiV26.Core
                     ExitPrice = pos.EntryPrice + pos.Pips * sym.PipSize * (pos.TradeType == TradeType.Buy ? 1 : -1),
                     Profit = pos.NetProfit,
                     Score = null,
-                    Confidence = meta?.Confidence
+                    Confidence = meta?.Confidence,
+                    SetupType = ResolveSetupType(meta?.EntryType),
+                    MarketRegime = ResolveMarketRegime(entryCtx),
+                    MfeR = ctx?.MfeR ?? 0.0,
+                    MaeR = ctx != null ? -Math.Abs(ctx.MaeR) : 0.0,
+                    RMultiple = ComputeRMultiple(pos, ctx, sym),
+                    TransitionQuality = entryCtx?.TransitionValid == true
+                        ? entryCtx.Transition?.QualityScore ?? 0.0
+                        : 0.0
                 });
 
             _positionContexts.Remove(pos.Id);
@@ -1971,6 +1979,63 @@ namespace GeminiV26.Core
             return IsNasSymbol(symbol)
                 || IsUs30(symbol)
                 || IsGer40(symbol);
+        }
+
+        private static string ResolveSetupType(string entryType)
+        {
+            if (string.IsNullOrWhiteSpace(entryType))
+                return string.Empty;
+
+            var setup = entryType.Trim();
+
+            if (setup.IndexOf("MicroContinuation", StringComparison.OrdinalIgnoreCase) >= 0)
+                return "MicroContinuation";
+            if (setup.IndexOf("Flag", StringComparison.OrdinalIgnoreCase) >= 0)
+                return "Flag";
+            if (setup.IndexOf("Pullback", StringComparison.OrdinalIgnoreCase) >= 0)
+                return "Pullback";
+            if (setup.IndexOf("Breakout", StringComparison.OrdinalIgnoreCase) >= 0)
+                return "Breakout";
+            if (setup.IndexOf("Transition", StringComparison.OrdinalIgnoreCase) >= 0)
+                return "Transition";
+
+            return setup;
+        }
+
+        private static string ResolveMarketRegime(EntryContext entryCtx)
+        {
+            if (entryCtx == null)
+                return string.Empty;
+
+            if (entryCtx.TransitionValid)
+                return "Transition";
+
+            var marketState = entryCtx.MarketState;
+            if (marketState != null)
+            {
+                if (marketState.IsTrend)
+                    return "Trend";
+                if (marketState.IsRange)
+                    return "Range";
+                if (marketState.IsLowVol)
+                    return "LowVol";
+            }
+
+            if (entryCtx.IsRange_M5)
+                return "Range";
+
+            if (entryCtx.TrendDirection != TradeDirection.None)
+                return "Trend";
+
+            return entryCtx.IsAtrExpanding_M5 ? "HighVol" : "LowVol";
+        }
+
+        private static double ComputeRMultiple(Position pos, PositionContext ctx, Symbol sym)
+        {
+            if (pos == null || ctx == null || sym == null || ctx.RiskPriceDistance <= 0)
+                return 0.0;
+
+            return (pos.Pips * sym.PipSize) / ctx.RiskPriceDistance;
         }
 
         // =========================================================


### PR DESCRIPTION
### Motivation
- Add lightweight per-trade analytics to the existing CSV export so offline AI/strategy-evolution workflows can analyse trade performance by setup and regime.
- Provide MFE/MAE (preferably in R units), RMultiple, setup classification, transition quality and market regime for each closed trade without changing trade logic, file/directory creation, or CSV mechanism.
- Keep runtime overhead minimal by sourcing values already present in runtime contexts and exporting them at close time.

### Description
- Extended `TradeStatsTracker.TradeCloseSnapshot` with new fields: `SetupType`, `MarketRegime`, `MfeR`, `MaeR`, `RMultiple`, and `TransitionQuality`.
- Updated CSV header and row serialization in `Core/Analytics/TradeStatsTracker.cs` to append `SetupType,MarketRegime,MFE_R,MAE_R,RMultiple,TransitionQuality` while preserving existing file and directory behavior.
- Populated the new snapshot fields at close time in `Core/TradeCore.cs` by mapping existing sources: `EntryType` → `SetupType` (via `ResolveSetupType`), `EntryContext`/`MarketState` → `MarketRegime` (via `ResolveMarketRegime`), `PositionContext.MfeR`/`MaeR` → `MfeR`/`MaeR` (with `MAE_R` exported negative for adverse semantics), and a computed `RMultiple` via `ComputeRMultiple`, plus `TransitionQuality` from `EntryContext.Transition.QualityScore` when applicable.
- Added small helper methods `ResolveSetupType`, `ResolveMarketRegime`, and `ComputeRMultiple` in `Core/TradeCore.cs` to produce consistent, human-readable values for CSV export.

### Testing
- Ran `git diff --check` to ensure no whitespace/style errors and the patch applied cleanly, which succeeded.
- Verified the changed files via `git show --stat` and committed the changes successfully, confirming the modifications to `Core/Analytics/TradeStatsTracker.cs` and `Core/TradeCore.cs`.
- No unit tests were added or modified since this change only extends export fields and uses existing runtime data; manual runtime verification is expected during normal trading runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b077f761b48328a80e3b86b88b0f85)