### PR TITLE
Refactor TradeCore to use async modular CSV loggers

### DIFF
--- a/Core/Logging/CsvAnalyticsLogger.cs
+++ b/Core/Logging/CsvAnalyticsLogger.cs
@@ -1,0 +1,128 @@
+using cAlgo.API;
+using GeminiV26.Core.Entry;
+using System;
+using System.Globalization;
+using System.IO;
+
+namespace GeminiV26.Core.Logging
+{
+    public sealed class CsvAnalyticsLogger : ITradeLogger
+    {
+        private static readonly string[] Header =
+        {
+            "Timestamp","Symbol","Direction",
+            "SetupType","SetupQuality","TransitionQuality","StructureQuality",
+            "ImpulseStrength","ImpulseBars","PullbackDepth","PullbackBars",
+            "BreakDistanceATR",
+            "MarketRegime","Session","ATR_percentile","TrendStrength","ADX",
+            "EntryScore","LogicConfidence","FinalConfidence",
+            "Outcome","MFE_R","MAE_R"
+        };
+
+        private readonly LogWriter _writer;
+        private readonly string _rootPath;
+
+        public CsvAnalyticsLogger(LogWriter writer, string rootPath = null)
+        {
+            _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+            _rootPath = string.IsNullOrWhiteSpace(rootPath)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "GeminiV26")
+                : rootPath;
+        }
+
+        public void OnTradeOpened(TradeLogContext context) { }
+
+        public void OnTradeUpdated(TradeLogContext context) { }
+
+        public void OnTradeClosed(TradeLogContext context, Position position, TradeLogResult result)
+        {
+            if (context == null)
+                return;
+
+            _writer.Enqueue(() => WriteRecord(context, result));
+        }
+
+        private void WriteRecord(TradeLogContext context, TradeLogResult result)
+        {
+            var timestamp = result?.ExitTimeUtc ?? context.TimestampUtc;
+            if (timestamp == default)
+                timestamp = DateTime.UtcNow;
+
+            string path = BuildPath(context.Symbol, timestamp, "Analytics", "analytics");
+            EnsureHeader(path, Header);
+
+            var pctx = context.PositionContext;
+            var ectx = context.EntryContext;
+            var transition = ectx?.Transition;
+
+            string outcome = "FLAT";
+            if (result?.NetProfit.HasValue == true)
+            {
+                if (result.NetProfit.Value > 0) outcome = "WIN";
+                else if (result.NetProfit.Value < 0) outcome = "LOSS";
+            }
+
+            var values = new[]
+            {
+                Csv(timestamp.ToString("O", CultureInfo.InvariantCulture)),
+                Csv(context.Symbol),
+                Csv(context.Direction),
+
+                Csv(context.PendingMeta?.EntryType ?? pctx?.EntryType),
+                CsvNum(pctx?.EntryScore),
+                CsvNum(transition?.QualityScore),
+                CsvNum(ectx?.TransitionScoreBonus),
+
+                CsvNum(ectx?.AdxSlope_M5),
+                CsvNum(ectx?.BarsSinceImpulse_M5),
+                CsvNum(ectx?.PullbackDepthAtr_M5),
+                CsvNum(ectx?.PullbackBars_M5),
+
+                CsvNum(ectx?.RangeBreakAtrSize_M5),
+
+                Csv(ectx?.MarketState?.ToString()),
+                Csv(ectx?.Session.ToString()),
+                Csv(null),
+                CsvNum(ectx?.Ema21Slope_M5),
+                CsvNum(ectx?.Adx_M5),
+
+                CsvNum(pctx?.EntryScore),
+                CsvNum(pctx?.LogicConfidence),
+                CsvNum(pctx?.FinalConfidence),
+
+                Csv(outcome),
+                CsvNum(pctx?.MfeR),
+                CsvNum(pctx?.MaeR)
+            };
+
+            File.AppendAllText(path, string.Join(",", values) + Environment.NewLine);
+        }
+
+        private string BuildPath(string symbol, DateTime utc, string category, string suffix)
+        {
+            string fileDir = Path.Combine(_rootPath, "Logs", category, utc.ToString("yyyy", CultureInfo.InvariantCulture), utc.ToString("MM", CultureInfo.InvariantCulture));
+            Directory.CreateDirectory(fileDir);
+            string safeSymbol = string.IsNullOrWhiteSpace(symbol) ? "UNKNOWN" : symbol.ToUpperInvariant();
+            return Path.Combine(fileDir, safeSymbol + "_" + suffix + ".csv");
+        }
+
+        private static void EnsureHeader(string path, string[] header)
+        {
+            if (!File.Exists(path))
+                File.WriteAllText(path, string.Join(",", header) + Environment.NewLine);
+        }
+
+        private static string Csv(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return "";
+            if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+                return "\"" + value.Replace("\"", "\"\"") + "\"";
+            return value;
+        }
+
+        private static string CsvNum(double? value)
+        {
+            return value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : "";
+        }
+    }
+}

--- a/Core/Logging/CsvTradeLogger.cs
+++ b/Core/Logging/CsvTradeLogger.cs
@@ -1,0 +1,145 @@
+using cAlgo.API;
+using GeminiV26.Core.Entry;
+using System;
+using System.Globalization;
+using System.IO;
+
+namespace GeminiV26.Core.Logging
+{
+    public sealed class CsvTradeLogger : ITradeLogger
+    {
+        private static readonly string[] Header =
+        {
+            "TradeId","Symbol","PositionId","Direction","StrategyVersion",
+            "EntryType","EntryReason","EntryTime","EntryPrice","VolumeInUnits",
+            "EntryScore","LogicConfidence","FinalConfidence",
+            "MarketRegime","Session","ATR_M5","ATR_percentile","ADX","TrendStrength","Spread",
+            "InitialRiskR","RiskPercent","StopDistanceATR","SlAtrMult","LotCapHit",
+            "MFE_R","MAE_R","BarsInTrade","MinutesInTrade",
+            "Tp1Hit","Tp2Hit","BeActivated","TrailingActivated",
+            "ExitMode","ExitReason","ExitTime","ExitPrice",
+            "NetProfit","GrossProfit","Commissions","Swap","Pips"
+        };
+
+        private readonly LogWriter _writer;
+        private readonly string _rootPath;
+
+        public CsvTradeLogger(LogWriter writer, string rootPath = null)
+        {
+            _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+            _rootPath = string.IsNullOrWhiteSpace(rootPath)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "GeminiV26")
+                : rootPath;
+        }
+
+        public void OnTradeOpened(TradeLogContext context) { }
+
+        public void OnTradeUpdated(TradeLogContext context) { }
+
+        public void OnTradeClosed(TradeLogContext context, Position position, TradeLogResult result)
+        {
+            if (context == null)
+                return;
+
+            _writer.Enqueue(() => WriteRecord(context, position, result));
+        }
+
+        private void WriteRecord(TradeLogContext context, Position position, TradeLogResult result)
+        {
+            var now = context.TimestampUtc == default ? DateTime.UtcNow : context.TimestampUtc;
+            string path = BuildPath(context.Symbol, now, "Trades", "trades");
+            EnsureHeader(path, Header);
+
+            var pctx = context.PositionContext;
+            var ectx = context.EntryContext;
+
+            var values = new[]
+            {
+                Csv(context.TradeId ?? position?.Id.ToString(CultureInfo.InvariantCulture)),
+                Csv(context.Symbol),
+                Csv(context.PositionId?.ToString(CultureInfo.InvariantCulture)),
+                Csv(context.Direction),
+                Csv(context.StrategyVersion),
+
+                Csv(context.PendingMeta?.EntryType ?? pctx?.EntryType),
+                Csv(context.PendingMeta?.EntryReason ?? pctx?.EntryReason),
+                Csv(pctx?.EntryTime.ToString("O", CultureInfo.InvariantCulture)),
+                CsvNum(pctx?.EntryPrice),
+                CsvNum(position?.VolumeInUnits ?? pctx?.EntryVolumeInUnits),
+
+                CsvNum(pctx?.EntryScore),
+                CsvNum(pctx?.LogicConfidence),
+                CsvNum(pctx?.FinalConfidence),
+
+                Csv(ectx?.MarketState?.ToString()),
+                Csv(ectx?.Session.ToString()),
+                CsvNum(ectx?.AtrM5),
+                Csv(null),
+                CsvNum(ectx?.Adx_M5),
+                CsvNum(ectx?.Ema21Slope_M5),
+                Csv(null),
+
+                CsvNum(pctx?.InitialStopLossR),
+                Csv(null),
+                CsvNum((pctx != null && ectx != null && ectx.AtrM5 > 0) ? pctx.RiskPriceDistance / ectx.AtrM5 : (double?)null),
+                CsvNum(pctx?.StopLossAtrMultiplier),
+                Csv(null),
+
+                CsvNum(pctx?.MfeR),
+                CsvNum(pctx?.MaeR),
+                CsvNum(pctx?.BarsSinceEntryM5),
+                CsvNum((result?.ExitTimeUtc.HasValue == true && pctx != null) ? (result.ExitTimeUtc.Value - pctx.EntryTime).TotalMinutes : (double?)null),
+
+                CsvBool(pctx?.Tp1Hit),
+                CsvBool((pctx != null) ? (bool?)(pctx.Tp2Hit > 0) : null),
+                CsvBool(pctx?.BeActivated),
+                CsvBool(pctx?.TrailingActivated),
+
+                Csv(result?.ExitMode),
+                Csv(result?.ExitReason),
+                Csv(result?.ExitTimeUtc?.ToString("O", CultureInfo.InvariantCulture)),
+                CsvNum(result?.ExitPrice),
+
+                CsvNum(result?.NetProfit),
+                CsvNum(result?.GrossProfit),
+                CsvNum(result?.Commissions),
+                CsvNum(result?.Swap),
+                CsvNum(result?.Pips)
+            };
+
+            File.AppendAllText(path, string.Join(",", values) + Environment.NewLine);
+        }
+
+        private string BuildPath(string symbol, DateTime utc, string category, string suffix)
+        {
+            string fileDir = Path.Combine(_rootPath, "Logs", category, utc.ToString("yyyy", CultureInfo.InvariantCulture), utc.ToString("MM", CultureInfo.InvariantCulture));
+            Directory.CreateDirectory(fileDir);
+            string safeSymbol = string.IsNullOrWhiteSpace(symbol) ? "UNKNOWN" : symbol.ToUpperInvariant();
+            return Path.Combine(fileDir, safeSymbol + "_" + suffix + ".csv");
+        }
+
+        private static void EnsureHeader(string path, string[] header)
+        {
+            if (!File.Exists(path))
+                File.WriteAllText(path, string.Join(",", header) + Environment.NewLine);
+        }
+
+        private static string Csv(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return "";
+            if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+                return "\"" + value.Replace("\"", "\"\"") + "\"";
+            return value;
+        }
+
+        private static string CsvNum(double? value)
+        {
+            return value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : "";
+        }
+
+        private static string CsvBool(bool? value)
+        {
+            return value.HasValue ? value.Value.ToString() : "";
+        }
+    }
+}

--- a/Core/Logging/ITradeLogger.cs
+++ b/Core/Logging/ITradeLogger.cs
@@ -1,0 +1,69 @@
+using cAlgo.API;
+using GeminiV26.Core.Entry;
+using System;
+using System.Collections.Generic;
+
+namespace GeminiV26.Core.Logging
+{
+    public interface ITradeLogger
+    {
+        void OnTradeOpened(TradeLogContext context);
+        void OnTradeUpdated(TradeLogContext context);
+        void OnTradeClosed(TradeLogContext context, Position position, TradeLogResult result);
+    }
+
+    public sealed class TradeLogContext
+    {
+        public DateTime TimestampUtc { get; set; }
+        public string Symbol { get; set; }
+        public string Direction { get; set; }
+        public string StrategyVersion { get; set; }
+        public long? PositionId { get; set; }
+        public string TradeId { get; set; }
+
+        public PositionContext PositionContext { get; set; }
+        public EntryContext EntryContext { get; set; }
+        public PendingEntryMeta PendingMeta { get; set; }
+    }
+
+    public sealed class TradeLogResult
+    {
+        public string ExitMode { get; set; }
+        public string ExitReason { get; set; }
+        public DateTime? ExitTimeUtc { get; set; }
+        public double? ExitPrice { get; set; }
+        public double? NetProfit { get; set; }
+        public double? GrossProfit { get; set; }
+        public double? Commissions { get; set; }
+        public double? Swap { get; set; }
+        public double? Pips { get; set; }
+    }
+
+    public sealed class CompositeTradeLogger : ITradeLogger
+    {
+        private readonly IReadOnlyList<ITradeLogger> _loggers;
+
+        public CompositeTradeLogger(params ITradeLogger[] loggers)
+        {
+            _loggers = loggers ?? Array.Empty<ITradeLogger>();
+        }
+
+        public void OnTradeOpened(TradeLogContext context)
+        {
+            foreach (var logger in _loggers)
+                logger?.OnTradeOpened(context);
+        }
+
+        public void OnTradeUpdated(TradeLogContext context)
+        {
+            foreach (var logger in _loggers)
+                logger?.OnTradeUpdated(context);
+        }
+
+        public void OnTradeClosed(TradeLogContext context, Position position, TradeLogResult result)
+        {
+            foreach (var logger in _loggers)
+                logger?.OnTradeClosed(context, position, result);
+        }
+    }
+}

--- a/Core/Logging/LogWriter.cs
+++ b/Core/Logging/LogWriter.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace GeminiV26.Core.Logging
+{
+    public sealed class LogWriter : IDisposable
+    {
+        private readonly BlockingCollection<Action> _queue = new BlockingCollection<Action>(new ConcurrentQueue<Action>());
+        private readonly Thread _worker;
+        private volatile bool _disposed;
+
+        public LogWriter()
+        {
+            _worker = new Thread(WorkLoop)
+            {
+                IsBackground = true,
+                Name = "GeminiV26.LogWriter"
+            };
+            _worker.Start();
+        }
+
+        public void Enqueue(Action writeAction)
+        {
+            if (_disposed || writeAction == null)
+                return;
+
+            try
+            {
+                _queue.Add(writeAction);
+            }
+            catch (InvalidOperationException)
+            {
+                // queue completed
+            }
+        }
+
+        private void WorkLoop()
+        {
+            foreach (var action in _queue.GetConsumingEnumerable())
+            {
+                try
+                {
+                    action();
+                }
+                catch
+                {
+                    // swallow to keep background writer alive
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _queue.CompleteAdding();
+
+            try
+            {
+                _worker.Join(TimeSpan.FromSeconds(2));
+            }
+            catch
+            {
+            }
+
+            _queue.Dispose();
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -35,8 +35,7 @@ using GeminiV26.EntryTypes.INDEX;
 using GeminiV26.EntryTypes.METAL;
 using GeminiV26.EntryTypes.Crypto;
 using GeminiV26.Interfaces;
-using GeminiV26.Data;
-using GeminiV26.Data.Models;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.XAUUSD;
 using GeminiV26.Instruments.NAS100;
 using GeminiV26.Instruments.US30;
@@ -79,7 +78,8 @@ namespace GeminiV26.Core
         private readonly FlagBreakoutDetector _flagBreakoutDetector;
         private readonly List<IEntryType> _entryTypes;
 
-        private readonly TradeLogger _tradeLogger;
+        private readonly LogWriter _logWriter;
+        private readonly ITradeLogger _logger;
         private readonly Dictionary<long, PositionContext> _positionContexts = new();
         private readonly TradeMetaStore _tradeMetaStore = new();
         private readonly TradeStatsTracker _statsTracker;
@@ -399,7 +399,10 @@ namespace GeminiV26.Core
             _contextBuilder = new EntryContextBuilder(bot);
             _transitionDetector = new TransitionDetector();
             _flagBreakoutDetector = new FlagBreakoutDetector(_bot.Print);
-            _tradeLogger = new TradeLogger(_bot.SymbolName);
+            _logWriter = new LogWriter();
+            _logger = new CompositeTradeLogger(
+                new CsvTradeLogger(_logWriter),
+                new CsvAnalyticsLogger(_logWriter));
             _statsTracker = new TradeStatsTracker(_bot.Print);
             _globalSessionGate = new GlobalSessionGate(_bot);
             _sessionMatrix = new SessionMatrix(new SessionMatrixProvider());
@@ -677,6 +680,9 @@ namespace GeminiV26.Core
 
                 if (_positionContexts.TryGetValue(pos.Id, out var pctx))
                     _contextRegistry.RegisterPosition(pctx);
+
+                _tradeMetaStore.TryGet(pos.Id, out var pendingMeta);
+                _logger.OnTradeOpened(BuildLogContext(pos, pendingMeta, pctx: _positionContexts.TryGetValue(pos.Id, out var ctxValue) ? ctxValue : null));
             };
 
             _bot.Positions.Closed += OnPositionClosed;
@@ -785,6 +791,8 @@ namespace GeminiV26.Core
 
                 ctx.LastUpdateUtc = DateTime.UtcNow;
                 _contextRegistry.RegisterPosition(ctx);
+                _tradeMetaStore.TryGet(pos.Id, out var openMeta);
+                _logger.OnTradeUpdated(BuildLogContext(pos, openMeta, ctx));
 
                 if (_bot.SymbolName.Contains("XAU"))
                     _xauExitManager?.OnBar(pos);
@@ -1841,49 +1849,21 @@ namespace GeminiV26.Core
 
             var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
 
-            _tradeLogger.Log(new TradeRecord
-            {
-                CloseTimestamp = _bot.Server.Time,
-
-                Symbol = pos.SymbolName,
-                PositionId = pos.Id,
-                Direction = pos.TradeType.ToString(),
-
-                EntryType = meta?.EntryType,
-                EntryReason = meta?.EntryReason,
-                Confidence = meta?.Confidence,
-
-                // --- Exit diagnostics ---
-                Tp1Hit = ctx != null ? (bool?)ctx.Tp1Hit : null,
-                Tp2Hit = ctx != null ? (bool?)(ctx.Tp2Hit > 0.0) : null,
-
-                EntryPrice = pos.EntryPrice,
-                ExitPrice = pos.EntryPrice
-                    + pos.Pips * sym.PipSize * (pos.TradeType == TradeType.Buy ? 1 : -1),
-
-                VolumeInUnits = ctx?.InitialVolumeInUnits > 0
-                    ? ctx.InitialVolumeInUnits
-                    : pos.VolumeInUnits,
-
-                NetProfit = pos.NetProfit,
-                GrossProfit = pos.GrossProfit,
-                Commissions = pos.Commissions,
-                Swap = pos.Swap,
-
-                ExitReason = args.Reason.ToString(),
-                ExitMode = exitMode,
-
-                EntryTime = pos.EntryTime,
-                ExitTime = _bot.Server.Time,
-                Pips = pos.Pips,
-
-                EntryVolumeInUnits = ctx?.InitialVolumeInUnits,
-                Tp1ClosedVolumeInUnits = ctx?.Tp1ClosedVolumeInUnits,
-                RemainingVolumeInUnits = ctx?.RemainingVolumeInUnits,
-
-                BeActivated = ctx?.BeActivated,
-                TrailingActivated = ctx?.TrailingActivated,
-            });
+            _logger.OnTradeClosed(
+                BuildLogContext(pos, meta, ctx, entryCtx),
+                pos,
+                new TradeLogResult
+                {
+                    ExitMode = exitMode,
+                    ExitReason = args.Reason.ToString(),
+                    ExitTimeUtc = _bot.Server.Time,
+                    ExitPrice = pos.EntryPrice + pos.Pips * sym.PipSize * (pos.TradeType == TradeType.Buy ? 1 : -1),
+                    NetProfit = pos.NetProfit,
+                    GrossProfit = pos.GrossProfit,
+                    Commissions = pos.Commissions,
+                    Swap = pos.Swap,
+                    Pips = pos.Pips
+                });
 
             _statsTracker.RegisterTradeClose(
                 pos.Id,
@@ -1915,9 +1895,26 @@ namespace GeminiV26.Core
             _tradeMetaStore.Remove(pos.Id);
         }
 
+        private TradeLogContext BuildLogContext(Position pos, PendingEntryMeta meta, PositionContext pctx = null, EntryContext ectx = null)
+        {
+            return new TradeLogContext
+            {
+                TimestampUtc = _bot.Server.Time.ToUniversalTime(),
+                Symbol = pos?.SymbolName ?? _bot.SymbolName,
+                Direction = pos?.TradeType.ToString(),
+                StrategyVersion = "GeminiV26",
+                PositionId = pos?.Id,
+                TradeId = pos?.Id.ToString(),
+                PositionContext = pctx,
+                EntryContext = ectx ?? (pos != null ? _contextRegistry.GetEntry(pos.Id) : null),
+                PendingMeta = meta
+            };
+        }
+
         public void OnStop()
         {
             _bot.Positions.Closed -= OnPositionClosed;
+            _logWriter?.Dispose();
         }
 
         // =================================================


### PR DESCRIPTION
### Motivation
- Remove direct CSV IO from `TradeCore` to reduce coupling and keep IO out of core orchestration logic.
- Provide asynchronous, non-blocking logging so trading flow never blocks on filesystem operations.
- Produce both execution and analytics datasets in stable CSV formats with automatic headers and permissive missing values.

### Description
- Added a logging module under `Core/Logging` with `ITradeLogger` and DTOs (`TradeLogContext`, `TradeLogResult`) and a `CompositeTradeLogger` to fan out events. (`Core/Logging/ITradeLogger.cs`).
- Implemented `LogWriter`, a background queue + worker thread for non-blocking writes, and disposed it in `TradeCore.OnStop()`. (`Core/Logging/LogWriter.cs`).
- Implemented `CsvTradeLogger` for execution logs writing to `Logs/Trades/YYYY/MM/<symbol>_trades.csv` and `CsvAnalyticsLogger` for research dataset writing to `Logs/Analytics/YYYY/MM/<symbol>_analytics.csv`, both auto-create headers and allow empty cells for missing values. (`Core/Logging/CsvTradeLogger.cs`, `Core/Logging/CsvAnalyticsLogger.cs`).
- Refactored `TradeCore` to remove direct `TradeLogger`/`TradeRecord` usage and to call logging interfaces only (`OnTradeOpened`, `OnTradeUpdated`, `OnTradeClosed`), added `BuildLogContext(...)` helper and wired log calls on position open/update/close. (`Core/TradeCore.cs`).

### Testing
- Ran repository inspections and grep checks to confirm `TradeCore` no longer writes CSV directly and new logging files are present; those checks succeeded.
- Verified logger wiring by inspecting `TradeCore` event handlers to ensure calls to `OnTradeOpened`, `OnTradeUpdated`, and `OnTradeClosed` are present; inspection succeeded.
- Confirmed headers are auto-written by `Csv*Logger` implementations via code review; manual invocation not performed here.
- Attempted to run a full project compile but no .NET/C# SDK was available in the environment (`dotnet`, `csc`, `mcs` not present), so a full build/test run could not be executed in this container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b15168b11083289b89efae09410fd4)