### PR TITLE
BTC: Add pullback quality filters (min confidence, impulse reclaim, timeout)

### DIFF
--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -605,6 +605,38 @@ namespace GeminiV26.EntryTypes.Crypto
 
             int dynamicMinScore = MIN_SCORE;
 
+            // ======================================
+            // BTC PULLBACK QUALITY FILTER
+            // ======================================
+
+            // 1) Minimum confidence (BTC pullback hard gate)
+            if (score < 45)
+            {
+                Console.WriteLine($"[BTC FILTER] rejected: low confidence {score}");
+                ctx.Log?.Invoke($"[BTC FILTER] rejected: low confidence {score}");
+                return Block(ctx, "BTC_FILTER_LOW_CONFIDENCE", score, dir);
+            }
+
+            // 2) Pullback requires impulse reclaim
+            bool impulseReclaimConfirmed =
+                ctx.HasImpulse_M5 &&
+                ctx.LastClosedBarInTrendDirection;
+
+            if (!impulseReclaimConfirmed)
+            {
+                Console.WriteLine("[BTC FILTER] rejected: no impulse reclaim");
+                ctx.Log?.Invoke("[BTC FILTER] rejected: no impulse reclaim");
+                return Block(ctx, "BTC_FILTER_NO_IMPULSE_RECLAIM", score, dir);
+            }
+
+            // 3) Pullback timeout (dead pullback filter)
+            if (ctx.PullbackBars_M5 > 4)
+            {
+                Console.WriteLine("[BTC FILTER] rejected: pullback timeout");
+                ctx.Log?.Invoke("[BTC FILTER] rejected: pullback timeout");
+                return Block(ctx, "BTC_FILTER_PULLBACK_TIMEOUT", score, dir);
+            }
+
             // =========================
             // FINAL CHECK
             // =========================


### PR DESCRIPTION
### Motivation
- Recent BTC pullback trades exhibit “dead pullbacks” where momentum never resumes, producing low MFE and repeated losses. 
- The change targets only BTC crypto pullback entries to reduce fake continuation trades without touching FX, Index, Metal, or transition logic.

### Description
- Added a BTC-only quality filter block in `EntryTypes/CRYPTO/BTC_PullbackEntry.cs` placed before the final validity check to reject weak setups early. 
- Implemented a hard minimum confidence gate by rejecting when `score < 45` and logging via `Console.WriteLine` and `ctx.Log?.Invoke`. 
- Implemented a momentum reclaim requirement that requires an impulse reclaim (`ctx.HasImpulse_M5 && ctx.LastClosedBarInTrendDirection`) and logs rejections. 
- Implemented a pullback timeout (dead pullback) filter rejecting when `ctx.PullbackBars_M5 > 4` and added explicit debug logs for this reason.

### Testing
- Attempted a build with `dotnet build` but it could not run in this environment due to `dotnet` not being installed (`bash: command not found: dotnet`).
- Verified the change by inspecting the repository diff and confirming the new filter block is present in `EntryTypes/CRYPTO/BTC_PullbackEntry.cs` and that no other instrument files were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b131719cd48328a30930a2b59ff70f)