### PR TITLE
Tune FX pullback filters and matrix thresholds for higher trade throughput

### DIFF
--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -24,6 +24,7 @@ namespace GeminiV26.EntryTypes.FX
         {
             int score = 60;   // baseline
             int penalty = 0;  // accumulated penalty (budgeted)
+            int penaltyBudget = 10;   // FlagEntry-style penalty budget
 
             if (ctx == null || !ctx.IsReady)
                 return Block(ctx, "CTX_NOT_READY", score);
@@ -31,6 +32,12 @@ namespace GeminiV26.EntryTypes.FX
             var fx = FxInstrumentMatrix.Get(ctx.Symbol);
             if (fx == null)
                 return Block(ctx, "NO_FX_PROFILE", score);
+
+            if (!fx.FlagTuning[FxSession.Asia].AtrExpansionHardBlock)
+                ctx?.Log?.Invoke("[MATRIX POLICY] ATR expansion hard block disabled");
+
+            if (!fx.FlagTuning[FxSession.Asia].RequireStrongEntryCandle)
+                ctx?.Log?.Invoke("[MATRIX POLICY] strong entry candle requirement disabled");
 
             var matrix = ctx.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowPullback)
@@ -46,15 +53,13 @@ namespace GeminiV26.EntryTypes.FX
 
             if (!atrRelativePass)
             {
-                ctx?.Log?.Invoke($"[FX_PullbackEntry] BLOCK ATR_RELATIVE_TOO_LOW atr={ctx.AtrM5:F2} avg20={atrAvg20:F2} threshold={atrRelativeThreshold:F2}");
-                return Block(ctx, "[ROUTER] SESSION_MATRIX_ATR_TOO_LOW_RELATIVE", score);
+                ApplyPenalty(ref score, ref penalty, 6, penaltyBudget, ctx, "ATR_CONTRACTION");
+                ctx?.Log?.Invoke($"[PB FILTER] ATR contraction penalty | ATR={ctx.AtrM5:F2} threshold={atrRelativeThreshold:F2}");
             }
 
             if (matrix.MinEmaDistance > 0 && System.Math.Abs(ctx.Ema8_M5 - ctx.Ema21_M5) < matrix.MinEmaDistance)
                 return Block(ctx, "SESSION_MATRIX_EMA_DISTANCE_TOO_LOW", score);
 
-            // FlagEntry-style penalty budget (prevents "death by a thousand cuts")
-            int penaltyBudget = 10;   // vagy 8–12, amit a FlagEntry-ben használsz
 
             // =========================
             // TREND RESOLUTION (HARD)
@@ -96,9 +101,11 @@ namespace GeminiV26.EntryTypes.FX
             // No impulse -> most pullbacks are just chop. FlagEntry is strict; we mimic that.
             if (!ctx.HasImpulse_M5)
             {
-                // Asia: hard block without impulse (your old logic already penalized heavily)
                 if (ctx.Session == FxSession.Asia)
-                    return Block(ctx, "ASIA_NO_IMPULSE", score);
+                {
+                    ApplyPenalty(ref score, ref penalty, 5, penaltyBudget, ctx, "ASIA_NO_IMPULSE");
+                    ctx?.Log?.Invoke("[PB FILTER] Asia impulse missing → penalty applied");
+                }
 
                 ApplyPenalty(ref score, ref penalty, 8, penaltyBudget, ctx, "NO_IMPULSE");
             }
@@ -120,8 +127,12 @@ namespace GeminiV26.EntryTypes.FX
             if (!ctx.HasReactionCandle_M5) weakCount++;
             if (!ctx.LastClosedBarInTrendDirection) weakCount++;
 
-            if (weakCount >= 2)
+            if (weakCount >= 3)
+            {
+                ctx?.Log?.Invoke($"[PB FILTER] weak structure blocked | weakCount={weakCount}");
                 return Block(ctx, "PB_WEAK_STRUCTURE", score);
+            }
+
                 
             // =========================
             // PULLBACK QUALITY (mostly HARD)

--- a/EntryTypes/FX/FxInstrumentMatrix.cs
+++ b/EntryTypes/FX/FxInstrumentMatrix.cs
@@ -28,8 +28,8 @@ namespace GeminiV26.Instruments.FX
                     new()
                     {
                         { FxSession.Asia,    -10 },
-                        { FxSession.London,  +2 },
-                        { FxSession.NewYork, +2 }
+                        { FxSession.London,  2 },
+                        { FxSession.NewYork, 2 }
                     },
                     new()
                     {
@@ -40,7 +40,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 66,               // SZIGORÍTÁS: 55-ről 62-re, kiöljük a bizonytalan trade-eket
+                        MinScore = 60,               // SZIGORÍTÁS: 55-ről 62-re, kiöljük a bizonytalan trade-eket
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.2,        // SZIGORÍTÁS: 1.6-ról 1.2-re, ne engedjük a túlnyúlt zászlókat
                         MaxPullbackAtr = 0.80,       // SZIGORÍTÁS: 0.95-ről 0.80-ra, csak szoros visszateszt
@@ -49,7 +49,7 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 4,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,     // ÚJ: Ázsiában kötelező az M1 trigger!
-                        AtrExpansionHardBlock = true // ÚJ: Blokkoljuk a hirtelen kiugrást
+                        AtrExpansionHardBlock = false // ÚJ: Blokkoljuk a hirtelen kiugrást
                     },
                     london: new FxFlagSessionTuning
                     {
@@ -104,8 +104,8 @@ namespace GeminiV26.Instruments.FX
                     new()
                     {
                         { FxSession.Asia,    -10 },
-                        { FxSession.London,  +6 },
-                        { FxSession.NewYork, +3 }
+                        { FxSession.London,  6 },
+                        { FxSession.NewYork, 3 }
                     },
                     new()
                     {
@@ -116,7 +116,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 66,
+                        MinScore = 60,
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.5,
                         MaxPullbackAtr = 0.08,
@@ -125,7 +125,7 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 4,
                         FlagQualityBonus = 0,
                         RequireM1Trigger = false,
-                        AtrExpansionHardBlock = true
+                        AtrExpansionHardBlock = false
                     },
                     london: new FxFlagSessionTuning
                     {
@@ -139,7 +139,7 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 5,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = false,
-                        AtrExpansionHardBlock = true
+                        AtrExpansionHardBlock = false
                     },
                     ny: new FxFlagSessionTuning
                     {
@@ -153,7 +153,7 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 0,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = false,
-                        AtrExpansionHardBlock = true
+                        AtrExpansionHardBlock = false
                     },
                     // ===== CONTINUATION CHARACTER =====
                         maxContinuationRatr: 1.45,
@@ -201,7 +201,7 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 4,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = false,     // KRITIKUS: Itt is kötelező az M1 trigger!
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = false,
                         RequireStrongEntryCandle = false
                     },
@@ -217,7 +217,7 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 4,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = false,     // KRITIKUS: Londonban is kötelező az M1 trigger!
-                        AtrExpansionHardBlock = true
+                        AtrExpansionHardBlock = false
                     },
                     ny: new FxFlagSessionTuning
                     {
@@ -231,9 +231,9 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 0,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = false,
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true
+                        RequireStrongEntryCandle = false
                     },
                     // ===== CONTINUATION CHARACTER =====
                         maxContinuationRatr: 1.6,
@@ -260,7 +260,7 @@ namespace GeminiV26.Instruments.FX
                     new()
                     {
                         { FxSession.Asia,    +5 },
-                        { FxSession.London,  +5 },
+                        { FxSession.London,  5 },
                         { FxSession.NewYork, -5 }
                     },
                     new()
@@ -272,7 +272,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 66,               // SZIGORÍTÁS: 55 helyett 60, csak a legjobb setupok menjenek át
+                        MinScore = 60,               // SZIGORÍTÁS: 55 helyett 60, csak a legjobb setupok menjenek át
                         FlagBars = 3,                // STABILITÁS: 2 helyett 3 bár, hogy a zajt jobban szűrjük
                         MaxFlagAtrMult = 1.2,        // SZIGORÍTÁS: Kisebb zászló kiterjedés
                         MaxPullbackAtr = 1.20,       // LAZÍTÁS: 1.00-ról 1.20-ra - kell a tér a GBPJPY zajának
@@ -281,9 +281,9 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 2,
                         FlagQualityBonus = 3,        // ÚJ: Bónusz a minőségi alakzatnak
                         RequireM1Trigger = true,     // BIZTONSÁG: Ázsiában kötelező az M1 visszaigazolás
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true
+                        RequireStrongEntryCandle = false
                     },
                     london: new FxFlagSessionTuning
                     {
@@ -297,12 +297,12 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 5,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = false,
-                        AtrExpansionHardBlock = true
+                        AtrExpansionHardBlock = false
                     },
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 62,
+                        MinScore = 60,
                         FlagBars = 2,
                         MaxFlagAtrMult = 1.2,
                         MaxPullbackAtr = 0.95,
@@ -311,7 +311,7 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 0,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
-                        AtrExpansionHardBlock = true
+                        AtrExpansionHardBlock = false
                     },
                     // ===== CONTINUATION CHARACTER =====
                         maxContinuationRatr: 1.8,
@@ -339,7 +339,7 @@ namespace GeminiV26.Instruments.FX
                 {
                     { FxSession.Asia,    -5 }, // ÚJ: Minimális büntetés Ázsiára is a JPY kockázat miatt
                     { FxSession.London,  -5 },
-                    { FxSession.NewYork, -20 }
+                    { FxSession.NewYork, -10 }
                 },
                 new()
                 {
@@ -350,7 +350,7 @@ namespace GeminiV26.Instruments.FX
                 asia: new FxFlagSessionTuning
                 {
                     BaseScore = 52,
-                    MinScore = 68,               // SZIGORÍTÁS: 55-ről 60-ra (csak a legtisztább EMA21 bounce mehet)
+                    MinScore = 60,               // SZIGORÍTÁS: 55-ről 60-ra (csak a legtisztább EMA21 bounce mehet)
                     FlagBars = 3,                // STABILITÁS: Több megerősítő gyertya kell
                     MaxFlagAtrMult = 1.2,        // SZIGORÍTÁS: 1.3-ról 1.2-re (kisebb zászló = kisebb kockázat)
                     MaxPullbackAtr = 0.80,       // SZIGORÍTÁS: 0.85-ről 0.80-ra
@@ -359,14 +359,14 @@ namespace GeminiV26.Instruments.FX
                     M1TriggerBonus = 4,
                     FlagQualityBonus = 3,
                     RequireM1Trigger = true,
-                    AtrExpansionHardBlock = true,
+                    AtrExpansionHardBlock = false,
                     RequireAtrSlopePositive = true,
-                    RequireStrongEntryCandle = true
+                    RequireStrongEntryCandle = false
                 },
                 london: new FxFlagSessionTuning
                 {
                     BaseScore = 54,
-                    MinScore = 62,               // SZIGORÍTÁS: Londonban is magasabb küszöb
+                    MinScore = 60,               // SZIGORÍTÁS: Londonban is magasabb küszöb
                     FlagBars = 3,
                     MaxFlagAtrMult = 1.8,        // SZIGORÍTÁS: 2.0-ról 1.8-ra (kevesebb zajt engedünk)
                     MaxPullbackAtr = 1.10,       // SZIGORÍTÁS: 1.30-ról 1.10-re (ne engedjünk túl mély korrekciót)
@@ -375,13 +375,13 @@ namespace GeminiV26.Instruments.FX
                     M1TriggerBonus = 5,
                     FlagQualityBonus = 3,
                     RequireM1Trigger = true,     // KRITIKUS: Londonban is kötelezővé tesszük az M1 triggert!
-                    AtrExpansionHardBlock = true // ÚJ: Itt is bekapcsoljuk a blokkolást hirtelen tágulásnál
+                    AtrExpansionHardBlock = false // ÚJ: Itt is bekapcsoljuk a blokkolást hirtelen tágulásnál
                 },
                 ny: new FxFlagSessionTuning
                 {
                     // New York marad a -20-as bias miatt eleve tiltáshoz közeli állapotban
                     BaseScore = 54,
-                    MinScore = 70,
+                    MinScore = 60,
                     FlagBars = 2,
                     MaxFlagAtrMult = 1.1,
                     MaxPullbackAtr = 0.75,
@@ -390,9 +390,9 @@ namespace GeminiV26.Instruments.FX
                     M1TriggerBonus = 0,
                     FlagQualityBonus = 3,
                     RequireM1Trigger = true,
-                    AtrExpansionHardBlock = true,
+                    AtrExpansionHardBlock = false,
                     RequireAtrSlopePositive = true,
-                    RequireStrongEntryCandle = true
+                    RequireStrongEntryCandle = false
                 },
                 // ===== CONTINUATION CHARACTER =====
                         maxContinuationRatr: 1.6,
@@ -418,8 +418,8 @@ namespace GeminiV26.Instruments.FX
                     new()
                     {
                         { FxSession.Asia,    -5 }, // ÚJ: Itt is bevezetünk egy kis szigort
-                        { FxSession.London, -15 }, // SZIGORÍTÁS: -10 helyett -15
-                        { FxSession.NewYork,-25 }  // SZIGORÍTÁS: -20 helyett -25
+                        { FxSession.London, -5 }, // SZIGORÍTÁS: -10 helyett -15
+                        { FxSession.NewYork,-10 }  // SZIGORÍTÁS: -20 helyett -25
                     },
                     new()
                     {
@@ -430,7 +430,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 68,               // SZIGORÍTÁS: 55-ről 60-ra
+                        MinScore = 60,               // SZIGORÍTÁS: 55-ről 60-ra
                         FlagBars = 3,                // STABILITÁS: 2 helyett 3 bár
                         MaxFlagAtrMult = 1.1,        // SZIGORÍTÁS: 1.4-ről 1.1-re (ne vegyünk túlnyúlt mozgást)
                         MaxPullbackAtr = 0.65,       // SZIGORÍTÁS: 0.75-ről 0.65-re
@@ -439,15 +439,15 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 4,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true // KRITIKUS: Mostantól kötelező az erős belépő gyertya!
+                        RequireStrongEntryCandle = false // KRITIKUS: Mostantól kötelező az erős belépő gyertya!
                     },
                     london: new FxFlagSessionTuning
                     {
                         // London marad szigorú, de itt is bekapcsoljuk a biztonsági fékeket
                         BaseScore = 54,
-                        MinScore = 64,
+                        MinScore = 60,
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.2,
                         MaxPullbackAtr = 0.70,
@@ -456,14 +456,14 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 5,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true
+                        RequireStrongEntryCandle = false
                     },
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 72,               // NY-ban szinte elérhetetlen szigor
+                        MinScore = 60,               // NY-ban szinte elérhetetlen szigor
                         FlagBars = 1,
                         MaxFlagAtrMult = 0.9,
                         MaxPullbackAtr = 0.60,
@@ -472,7 +472,7 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 0,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
                         RequireStrongEntryCandle = false
                     },
@@ -501,8 +501,8 @@ namespace GeminiV26.Instruments.FX
                     new()
                     {
                         { FxSession.Asia,    -5 }, // ÚJ: Minimális szigorítás
-                        { FxSession.London, -15 }, // SZIGORÍTÁS: -10 -> -15
-                        { FxSession.NewYork,-35 }  // SZIGORÍTÁS: -30 -> -35
+                        { FxSession.London, -5 }, // SZIGORÍTÁS: -10 -> -15
+                        { FxSession.NewYork,-10 }  // SZIGORÍTÁS: -30 -> -35
                     },
                     new()
                     {
@@ -513,7 +513,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 68,               // SZIGORÍTÁS: 55 -> 60
+                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 60
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.1,        // SZIGORÍTÁS: 1.7 -> 1.1 (csak kompakt alakzatok)
                         MaxPullbackAtr = 0.70,       // SZIGORÍTÁS: 1.05 -> 0.70
@@ -522,14 +522,14 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 4,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,     // ÚJ: Kötelező M1 visszaigazolás
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true // ÚJ: Ne vegyen "gyenge" gyertyával
+                        RequireStrongEntryCandle = false // ÚJ: Ne vegyen "gyenge" gyertyával
                     },
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 64,
+                        MinScore = 60,
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.3,        // SZIGORÍTÁS: 1.8 -> 1.3
                         MaxPullbackAtr = 0.85,       // SZIGORÍTÁS: 1.35 -> 0.85
@@ -538,12 +538,12 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 5,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,     // ÚJ: Itt is kell az M1 kontroll
-                        AtrExpansionHardBlock = true
+                        AtrExpansionHardBlock = false
                     },
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 74,
+                        MinScore = 60,
                         FlagBars = 2,
                         MaxFlagAtrMult = 0.9,
                         MaxPullbackAtr = 0.85,
@@ -552,7 +552,7 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 0,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
-                        AtrExpansionHardBlock = true
+                        AtrExpansionHardBlock = false
                     },
                     // ===== CONTINUATION CHARACTER =====
                         maxContinuationRatr: 1.3,
@@ -579,8 +579,8 @@ namespace GeminiV26.Instruments.FX
                     new()
                     {
                         { FxSession.Asia,    -5 },  // SZIGORÍTÁS: Ne legyen ingyen a belépés Ázsiában sem
-                        { FxSession.London,  -20 }, // SZIGORÍTÁS: Londonban ez a pár csak zaj
-                        { FxSession.NewYork, -40 }  // TILTÁS KÖZELI: New Yorkban értelmezhetetlen
+                        { FxSession.London,  -5 }, // SZIGORÍTÁS: Londonban ez a pár csak zaj
+                        { FxSession.NewYork, -10 }  // TILTÁS KÖZELI: New Yorkban értelmezhetetlen
                     },
                     new()
                     {
@@ -591,7 +591,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 66,               // SZIGORÍTÁS: 55 -> 62 (legyen nagyon válogatós)
+                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 62 (legyen nagyon válogatós)
                         FlagBars = 3,                // STABILITÁS: 2 -> 4 bár (építsen komoly bázist)
                         MaxFlagAtrMult = 1.2,        // SZIGORÍTÁS: 1.8 -> 1.0 (csak kompakt, sűrű bázis)
                         MaxPullbackAtr = 0.75,       // SZIGORÍTÁS: 1.10 -> 0.60 (ne engedjünk mély visszatesztet)
@@ -600,14 +600,14 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 4,
                         FlagQualityBonus = 5,        // ÚJ: Extra bónusz, ha vizuálisan tiszta a setup
                         RequireM1Trigger = true,     // KRITIKUS: Itt kötelező az M1
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true
+                        RequireStrongEntryCandle = false
                     },
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 68,               // Londonban szinte csak "véletlenül" lépjen be
+                        MinScore = 60,               // Londonban szinte csak "véletlenül" lépjen be
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.3,
                         MaxPullbackAtr = 0.85,
@@ -616,12 +616,12 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 5,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
-                        AtrExpansionHardBlock = true
+                        AtrExpansionHardBlock = false
                     },
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 80,               // Gyakorlatilag kikapcsolva
+                        MinScore = 60,               // Gyakorlatilag kikapcsolva
                         FlagBars = 2,
                         MaxFlagAtrMult = 0.7,
                         MaxPullbackAtr = 0.50,
@@ -630,7 +630,7 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 0,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
-                        AtrExpansionHardBlock = true
+                        AtrExpansionHardBlock = false
                     },
                     // ===== CONTINUATION CHARACTER =====
                         maxContinuationRatr: 1.4,
@@ -658,7 +658,7 @@ namespace GeminiV26.Instruments.FX
                     {
                         { FxSession.Asia,    -10 }, // SZIGORÍTÁS: -5 -> -10 (Ázsiában csak a CAD "véletlen" mozgásai vannak)
                         { FxSession.London,   0 },
-                        { FxSession.NewYork, +5 }   // JUTALMAZÁS: +2 -> +5 (Ez a pár itt él igazán)
+                        { FxSession.NewYork, 5 }   // JUTALMAZÁS: +2 -> +5 (Ez a pár itt él igazán)
                     },
                     new()
                     {
@@ -669,7 +669,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 68,               // SZIGORÍTÁS: 55 -> 60
+                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 60
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.2,        // SZIGORÍTÁS: 1.4 -> 1.2
                         MaxPullbackAtr = 0.75,       // SZIGORÍTÁS: 0.85 -> 0.75
@@ -678,14 +678,14 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 4,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true // ÚJ: Kell a lendület!
+                        RequireStrongEntryCandle = false // ÚJ: Kell a lendület!
                     },
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 62,               // SZIGORÍTÁS: 55 -> 58
+                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 58
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.6,        // SZIGORÍTÁS: 2.0 -> 1.6 (megfogja a csúcson vételt)
                         MaxPullbackAtr = 1.00,       // SZIGORÍTÁS: 1.30 -> 1.00
@@ -694,9 +694,9 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 5,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,     // ÚJ: Itt is kötelező az M1 trigger
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true // ÚJ: Kell a lendület!
+                        RequireStrongEntryCandle = false // ÚJ: Kell a lendület!
                     },
                     ny: new FxFlagSessionTuning
                     {
@@ -710,9 +710,9 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 2,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true // ÚJ: Itt is kötelező
+                        RequireStrongEntryCandle = false // ÚJ: Itt is kötelező
                     },
                     // ===== CONTINUATION CHARACTER =====
                         maxContinuationRatr: 1.6,
@@ -739,8 +739,8 @@ namespace GeminiV26.Instruments.FX
                     new()
                     {
                         { FxSession.Asia,    -15 }, // SZIGORÍTÁS: -5 -> -15 (Ázsiában tiltsuk le szinte teljesen)
-                        { FxSession.London,  +4 },
-                        { FxSession.NewYork, +2 }   // JUTALMAZÁS: 0 -> +2 (NY-ban is tud szépen mozogni)
+                        { FxSession.London,  4 },
+                        { FxSession.NewYork, 2 }   // JUTALMAZÁS: 0 -> +2 (NY-ban is tud szépen mozogni)
                     },
                     new()
                     {
@@ -751,7 +751,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 75,               // SZIGORÍTÁS: 55 -> 65 (Csak extrém jó jel mehet át)
+                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 65 (Csak extrém jó jel mehet át)
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.0,        // SZIGORÍTÁS: 1.4 -> 1.0 (Csak nagyon szűk bázis)
                         MaxPullbackAtr = 0.60,       // SZIGORÍTÁS: 0.95 -> 0.60
@@ -760,14 +760,14 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 4,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,     // ÚJ: Kötelező M1
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true
+                        RequireStrongEntryCandle = false
                     },
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 62,               // SZIGORÍTÁS: 55 -> 58
+                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 58
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.4,        // SZIGORÍTÁS: 2.0 -> 1.4 (Kompaktabb setupok)
                         MaxPullbackAtr = 0.85,       // SZIGORÍTÁS: 1.30 -> 0.85
@@ -776,14 +776,14 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 5,
                         FlagQualityBonus = 5,        // JUTALMAZÁS: Ha tiszta a kép, kapjon nagy bónuszt
                         RequireM1Trigger = true,     // ÚJ: Londonban is kötelező az M1 trigger
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true
+                        RequireStrongEntryCandle = false
                     },
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 64,
+                        MinScore = 60,
                         FlagBars = 2,
                         MaxFlagAtrMult = 1.1,
                         MaxPullbackAtr = 0.75,       // SZIGORÍTÁS: 0.90 -> 0.75
@@ -792,9 +792,9 @@ namespace GeminiV26.Instruments.FX
                         M1TriggerBonus = 2,
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
-                        AtrExpansionHardBlock = true,
+                        AtrExpansionHardBlock = false,
                         RequireAtrSlopePositive = true,
-                        RequireStrongEntryCandle = true
+                        RequireStrongEntryCandle = false
                     },
                     // ===== CONTINUATION CHARACTER =====
                         maxContinuationRatr: 1.3,


### PR DESCRIPTION
### Motivation
- Reduce over-filtering that blocks valid FX continuation pullbacks during volatility contraction and quieter sessions while preserving the pipeline and scoring architecture.
- Convert brittle hard-gates into soft penalties where appropriate so the router can still rank candidates instead of outright rejecting them.
- Relax session and structure rules that were too strict and prevented reasonable M15→M5 continuation setups.

### Description
- In `FX_PullbackEntry` converted the ATR-relative contraction hard block into a soft penalty (`ApplyPenalty(..., 6, ...)`) and added `[PB FILTER] ATR contraction penalty | ...` logging instead of blocking the trade.
- In `FX_PullbackEntry` changed Asia missing-impulse from a hard block to a soft penalty (`ApplyPenalty(..., 5, ...)`) and added `"[PB FILTER] Asia impulse missing → penalty applied"` logging; preserved existing stronger penalties for no impulse generally.
- In `FX_PullbackEntry` relaxed the weak-structure gate from `weakCount >= 2` to `weakCount >= 3` and added `"[PB FILTER] weak structure blocked | weakCount=X"` logging to surface blocked cases.
- Added `[MATRIX POLICY]` debug logs in `FX_PullbackEntry` when matrix tunings (ATR expansion hard block or strong entry candle requirement) are disabled, for monitoring of matrix-driven policy changes.
- In `FxInstrumentMatrix` updated default FX tuning values to reduce over-filtering: set `AtrExpansionHardBlock = false` and `RequireStrongEntryCandle = false` where present, capped all `MinScore` values to `60`, and reduced aggressive session penalties so London does not go below `-5` and New York does not go below `-10` (many session deltas normalized accordingly).
- Preserved core system principles and interfaces; did not change scoring mechanics, pipeline order, TransitionDetector, EntryRouter, RiskSizer, or ExitManager.

### Testing
- Ran targeted code searches to verify inserted logs and removed hard flags: `rg -n "ATR contraction penalty|weak structure blocked|Asia impulse missing|MATRIX POLICY" EntryTypes/FX/FX_PullbackEntry.cs` and the expected log lines were found (success).
- Ran pattern checks to ensure no remaining disallowed hard settings: searches for `AtrExpansionHardBlock = true`, `RequireStrongEntryCandle = true`, `MinScore` above `60`, and overly aggressive session penalties returned no matches (success).
- Performed a commit which recorded the changes (`git commit -m "Tune FX pullback filters to increase trade frequency"`) and confirmed the branch and commit (`work` / `45e8cb1`) (success).
- No unit tests or runtime integration tests were present or executed in this rollout; verification was by code inspection and automated text/pattern checks described above (not applicable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b161bfa2c48328995326cbc19dce72)