### PR TITLE
Make `logs_root` positional argument optional in analyzer CLI

### DIFF
--- a/gemini_log_analyzer.py
+++ b/gemini_log_analyzer.py
@@ -326,7 +326,13 @@ def plot_equity_drawdown(df: pd.DataFrame, output_dir: Path) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Analyze Gemini V26 trade CSV logs.")
-    parser.add_argument("logs_root", type=Path, help="Root Logs directory to scan.")
+    parser.add_argument(
+        "logs_root",
+        nargs="?",
+        type=Path,
+        default=Path("."),
+        help="Root Logs directory to scan (default: current dir).",
+    )
     parser.add_argument(
         "--output-dir",
         type=Path,


### PR DESCRIPTION
### Motivation
- Prevent the script from failing when users don't provide a `logs_root` argument and allow running the analyzer from the current directory by default.

### Description
- Changed the `logs_root` positional argument in `gemini_log_analyzer.py` to be optional by adding `nargs='?'` and `default=Path('.')`.
- Updated the CLI help text for `logs_root` to mention the default of the current directory.
- The only modified file is `gemini_log_analyzer.py` and the change only affects argument parsing behavior.

### Testing
- Applied the change and inspected the updated parser to verify `logs_root` is optional and defaults to `Path('.')`.
- Attempted to run `python gemini_log_analyzer.py --help`, but the run failed with `ModuleNotFoundError: No module named 'matplotlib'` because the environment lacks that dependency, so runtime help/usage validation could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b149235d1c8328baa24860a87e99ac)