### PR TITLE
Fix ComputeRMultiple nullable signature in TradeCore

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2030,7 +2030,7 @@ namespace GeminiV26.Core
             return entryCtx.IsAtrExpanding_M5 ? "HighVol" : "LowVol";
         }
 
-        private static double ComputeRMultiple(Position pos, PositionContext? ctx, Symbol? sym)
+        private static double ComputeRMultiple(Position pos, PositionContext ctx, Symbol sym)
         {
             if (pos == null || ctx == null || sym == null || ctx.RiskPriceDistance <= 0)
                 return 0.0;


### PR DESCRIPTION
### Motivation
- The repository reported compile-time issues around `TradeCore` (lines near 1906, 2033, 2035, 2038) caused by nullable-reference syntax in the `ComputeRMultiple` signature that is incompatible with the current compile settings.
- The change's intent is to restore a compilable, consistent method signature while keeping existing runtime null-guards and behavior intact.

### Description
- Updated `Core/TradeCore.cs` by changing the `ComputeRMultiple` signature from `ComputeRMultiple(Position pos, PositionContext? ctx, Symbol? sym)` to `ComputeRMultiple(Position pos, PositionContext ctx, Symbol sym)` to avoid nullable-reference syntax errors.
- Preserved the original runtime null checks inside the method so behavior is unchanged when callers pass nulls.
- Verified the callsite at the `RMultiple = ComputeRMultiple(pos, ctx, sym)` usage remains consistent with the new signature.
- Committed the change to the repository (`Core/TradeCore.cs`).

### Testing
- Attempted to run `dotnet build -nologo` but the environment lacks the .NET SDK, so a full build could not be executed (`bash: command not found: dotnet`).
- Performed static verification by inspecting the modified file and surrounding lines using `nl -ba Core/TradeCore.cs | sed -n '1898,2042p'` and reviewed the `git diff` for the change; these inspections succeeded.
- Committed the fix successfully; no automated unit/integration builds ran due to the missing `dotnet` toolchain in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07add089c83289943d7dd8ef7fd2c)