### PR TITLE
Refine BTC pullback-only quality filters and logging

### DIFF
--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -608,13 +608,14 @@ namespace GeminiV26.EntryTypes.Crypto
             // ======================================
             // BTC PULLBACK QUALITY FILTER
             // ======================================
+            bool isPullbackSetup = Type == EntryType.Crypto_Pullback;
 
-            // 1) Minimum confidence (BTC pullback hard gate)
-            if (score < 45)
+            // 1) Minimum confidence (only for pullback)
+            if (isPullbackSetup && score < 45)
             {
-                Console.WriteLine($"[BTC FILTER] rejected: low confidence {score}");
-                ctx.Log?.Invoke($"[BTC FILTER] rejected: low confidence {score}");
-                return Block(ctx, "BTC_FILTER_LOW_CONFIDENCE", score, dir);
+                Console.WriteLine($"[BTC FILTER] rejected: pullback low confidence {score}");
+                ctx.Log?.Invoke($"[BTC FILTER] rejected: pullback low confidence {score}");
+                return Block(ctx, "BTC_FILTER_PULLBACK_LOW_CONFIDENCE", score, dir);
             }
 
             // 2) Pullback requires impulse reclaim
@@ -622,7 +623,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 ctx.HasImpulse_M5 &&
                 ctx.LastClosedBarInTrendDirection;
 
-            if (!impulseReclaimConfirmed)
+            if (isPullbackSetup && !impulseReclaimConfirmed)
             {
                 Console.WriteLine("[BTC FILTER] rejected: no impulse reclaim");
                 ctx.Log?.Invoke("[BTC FILTER] rejected: no impulse reclaim");
@@ -630,11 +631,24 @@ namespace GeminiV26.EntryTypes.Crypto
             }
 
             // 3) Pullback timeout (dead pullback filter)
-            if (ctx.PullbackBars_M5 > 4)
+            if (isPullbackSetup && ctx.PullbackBars_M5 > 4)
             {
-                Console.WriteLine("[BTC FILTER] rejected: pullback timeout");
-                ctx.Log?.Invoke("[BTC FILTER] rejected: pullback timeout");
-                return Block(ctx, "BTC_FILTER_PULLBACK_TIMEOUT", score, dir);
+                Console.WriteLine($"[BTC FILTER] rejected: pullback timeout bars={ctx.PullbackBars_M5}");
+                ctx.Log?.Invoke($"[BTC FILTER] rejected: pullback timeout bars={ctx.PullbackBars_M5}");
+                return Block(ctx, $"BTC_FILTER_PULLBACK_TIMEOUT_BARS_{ctx.PullbackBars_M5}", score, dir);
+            }
+
+            // 4) ATR depth filter (reject overly deep pullbacks)
+            if (isPullbackSetup)
+            {
+                double pullbackDepth = Math.Abs(ctx.PullbackDepthAtr_M5);
+
+                if (pullbackDepth > 0.5)
+                {
+                    Console.WriteLine($"[BTC FILTER] rejected: pullback too deep depth={pullbackDepth:F2}");
+                    ctx.Log?.Invoke($"[BTC FILTER] rejected: pullback too deep depth={pullbackDepth:F2}");
+                    return Block(ctx, "BTC_FILTER_PULLBACK_TOO_DEEP", score, dir);
+                }
             }
 
             // =========================


### PR DESCRIPTION
### Motivation

- Isolate the new pullback-quality gating so it only affects BTC pullback setups and not Flag/Transition or other instrument logic. 
- Improve diagnostic messages to make it easier to analyze why BTC pullback entries are rejected. 
- Reject overly deep pullbacks using an ATR-based depth measure to avoid low-quality continuation trades in crypto markets.

### Description

- Add a pullback-only guard `isPullbackSetup = Type == EntryType.Crypto_Pullback` and scope all new filters to this guard. 
- Tighten the confidence gate to run only for pullbacks and return a pullback-specific reason code `BTC_FILTER_PULLBACK_LOW_CONFIDENCE` with clearer logging via `Console.WriteLine` and `ctx.Log?.Invoke`. 
- Improve timeout diagnostics to include the bar count in the message and block reason (`BTC_FILTER_PULLBACK_TIMEOUT_BARS_{n}`). 
- Add an ATR depth filter that uses `ctx.PullbackDepthAtr_M5` and rejects pullbacks deeper than `0.5` ATR with reason `BTC_FILTER_PULLBACK_TOO_DEEP` and enhanced logging. 

### Testing

- Attempted to run `dotnet build -nologo` in this environment but the command failed because `dotnet` is not installed here (build not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b132ebd47883289387118efe9f17c9)