### PR TITLE
Fix XAU rehydrate context confidence initialization

### DIFF
--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -420,6 +420,9 @@ namespace GeminiV26.Instruments.XAUUSD
                     IsRehydrated = true
                 };
 
+                // AGENTS rule: PositionContext létrehozás után azonnal számoljuk a FinalConfidence-t.
+                ctx.ComputeFinalConfidence();
+
                 // TP1R becslés rehydrate-nél (nincs FC, ezért normal bucket)
                 ctx.Tp1R = _profile.Tp1R_Normal;
                 ctx.Tp1CloseFraction = 0.40;


### PR DESCRIPTION
### Motivation
- Rehydrated XAU `PositionContext` instances were created without immediately computing `FinalConfidence`, which can leave confidence-dependent risk/management logic in an inconsistent default state after restart.

### Description
- Call `ctx.ComputeFinalConfidence()` immediately after `PositionContext` construction in `XauExitManager.RehydrateFromLivePositions` so rehydrated contexts have the canonical `FinalConfidence` value before registration.

### Testing
- Verified with `rg` and a repository-wide Python check that all `new PositionContext` call sites are followed by `ComputeFinalConfidence()` within the checked window and the check reported OK; no build was run because no `.sln`/`.csproj` files are present in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1727d24c08328b23112e2fa5f0f23)