### PR TITLE
Adjust score weight multipliers for crypto and index instruments

### DIFF
--- a/EntryTypes/CRYPTO/CryptoInstrumentMatrix.cs
+++ b/EntryTypes/CRYPTO/CryptoInstrumentMatrix.cs
@@ -49,7 +49,10 @@ namespace GeminiV26.EntryTypes.Crypto
                     AllowMeanReversion = false,
                     AllowRangeBreakout = true,
                     BlockPullbackOnHighVolWithoutImpulse = false,
-                    RequireStrongImpulseForPullback = false
+                    RequireStrongImpulseForPullback = false,
+
+                    // === Score character ===
+                    ScoreWeightMultiplier = 1.10
                 },
 
                 // =========================
@@ -88,7 +91,10 @@ namespace GeminiV26.EntryTypes.Crypto
                     AllowMeanReversion = false,
                     AllowRangeBreakout = true,
                     BlockPullbackOnHighVolWithoutImpulse = false,
-                    RequireStrongImpulseForPullback = false
+                    RequireStrongImpulseForPullback = false,
+
+                    // === Score character ===
+                    ScoreWeightMultiplier = 1.08
                 }
             };
 

--- a/EntryTypes/CRYPTO/CryptoInstrumentProfile.cs
+++ b/EntryTypes/CRYPTO/CryptoInstrumentProfile.cs
@@ -47,6 +47,9 @@
         // === Range ===
         public double RangeMaxWidthAtr { get; init; }
 
+        // === Score character ===
+        public double ScoreWeightMultiplier { get; set; } = 1.0;
+
         // === Viselkedési engedélyek ===
         public bool AllowMeanReversion { get; init; }
         public bool AllowRangeBreakout { get; init; }

--- a/EntryTypes/INDEX/IndexInstrumentMatrix.cs
+++ b/EntryTypes/INDEX/IndexInstrumentMatrix.cs
@@ -58,7 +58,7 @@ namespace GeminiV26.Instruments.INDEX
                     // =========================
                     // SCORE CHARACTER
                     // =========================
-                    ScoreWeightMultiplier = 1.00,
+                    ScoreWeightMultiplier = 1.08,
 
                     // =========================
                     // PROFIT STRUCTURE
@@ -134,7 +134,7 @@ namespace GeminiV26.Instruments.INDEX
                     // =========================
                     // SCORE CHARACTER
                     // =========================
-                    ScoreWeightMultiplier = 1.15,  // agresszívebb karakter
+                    ScoreWeightMultiplier = 1.20,  // agresszívebb karakter
 
                     // =========================
                     // PROFIT STRUCTURE
@@ -210,7 +210,7 @@ namespace GeminiV26.Instruments.INDEX
                     // =========================
                     // SCORE CHARACTER
                     // =========================
-                    ScoreWeightMultiplier = 0.95,
+                    ScoreWeightMultiplier = 1.02,
 
                     // =========================
                     // PROFIT STRUCTURE


### PR DESCRIPTION
### Motivation
- Increase entry probability slightly by amplifying score weighting at the instrument level while keeping structural filtering and gating logic unchanged.
- Apply modest, instrument-specific score boosts for heavily filtered crypto setups and underweighted index instruments so strong setups cross thresholds more often.

### Description
- Added `ScoreWeightMultiplier` to `CryptoInstrumentProfile` with a default of `1.0` to allow per-crypto score amplification (`EntryTypes/CRYPTO/CryptoInstrumentProfile.cs`).
- Set `BTCUSD` to `ScoreWeightMultiplier = 1.10` and `ETHUSD` to `ScoreWeightMultiplier = 1.08` in `EntryTypes/CRYPTO/CryptoInstrumentMatrix.cs`.
- Updated index multipliers in `EntryTypes/INDEX/IndexInstrumentMatrix.cs`: `NAS100` `1.00 -> 1.08`, `US30` `1.15 -> 1.20`, and `GER40` `0.95 -> 1.02`.
- No other parameters, gating logic, ATR/ADX thresholds, impulse/flag/pullback/breakout logic, method signatures, or external dependencies were changed.

### Testing
- Ran repository inspections to validate changes with `rg`/`sed` and file prints to confirm the new property and updated values, and these checks succeeded.
- Verified diffs with `git diff -- EntryTypes/CRYPTO/CryptoInstrumentProfile.cs EntryTypes/CRYPTO/CryptoInstrumentMatrix.cs EntryTypes/INDEX/IndexInstrumentMatrix.cs` which showed only the intended changes.
- Confirmed commit recorded with `git show --stat --oneline HEAD` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2946bd3c08328b3281cc6ecbf211e)