### PR TITLE
Adjust HardLossGuard limits for increased lot caps

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2071,16 +2071,16 @@ namespace GeminiV26.Core
                 string sym = pos.SymbolName.ToUpper();
 
                 if (sym.Contains("XAU"))
-                    hardLimit = -250.0;
+                    hardLimit = -600.0;
 
                 else if (sym.Contains("BTC") || sym.Contains("ETH"))
-                    hardLimit = -250.0;
+                    hardLimit = -900.0;
 
                 else if (sym.Contains("NAS") || sym.Contains("US30") || sym.Contains("SPX") || sym.Contains("GER"))
-                    hardLimit = -220.0;
+                    hardLimit = -650.0;
 
                 else
-                    hardLimit = -150.0; // default FX
+                    hardLimit = -450.0; // default FX
 
 
                 if (loss > hardLimit)


### PR DESCRIPTION
### Motivation
- Update `TradeCore.CheckHardLoss()` hardLimit thresholds so the emergency HardLossGuard does not trigger before normal `StopLoss` after LotCap increases.

### Description
- Change instrument-specific `hardLimit` constants in `Core/TradeCore.cs` within `private bool CheckHardLoss()` to XAU `-600.0`, BTC/ETH `-900.0`, indices `-650.0`, and default FX `-450.0` while leaving all logic, symbol detection, filtering, iteration, logging, and method structure unchanged.

### Testing
- No automated tests were executed for this change; the update was validated by code inspection and diff verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e4fe37688328bf2aafb51bdbe433)