### PR TITLE
Derive InstrumentType from EntryContext.Symbol in TransitionDetector

### DIFF
--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -11,7 +11,7 @@ namespace GeminiV26.Core.Entry
                 return new TransitionEvaluation { Reason = "InsufficientData" };
             }
 
-            var rules = TransitionRules.ForInstrument(ctx.InstrumentType);
+            var rules = TransitionRules.ForInstrument(ResolveInstrumentType(ctx));
             int last = ctx.M5.Count - 2;
 
             int impulseIndex = -1;
@@ -328,6 +328,33 @@ namespace GeminiV26.Core.Entry
                 return 1.0;
 
             return value;
+        }
+
+        private static InstrumentType ResolveInstrumentType(EntryContext ctx)
+        {
+            string symbol = ctx?.Symbol;
+            if (string.IsNullOrWhiteSpace(symbol))
+                return InstrumentType.FX;
+
+            string normalized = symbol.ToUpperInvariant();
+
+            if (normalized.Contains("BTC") || normalized.Contains("ETH") || normalized.Contains("CRYPTO"))
+                return InstrumentType.CRYPTO;
+
+            if (normalized.Contains("XAU") || normalized.Contains("XAG") || normalized.Contains("GOLD") || normalized.Contains("SILVER"))
+                return InstrumentType.METAL;
+
+            if (normalized.Contains("US30")
+                || normalized.Contains("NAS")
+                || normalized.Contains("USTEC")
+                || normalized.Contains("GER40")
+                || normalized.Contains("GER")
+                || normalized.Contains("DAX"))
+            {
+                return InstrumentType.INDEX;
+            }
+
+            return InstrumentType.FX;
         }
 
         private static string BuildReason(bool hasImpulse, bool hasPullback, bool hasFlag, bool flagStructureBroken, bool weakImpulse, double pullbackDepthR, double maxPullbackDepthR, double compression, double maxCompression)


### PR DESCRIPTION
### Motivation

- Fix a compile-time error caused by referencing a non-existent `EntryContext.InstrumentType` field while selecting transition rules. 
- Avoid changing the `EntryContext` shape used across the codebase by deriving instrument type locally in the detector. 

### Description

- Replace `TransitionRules.ForInstrument(ctx.InstrumentType)` with `TransitionRules.ForInstrument(ResolveInstrumentType(ctx))` in `TransitionDetector.Evaluate`. 
- Add a private helper `ResolveInstrumentType(EntryContext ctx)` that infers `InstrumentType` from `ctx.Symbol` using symbol naming conventions. 
- The resolver maps `BTC`/`ETH`/`CRYPTO` -> `CRYPTO`, `XAU`/`XAG`/`GOLD`/`SILVER` -> `METAL`, common index tokens (`US30`, `NAS`, `USTEC`, `GER40`, `GER`, `DAX`) -> `INDEX`, and defaults to `FX`. 

### Testing

- Ran a symbol/reference search `rg "ForInstrument\(|ResolveInstrumentType\(" Core/Entry/TransitionDetector.cs -n` to verify the new call site and helper presence, which succeeded. 
- Confirmed the patch application succeeded and inspected the updated file with `nl`/file view to ensure the new helper is appended, which succeeded. 
- No new unit tests were added and no full build was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2839e14988328b473ddb2fec08a3f)