### PR TITLE
Phase 3.9.1: XAU transition deadlock fix (pullback trend sync + flag fallback)

### DIFF
--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -112,24 +112,41 @@ namespace GeminiV26.Core.Entry
             bool noStructureBreak = false;
             bool hasFlag = false;
             bool flagStructureBroken = false;
+            bool relaxedContinuation = false;
 
-            if (hasImpulse && hasPullback && flagBars > 0)
+            if (hasImpulse && hasPullback)
             {
-                double avgRange = AverageRange(ctx, flagStart, last);
-                compression = impulseRange > 0 ? avgRange / impulseRange : 1.0;
-                compressionScore = Clamp01(1.0 - compression);
+                if (flagBars > 0)
+                {
+                    double avgRange = AverageRange(ctx, flagStart, last);
+                    compression = impulseRange > 0 ? avgRange / impulseRange : 1.0;
+                    compressionScore = Clamp01(1.0 - compression);
 
-                noStructureBreak = ValidateNoStructureBreak(ctx, flagStart, last, impulseDirection, pullbackStart, pullbackEnd);
-                flagStructureBroken = !noStructureBreak;
+                    noStructureBreak = ValidateNoStructureBreak(ctx, flagStart, last, impulseDirection, pullbackStart, pullbackEnd);
+                    flagStructureBroken = !noStructureBreak;
 
-                hasFlag = flagBars <= rules.MaxFlagBars
-                    && compression <= rules.MaxCompressionRatio
-                    && noStructureBreak;
+                    hasFlag = flagBars <= rules.MaxFlagBars
+                        && compression <= rules.MaxCompressionRatio
+                        && noStructureBreak;
+                }
+
+                double strongImpulseThreshold = Math.Max(rules.MinImpulseStrength, 0.60);
+                double maxPullbackDepth = Math.Min(rules.MaxPullbackDepthR, 0.50);
+                const double StrongAdxThreshold = 30.0;
+
+                relaxedContinuation =
+                    impulseStrength > strongImpulseThreshold &&
+                    pullbackDepthR < maxPullbackDepth &&
+                    ctx.MarketState != null &&
+                    ctx.MarketState.Adx > StrongAdxThreshold;
+
+                ctx.Log?.Invoke(
+                    $"[TRANSITION][RELAXED_CHECK] compression={compression:0.00} impulse={impulseStrength:0.00} pullbackDepth={pullbackDepthR:0.00} adx={ctx.MarketState?.Adx:0.00} allowed={relaxedContinuation.ToString().ToLowerInvariant()}");
             }
 
             ctx.Log?.Invoke($"[TRANSITION][FLAG] bars={flagBars} compression={compression:0.00}");
 
-            bool isValid = hasImpulse && hasPullback && hasFlag;
+            bool isValid = hasImpulse && hasPullback && (hasFlag || relaxedContinuation);
 
             double qualityScore = 0.0;
             int bonus = 0;
@@ -144,7 +161,7 @@ namespace GeminiV26.Core.Entry
             }
 
             string reason = isValid
-                ? "OK"
+                ? (hasFlag ? "OK" : "OK_RELAXED_CONTINUATION")
                 : BuildReason(hasImpulse, hasPullback, hasFlag, flagStructureBroken, weakImpulse, pullbackDepthR, rules.MaxPullbackDepthR, compression, rules.MaxCompressionRatio);
 
             ctx.Log?.Invoke($"[TRANSITION][QUALITY] impulse={impulseStrength:0.00} compression={compressionScore:0.00} pullback={pullbackQuality:0.00} score={qualityScore:0.00} bonus={bonus}");

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1157,14 +1157,47 @@ namespace GeminiV26.Core
                     if (bias.State == HtfBiasState.Neutral ||
                         bias.State == HtfBiasState.Transition)
                     {
-                        _bot.Print("[TC] XAU HTF POLICY: Transition/Neutral -> Pullback only");
+                        _bot.Print("[TC] XAU HTF POLICY: Transition/Neutral -> Pullback primary, strong flag fallback");
 
-                        symbolSignals = symbolSignals
-                            .Where(e =>
-                                e == null ||
-                                !e.IsValid ||
-                                e.Type == EntryType.XAU_Pullback)
+                        var pullbackSignals = symbolSignals
+                            .Where(e => e != null && e.Type == EntryType.XAU_Pullback)
                             .ToList();
+
+                        bool pullbackValid = pullbackSignals.Any(e => e.IsValid);
+                        if (pullbackValid)
+                        {
+                            symbolSignals = symbolSignals
+                                .Where(e => e == null || !e.IsValid || e.Type == EntryType.XAU_Pullback)
+                                .ToList();
+                        }
+                        else
+                        {
+                            const int StrongAdxThreshold = 30;
+                            var fallbackFlags = symbolSignals
+                                .Where(e =>
+                                    e != null &&
+                                    e.Type == EntryType.XAU_Flag &&
+                                    e.IsValid &&
+                                    e.Score >= 62 &&
+                                    _ctx.MarketState?.IsTrend == true &&
+                                    _ctx.MarketState.Adx > StrongAdxThreshold)
+                                .ToList();
+
+                            if (fallbackFlags.Count > 0)
+                            {
+                                _bot.Print("[HTF][FALLBACK_FLAG] transition fallback");
+                                symbolSignals = fallbackFlags;
+                            }
+                            else
+                            {
+                                symbolSignals = symbolSignals
+                                    .Where(e =>
+                                        e == null ||
+                                        !e.IsValid ||
+                                        e.Type == EntryType.XAU_Pullback)
+                                    .ToList();
+                            }
+                        }
 
                         if (symbolSignals.All(e => e == null || !e.IsValid))
                         {
@@ -1176,7 +1209,7 @@ namespace GeminiV26.Core
                                     $"score={s?.Score} reason={s?.Reason}");
                             }
 
-                            _bot.Print("[TC] XAU HTF BLOCK: no valid pullback in Transition/Neutral");
+                            _bot.Print("[TC] XAU HTF BLOCK: no valid pullback/flag fallback in Transition/Neutral");
                             return;
                         }
                     }

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -25,6 +25,7 @@ namespace GeminiV26.EntryTypes.METAL
         private const int HtfAgainstPenalty = 6;          // small score penalty only (NO hard block)
         private const double MinBodyRatio = 0.55;         // body dominance floor (body/range)
         private const int BarsNotReadyMin = 20;
+        private const int MaxFlagBarsHardLimit = 50;
 
         // HTF-against quality requirements (NOT huge penalty; stronger definition)
         private const double HtfAgainstMinCloseBreakAtr = 0.08; // close must be this far beyond hi/lo in ATR units
@@ -284,7 +285,17 @@ namespace GeminiV26.EntryTypes.METAL
                 // ignore if field not present
             }
 
-            if (score < minScore)
+            bool nearThreshold = score >= (minScore - 3);
+            bool strongContext =
+                ctx.MarketState?.IsTrend == true &&
+                ctx.MarketState?.Adx > 30.0 &&
+                (ctx.MetalHtfAllowedDirection == TradeDirection.None || ctx.MetalHtfAllowedDirection == dir);
+
+            bool valid = score >= minScore || (nearThreshold && strongContext);
+
+            reasons.Add($"[FLAG][THRESHOLD_CHECK] score={score} threshold={minScore} near={nearThreshold.ToString().ToLowerInvariant()} context={strongContext.ToString().ToLowerInvariant()} valid={valid.ToString().ToLowerInvariant()}");
+
+            if (!valid)
                 return InvalidDecisionDir(ctx, session, tag, score, minScore, dir, "LOW_SCORE", reasons);
 
             reasons.Add("ACCEPT");
@@ -300,6 +311,12 @@ namespace GeminiV26.EntryTypes.METAL
             hi = double.MinValue;
             lo = double.MaxValue;
             rangeAtr = 999;
+
+            if (flagBars > MaxFlagBarsHardLimit)
+            {
+                ctx?.Log?.Invoke("[FLAG][ERROR] invalid bar count");
+                return false;
+            }
 
             var bars = ctx.M5;
 
@@ -323,7 +340,8 @@ namespace GeminiV26.EntryTypes.METAL
             if (range <= 0)
                 return false;
 
-                rangeAtr = range / ctx.AtrM5;
+            rangeAtr = range / ctx.AtrM5;
+            ctx.Log?.Invoke($"[FLAG][BARCOUNT] bars={flagBars} range={range:0.00} compression={rangeAtr:0.00}");
             return true;
         }
 

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -40,8 +40,12 @@ namespace GeminiV26.EntryTypes.METAL
             // =========================
             // HARD MARKET STATE GATES (XAU)
             // =========================
-            if (ctx.MarketState == null || !ctx.MarketState.IsTrend)
-                return Reject(ctx, "XAU_NO_TREND_STATE");
+            bool trend = ctx.MarketState?.IsTrend == true;
+            ctx.Log?.Invoke(
+                $"[PB][TREND_CHECK] trend={trend.ToString().ToLowerInvariant()} adx={ctx.MarketState?.Adx:0.00}");
+
+            if (!trend)
+                return Reject(ctx, "NO_TREND_STATE");
 
             if (ctx.MarketState.Adx < 16.0)
             {


### PR DESCRIPTION
### Motivation
- Remove a deadlock where HTF state `Transition`/`Neutral` forced Pullback-only and left TradeCore without any valid entry in common XAU continuation cases.
- Preserve existing risk/exit/session behavior while allowing institutional continuation setups (strong impulse + shallow pullback + high ADX) to pass.

### Description
- Align XAU pullback trend gate with `ctx.MarketState.IsTrend` and add `[PB][TREND_CHECK]` debug logging so pullback uses the same trend definition as MarketState (`EntryTypes/METAL/XAU_PullbackEntry.cs`).
- Add a relaxed continuation path to the transition detector that permits continuation when impulse strength is strong, pullback is shallow and ADX is high, with `[TRANSITION][RELAXED_CHECK]` diagnostics and `OK_RELAXED_CONTINUATION` reasoning (`Core/Entry/TransitionDetector.cs`).
- Add near-threshold tolerance for XAU flag evaluation (accept `minScore - 3`) when strong context (trend + ADX > 30 + HTF alignment/neutral) is present, with `[FLAG][THRESHOLD_CHECK]` logging (`EntryTypes/METAL/XAU_FlagEntry.cs`).
- Add hard cap on flag bar count (reject if > 50) and related `[FLAG][ERROR]` / `[FLAG][BARCOUNT]` logs to avoid pathological bar counts (`EntryTypes/METAL/XAU_FlagEntry.cs`).
- Update TradeCore HTF routing for XAU to keep Pullback as primary but allow strong Flag fallback when no valid Pullback exists (logs `[HTF][FALLBACK_FLAG]`) (`Core/TradeCore.cs`).

### Testing
- Applied and inspected source changes with repository diffs and file searches using `rg` and `git diff`, and confirmed modified files are staged/updated via `git status`.
- Performed targeted file-level validations (pattern checks and inserted diagnostic logging) and confirmed the new debug lines are present in the modified sources.
- No solution (`.sln`) or project (`.csproj`) files were found in the environment, so a full compile/run of the C# project and automated unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b27835791c8328951cdebbf9cad2d0)