### PR TITLE
Use EntryContext.InstrumentType for transition rules (replace symbol parsing)

### DIFF
--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -11,7 +11,7 @@ namespace GeminiV26.Core.Entry
                 return new TransitionEvaluation { Reason = "InsufficientData" };
             }
 
-            var rules = TransitionRules.ForSymbol(ctx.Symbol);
+            var rules = TransitionRules.ForInstrument(ctx.InstrumentType);
             int last = ctx.M5.Count - 2;
 
             int impulseIndex = -1;
@@ -148,13 +148,11 @@ namespace GeminiV26.Core.Entry
 
                 double strongImpulseThreshold = Math.Max(rules.MinImpulseStrength, 0.60);
                 double maxPullbackDepth = Math.Min(rules.MaxPullbackDepthR, 0.50);
-                const double StrongAdxThreshold = 30.0;
-
                 relaxedContinuation =
                     impulseStrength > strongImpulseThreshold &&
                     pullbackDepthR < maxPullbackDepth &&
                     ctx.MarketState != null &&
-                    ctx.MarketState.Adx > StrongAdxThreshold;
+                    ctx.MarketState.Adx > rules.StrongAdxThreshold;
 
                 ctx.Log?.Invoke(
                     $"[TRANSITION][RELAXED_CHECK] compression={compression:0.00} impulse={impulseStrength:0.00} pullbackDepth={pullbackDepthR:0.00} adx={ctx.MarketState?.Adx:0.00} allowed={relaxedContinuation.ToString().ToLowerInvariant()}");

--- a/Core/Entry/TransitionRules.cs
+++ b/Core/Entry/TransitionRules.cs
@@ -1,5 +1,13 @@
 namespace GeminiV26.Core.Entry
 {
+    public enum InstrumentType
+    {
+        FX,
+        INDEX,
+        CRYPTO,
+        METAL
+    }
+
     public sealed class TransitionRules
     {
         public int MaxImpulseAge { get; init; } = 8;
@@ -14,42 +22,68 @@ namespace GeminiV26.Core.Entry
 
         public int MaxFlagBars { get; init; } = 5;
         public double MaxCompressionRatio { get; init; } = 0.75;
+        public double StrongAdxThreshold { get; init; } = 30.0;
 
-        public static TransitionRules ForSymbol(string symbol)
+        public static TransitionRules ForInstrument(InstrumentType type)
         {
-            var sym = (symbol ?? string.Empty).ToUpperInvariant();
-
-            if (sym.Contains("BTC") || sym.Contains("ETH") || sym.Contains("CRYPTO"))
+            switch (type)
             {
-                return new TransitionRules
-                {
-                    MaxImpulseAge = 6,
-                    ImpulseMultiplier = 1.4,
-                    MinImpulseStrength = 0.45,
-                    MaxPullbackDepthR = 0.45,
-                    MinPullbackBars = 2,
-                    OptimalPullbackDepthR = 0.40,
-                    MaxFlagBars = 4,
-                    MaxCompressionRatio = 0.70
-                };
-            }
+                case InstrumentType.CRYPTO:
+                    return new TransitionRules
+                    {
+                        MaxImpulseAge = 6,
+                        ImpulseMultiplier = 1.4,
+                        MinImpulseStrength = 0.45,
+                        MaxPullbackDepthR = 0.45,
+                        MinPullbackBars = 2,
+                        OptimalPullbackDepthR = 0.40,
+                        MaxFlagBars = 4,
+                        MaxCompressionRatio = 0.70,
+                        StrongAdxThreshold = 20
+                    };
 
-            if (sym.Contains("NAS") || sym.Contains("US30") || sym.Contains("GER") || sym.Contains("DAX"))
-            {
-                return new TransitionRules
-                {
-                    MaxImpulseAge = 7,
-                    ImpulseMultiplier = 1.3,
-                    MinImpulseStrength = 0.40,
-                    MaxPullbackDepthR = 0.5,
-                    MinPullbackBars = 2,
-                    OptimalPullbackDepthR = 0.42,
-                    MaxFlagBars = 5,
-                    MaxCompressionRatio = 0.80
-                };
-            }
+                case InstrumentType.INDEX:
+                    return new TransitionRules
+                    {
+                        MaxImpulseAge = 7,
+                        ImpulseMultiplier = 1.3,
+                        MinImpulseStrength = 0.40,
+                        MaxPullbackDepthR = 0.50,
+                        MinPullbackBars = 2,
+                        OptimalPullbackDepthR = 0.42,
+                        MaxFlagBars = 5,
+                        MaxCompressionRatio = 0.80,
+                        StrongAdxThreshold = 25
+                    };
 
-            return new TransitionRules();
+                case InstrumentType.METAL:
+                    return new TransitionRules
+                    {
+                        MaxImpulseAge = 6,
+                        ImpulseMultiplier = 1.35,
+                        MinImpulseStrength = 0.45,
+                        MaxPullbackDepthR = 0.55,
+                        MinPullbackBars = 2,
+                        OptimalPullbackDepthR = 0.40,
+                        MaxFlagBars = 5,
+                        MaxCompressionRatio = 0.75,
+                        StrongAdxThreshold = 22
+                    };
+
+                default:
+                    return new TransitionRules
+                    {
+                        MaxImpulseAge = 7,
+                        ImpulseMultiplier = 1.5,
+                        MinImpulseStrength = 0.50,
+                        MaxPullbackDepthR = 0.50,
+                        MinPullbackBars = 2,
+                        OptimalPullbackDepthR = 0.40,
+                        MaxFlagBars = 5,
+                        MaxCompressionRatio = 0.75,
+                        StrongAdxThreshold = 30
+                    };
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Remove fragile symbol substring checks and use the canonical instrument classification already available in `EntryContext` for robust, instrument-specific transition logic.
- Enable per-instrument tuning (CRYPTO, INDEX, METAL, FX) so rules and ADX thresholds can be adjusted cleanly without string parsing.

### Description
- Replaced `TransitionRules.ForSymbol(string)` with `TransitionRules.ForInstrument(InstrumentType)` and added an `InstrumentType` enum (`FX`, `INDEX`, `CRYPTO`, `METAL`).
- Implemented instrument-specific presets for `CRYPTO`, `INDEX`, `METAL`, and a default `FX` set in `TransitionRules.ForInstrument`, including a new `StrongAdxThreshold` rule parameter.
- Updated `TransitionDetector.Evaluate(EntryContext ctx)` to obtain rules via `TransitionRules.ForInstrument(ctx.InstrumentType)` instead of parsing `ctx.Symbol` and to use `rules.StrongAdxThreshold` in the relaxed continuation check.
- Modified files: `Core/Entry/TransitionRules.cs` and `Core/Entry/TransitionDetector.cs` (no other files changed). 

### Testing
- Ran `git diff` and `git status` to verify the two files were updated and committed successfully.
- Used repository searches (`rg`) to confirm the new `ForInstrument` usage and presence of the `InstrumentType` enum.
- Attempted `dotnet build -v minimal` but the environment lacks `dotnet` (`command not found`), so compilation could not be executed here.
- No automated unit tests were run in this environment due to missing SDK; changes are minimal and localized to the two allowed files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2810480cc8328b711572d99fbb293)