### PR TITLE
Fix nullable args in ComputeRMultiple (Core/TradeCore.cs)

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2030,7 +2030,7 @@ namespace GeminiV26.Core
             return entryCtx.IsAtrExpanding_M5 ? "HighVol" : "LowVol";
         }
 
-        private static double ComputeRMultiple(Position pos, PositionContext ctx, Symbol sym)
+        private static double ComputeRMultiple(Position pos, PositionContext? ctx, Symbol? sym)
         {
             if (pos == null || ctx == null || sym == null || ctx.RiskPriceDistance <= 0)
                 return 0.0;


### PR DESCRIPTION
### Motivation
- Align `ComputeRMultiple` signature with callsites that may pass a missing `PositionContext` or `Symbol` (issue observed around lines ~1906/2033) so the helper matches its internal null-safe logic.

### Description
- Update `Core/TradeCore.cs` to change the method signature from `ComputeRMultiple(Position pos, PositionContext ctx, Symbol sym)` to `ComputeRMultiple(Position pos, PositionContext? ctx, Symbol? sym)`, retaining the existing null checks and behavior.

### Testing
- Verified the source change with `git diff` and committed the update; attempted `dotnet build` but the environment does not have `dotnet` installed so a full build could not be executed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b079a9503483289acb0511dffc62ac)