### PR TITLE
Fix crypto entry deadlocks: flag barcount, router dir fallback, crypto HTF policy

### DIFF
--- a/Core/Entry/EntryRouter.cs
+++ b/Core/Entry/EntryRouter.cs
@@ -51,6 +51,18 @@ namespace GeminiV26.Core.Entry
                     if (eval == null)
                         continue;
 
+                    bool isCryptoSymbol = !string.IsNullOrEmpty(ctx.Symbol) &&
+                        (ctx.Symbol.ToUpperInvariant().Contains("BTC") ||
+                         ctx.Symbol.ToUpperInvariant().Contains("ETH") ||
+                         ctx.Symbol.ToUpperInvariant().Contains("CRYPTO"));
+
+                    if (eval.Direction == TradeDirection.None && isCryptoSymbol)
+                    {
+                        eval.Direction = ctx.TrendDirection;
+                        ctx.Log?.Invoke(
+                            $"[ROUTER][DIR] trendDirection={ctx.TrendDirection} dirAssigned={eval.Direction}");
+                    }
+
                     // Instrument-keveredés kizárása
                     if (eval.Symbol != ctx.Symbol)
                         continue;

--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -105,8 +105,8 @@ namespace GeminiV26.Core.Entry
 
             ctx.Log?.Invoke($"[TRANSITION][PULLBACK] bars={pullbackBars} depthR={pullbackDepthR:0.00}");
 
-            int flagStart = pullbackEnd + 1;
-            int flagBars = flagStart <= last ? (last - flagStart + 1) : 0;
+            int flagStart = -1;
+            int flagBars = 0;
             double compression = 1.0;
             double compressionScore = 0.0;
             bool noStructureBreak = false;
@@ -116,6 +116,22 @@ namespace GeminiV26.Core.Entry
 
             if (hasImpulse && hasPullback)
             {
+                flagStart = pullbackEnd + 1;
+                if (flagStart <= pullbackEnd || flagStart > last)
+                {
+                    ctx.Log?.Invoke("[FLAG][BARCOUNT] bars=0");
+                    return Invalid("FLAG_NOT_DETECTED", pullbackBars, 0, pullbackDepthR, 0.0);
+                }
+
+                flagBars = last - flagStart + 1;
+                ctx.Log?.Invoke($"[FLAG][BARCOUNT] bars={flagBars}");
+
+                if (flagBars > 50)
+                {
+                    ctx.Log?.Invoke("[FLAG][ERROR] invalid flag bar count");
+                    return Invalid("FLAG_INVALID_BAR_COUNT", pullbackBars, flagBars, pullbackDepthR, 0.0);
+                }
+
                 if (flagBars > 0)
                 {
                     double avgRange = AverageRange(ctx, flagStart, last);
@@ -235,6 +251,25 @@ namespace GeminiV26.Core.Entry
             }
 
             return true;
+        }
+
+        private static TransitionEvaluation Invalid(string reason, int pullbackBars = 0, int flagBars = 0, double pullbackDepthR = 0.0, double compressionScore = 0.0)
+        {
+            return new TransitionEvaluation
+            {
+                HasImpulse = false,
+                HasPullback = false,
+                HasFlag = false,
+                BarsSinceImpulse = -1,
+                PullbackBars = pullbackBars,
+                FlagBars = flagBars,
+                PullbackDepthR = pullbackDepthR,
+                CompressionScore = compressionScore,
+                QualityScore = 0.0,
+                IsValid = false,
+                BonusScore = 0,
+                Reason = reason
+            };
         }
 
         private static double AverageRange(EntryContext ctx, int start, int end)

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1096,6 +1096,9 @@ namespace GeminiV26.Core
 
             _bot.Print($"[CRYPTO HTF] state={bias.State} allow={bias.AllowedDirection}");
 
+            bool allowPullback = false;
+            bool allowFlag = false;
+
             // =====================================================
             // 1) TRANSITION / NEUTRAL
             //    -> Pullback only
@@ -1104,10 +1107,22 @@ namespace GeminiV26.Core
             if (bias.State == HtfBiasState.Neutral ||
                 bias.State == HtfBiasState.Transition)
             {
-                _bot.Print("[TC] CRYPTO HTF NOTE: Transition/Neutral -> pullback only, no direction filter");
+                allowPullback = true;
+                allowFlag = bias.State == HtfBiasState.Transition;
+
+                if (bias.State == HtfBiasState.Transition)
+                {
+                    _bot.Print($"[CRYPTO HTF POLICY] state=Transition allowPullback={allowPullback} allowFlag={allowFlag}");
+                }
+
+                _bot.Print("[TC] CRYPTO HTF NOTE: Transition/Neutral -> pullback/flag policy, no direction filter");
 
                 symbolSignals = symbolSignals
-                    .Where(e => e == null || !e.IsValid || e.Type == EntryType.Crypto_Pullback)
+                    .Where(e =>
+                        e == null ||
+                        !e.IsValid ||
+                        (allowPullback && e.Type == EntryType.Crypto_Pullback) ||
+                        (allowFlag && e.Type == EntryType.Crypto_Flag))
                     .ToList();
 
                 if (symbolSignals.All(e => e == null || !e.IsValid))
@@ -1120,7 +1135,7 @@ namespace GeminiV26.Core
                             $"score={s?.Score} reason={s?.Reason}");
                     }
 
-                    _bot.Print("[TC] CRYPTO HTF BLOCK: no valid pullback in Transition/Neutral");
+                    _bot.Print("[TC] CRYPTO HTF BLOCK: no valid pullback/flag in Transition/Neutral");
                     return;
                 }
             }


### PR DESCRIPTION
### Motivation
- Resolve three crypto-specific blockers that prevented BTC entries by addressing incorrect flag bar counts, lost direction in the router, and a HTF policy that blocked flag entries during Transition.
- Ensure fixes are surgical and limited to CRYPTO logic without adding MarketState properties or touching INDEX/FX/METAL modules.

### Description
- TransitionDetector: compute `flagBars` strictly from the detected flag segment after the pullback end, return `Invalid()` when no flag structure is detected, add a guard to log and invalidate when `flagBars > 50`, and emit `[FLAG][BARCOUNT]` and `[FLAG][ERROR]` debug logs; added a private `Invalid(...)` helper to produce an invalid `TransitionEvaluation`.
- EntryRouter: apply a local crypto-only fallback so that when `eval.Direction == TradeDirection.None` and the symbol appears to be crypto (`BTC`/`ETH`/`CRYPTO` substrings), assign `eval.Direction = ctx.TrendDirection` and log `[ROUTER][DIR]`.
- TradeCore (CRYPTO HTF gate): for `HtfBiasState.Transition` allow both pullback and flag entries (while keeping breakout disabled), for `Neutral` allow pullbacks only, update the symbol filter accordingly, and emit `[CRYPTO HTF POLICY]` debug log when in Transition.

### Testing
- Ran `git diff --check` to validate whitespace/format issues and it succeeded with no problems.
- Ran `git status --short` to confirm working tree state and it reported no unexpected local changes (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b27c9457a08328882d87075767c8bc)