### PR TITLE
Post-TP1 trend management and adaptive trailing engines (global)

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -341,6 +341,22 @@ namespace GeminiV26.Core
         /// </summary>
         public double? LastStopLossPrice { get; set; }
 
+
+        // =========================
+        // Post-TP1 management state
+        // =========================
+        public int PostTp1TrendScore { get; set; }
+
+        public string PostTp1TrendState { get; set; } = string.Empty;
+
+        public string PostTp1TrailingMode { get; set; } = string.Empty;
+
+        public double Tp2ExtensionMultiplierApplied { get; set; } = 1.0;
+
+        public double? LastExtendedTp2 { get; set; }
+
+        public double? LastTrailingStopTarget { get; set; }
+
         public bool MarketTrend { get; set; }
     }
 }

--- a/Core/TradeManagement/AdaptiveTrailingEngine.cs
+++ b/Core/TradeManagement/AdaptiveTrailingEngine.cs
@@ -1,0 +1,193 @@
+using System;
+using cAlgo.API;
+using cAlgo.API.Indicators;
+using GeminiV26.Core;
+
+namespace GeminiV26.Core.TradeManagement
+{
+    public sealed class AdaptiveTrailingEngine
+    {
+        private readonly Robot _bot;
+        private readonly AverageTrueRange _atr;
+
+        public AdaptiveTrailingEngine(Robot bot)
+        {
+            _bot = bot;
+            _atr = _bot.Indicators.AverageTrueRange(14, MovingAverageType.Exponential);
+        }
+
+        public void Apply(Position pos, PositionContext ctx, TrendDecision decision, StructureSnapshot structure, TrailingProfile profile)
+        {
+            if (!pos.StopLoss.HasValue)
+                return;
+
+            double atr = _atr.Result.LastValue;
+            if (atr <= 0)
+                return;
+
+            double oldSl = pos.StopLoss.Value;
+            double newSl;
+            bool valid;
+
+            switch (decision.TrailingMode)
+            {
+                case AdaptiveTrailingMode.Structure:
+                    valid = TryBuildStructureStop(pos, structure, profile, atr, out newSl);
+                    if (!valid)
+                    {
+                        _bot.Print("[TRAIL][STRUCT] skipped=no confirmed structure");
+                        return;
+                    }
+                    _bot.Print($"[TRAIL][STRUCT] oldSL={oldSl} newSL={newSl}");
+                    break;
+
+                case AdaptiveTrailingMode.Liquidity:
+                    valid = TryBuildLiquidityStop(pos, structure, profile, atr, out newSl);
+                    if (!valid)
+                    {
+                        _bot.Print("[TRAIL][LIQ] skipped=no liquidityLevel");
+                        return;
+                    }
+                    _bot.Print($"[TRAIL][LIQ] oldSL={oldSl} newSL={newSl}");
+                    break;
+
+                default:
+                    BuildVolatilityStop(pos, profile, atr, out newSl, out string regime, out double multiplier);
+                    _bot.Print($"[TRAIL][VOL] regime={regime} multiplier={multiplier:0.00}");
+                    _bot.Print($"[TRAIL][VOL] oldSL={oldSl} newSL={newSl}");
+                    break;
+            }
+
+            if (ctx.BePrice > 0)
+            {
+                newSl = pos.TradeType == TradeType.Buy
+                    ? Math.Max(newSl, ctx.BePrice)
+                    : Math.Min(newSl, ctx.BePrice);
+            }
+
+            newSl = Normalize(newSl);
+
+            if (!ImprovesStop(pos, newSl, oldSl))
+            {
+                _bot.Print("[TRAIL] skipped=no improvement");
+                return;
+            }
+
+            double minDelta = Math.Max(profile.MinSlUpdateDeltaPips * _bot.Symbol.PipSize, atr * 0.05);
+            if (Math.Abs(newSl - oldSl) < minDelta)
+            {
+                _bot.Print("[TRAIL] skipped=minDelta");
+                return;
+            }
+
+            if (ctx.LastTrailingStopTarget.HasValue && Math.Abs(ctx.LastTrailingStopTarget.Value - newSl) < (_bot.Symbol.PipSize * 0.1))
+            {
+                _bot.Print("[TRAIL] skipped=sameTarget");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, newSl, pos.TakeProfit);
+            ctx.LastTrailingStopTarget = newSl;
+            ctx.LastStopLossPrice = newSl;
+            _bot.Print($"[TRAIL] modified pos={pos.Id} oldSL={oldSl} newSL={newSl}");
+        }
+
+        private bool TryBuildStructureStop(Position pos, StructureSnapshot structure, TrailingProfile profile, double atr, out double newSl)
+        {
+            double buffer = atr * profile.StructureBufferAtr;
+            if (pos.TradeType == TradeType.Buy)
+            {
+                if (structure.LastHigherLow == null && structure.LastSwingLow == null)
+                {
+                    newSl = 0;
+                    return false;
+                }
+
+                double anchor = structure.LastHigherLow?.Price ?? structure.LastSwingLow.Price;
+                _bot.Print($"[TRAIL][STRUCT] lastSwingLow={anchor}");
+                newSl = anchor - buffer;
+                return true;
+            }
+
+            if (structure.LastLowerHigh == null && structure.LastSwingHigh == null)
+            {
+                newSl = 0;
+                return false;
+            }
+
+            double sellAnchor = structure.LastLowerHigh?.Price ?? structure.LastSwingHigh.Price;
+            _bot.Print($"[TRAIL][STRUCT] lastSwingHigh={sellAnchor}");
+            newSl = sellAnchor + buffer;
+            return true;
+        }
+
+        private bool TryBuildLiquidityStop(Position pos, StructureSnapshot structure, TrailingProfile profile, double atr, out double newSl)
+        {
+            double buffer = atr * (profile.StructureBufferAtr * 0.8);
+
+            if (pos.TradeType == TradeType.Buy)
+            {
+                if (structure.LastSwingLow == null)
+                {
+                    newSl = 0;
+                    return false;
+                }
+
+                double liquidityLevel = structure.LastSwingLow.Price;
+                _bot.Print($"[TRAIL][LIQ] liquidityLevel={liquidityLevel}");
+                newSl = liquidityLevel - buffer;
+                return true;
+            }
+
+            if (structure.LastSwingHigh == null)
+            {
+                newSl = 0;
+                return false;
+            }
+
+            double shortLiquidityLevel = structure.LastSwingHigh.Price;
+            _bot.Print($"[TRAIL][LIQ] liquidityLevel={shortLiquidityLevel}");
+            newSl = shortLiquidityLevel + buffer;
+            return true;
+        }
+
+        private void BuildVolatilityStop(Position pos, TrailingProfile profile, double atr, out double newSl, out string regime, out double multiplier)
+        {
+            double atrPips = atr / _bot.Symbol.PipSize;
+            if (atrPips < 15)
+            {
+                regime = "Low";
+                multiplier = profile.AtrMultiplierLowVol;
+            }
+            else if (atrPips > 45)
+            {
+                regime = "High";
+                multiplier = profile.AtrMultiplierHighVol;
+            }
+            else
+            {
+                regime = "Normal";
+                multiplier = profile.AtrMultiplierNormal;
+            }
+
+            double price = pos.TradeType == TradeType.Buy ? _bot.Symbol.Bid : _bot.Symbol.Ask;
+            newSl = pos.TradeType == TradeType.Buy
+                ? price - atr * multiplier
+                : price + atr * multiplier;
+        }
+
+        private bool ImprovesStop(Position pos, double candidate, double current)
+        {
+            return pos.TradeType == TradeType.Buy
+                ? candidate > current
+                : candidate < current;
+        }
+
+        private double Normalize(double price)
+        {
+            var s = _bot.Symbol;
+            double steps = Math.Round(price / s.TickSize);
+            return Math.Round(steps * s.TickSize, s.Digits);
+        }
+    }
+}

--- a/Core/TradeManagement/StructureTracker.cs
+++ b/Core/TradeManagement/StructureTracker.cs
@@ -1,0 +1,149 @@
+using System;
+using cAlgo.API;
+
+namespace GeminiV26.Core.TradeManagement
+{
+    public sealed class StructurePoint
+    {
+        public int Index { get; init; }
+        public DateTime Time { get; init; }
+        public double Price { get; init; }
+    }
+
+    public sealed class StructureSnapshot
+    {
+        public StructurePoint LastSwingLow { get; init; }
+        public StructurePoint LastSwingHigh { get; init; }
+        public StructurePoint LastHigherLow { get; init; }
+        public StructurePoint LastLowerHigh { get; init; }
+    }
+
+    public sealed class StructureTracker
+    {
+        private readonly Robot _bot;
+        private readonly Bars _bars;
+        private readonly int _strength;
+
+        private DateTime _lastProcessedBarTime = DateTime.MinValue;
+        private StructurePoint _lastSwingLow;
+        private StructurePoint _lastSwingHigh;
+        private StructurePoint _lastHigherLow;
+        private StructurePoint _lastLowerHigh;
+
+        public StructureTracker(Robot bot, Bars bars, int strength = 2)
+        {
+            _bot = bot;
+            _bars = bars;
+            _strength = Math.Max(2, strength);
+        }
+
+        public StructureSnapshot GetSnapshot()
+        {
+            UpdateStructureIfNeeded();
+            return new StructureSnapshot
+            {
+                LastSwingLow = _lastSwingLow,
+                LastSwingHigh = _lastSwingHigh,
+                LastHigherLow = _lastHigherLow,
+                LastLowerHigh = _lastLowerHigh
+            };
+        }
+
+        public bool TryGetLastHigherLow(out StructurePoint point)
+        {
+            UpdateStructureIfNeeded();
+            point = _lastHigherLow;
+            return point != null;
+        }
+
+        public bool TryGetLastLowerHigh(out StructurePoint point)
+        {
+            UpdateStructureIfNeeded();
+            point = _lastLowerHigh;
+            return point != null;
+        }
+
+        public StructurePoint GetLastConfirmedSwingLow()
+        {
+            UpdateStructureIfNeeded();
+            return _lastSwingLow;
+        }
+
+        public StructurePoint GetLastConfirmedSwingHigh()
+        {
+            UpdateStructureIfNeeded();
+            return _lastSwingHigh;
+        }
+
+        private void UpdateStructureIfNeeded()
+        {
+            if (_bars.Count < (_strength * 2 + 3))
+                return;
+
+            // csak új bar esetén frissítünk (OnTick-safe)
+            DateTime currentBarTime = _bars.OpenTimes.LastValue;
+            if (currentBarTime == _lastProcessedBarTime)
+                return;
+
+            _lastProcessedBarTime = currentBarTime;
+
+            int lastClosed = _bars.Count - 2;
+            int pivotIndex = lastClosed - _strength;
+            if (pivotIndex <= _strength)
+                return;
+
+            bool isSwingLow = true;
+            bool isSwingHigh = true;
+
+            double pivotLow = _bars.LowPrices[pivotIndex];
+            double pivotHigh = _bars.HighPrices[pivotIndex];
+
+            for (int i = pivotIndex - _strength; i <= pivotIndex + _strength; i++)
+            {
+                if (i == pivotIndex)
+                    continue;
+
+                if (_bars.LowPrices[i] <= pivotLow)
+                    isSwingLow = false;
+
+                if (_bars.HighPrices[i] >= pivotHigh)
+                    isSwingHigh = false;
+
+                if (!isSwingLow && !isSwingHigh)
+                    break;
+            }
+
+            if (isSwingLow)
+            {
+                var newLow = new StructurePoint
+                {
+                    Index = pivotIndex,
+                    Time = _bars.OpenTimes[pivotIndex],
+                    Price = pivotLow
+                };
+
+                if (_lastSwingLow == null || newLow.Price > _lastSwingLow.Price)
+                    _lastHigherLow = newLow;
+
+                _lastSwingLow = newLow;
+                _bot.Print($"[STRUCT] newSwingLow t={newLow.Time:O} price={newLow.Price}");
+            }
+
+            if (isSwingHigh)
+            {
+                var newHigh = new StructurePoint
+                {
+                    Index = pivotIndex,
+                    Time = _bars.OpenTimes[pivotIndex],
+                    Price = pivotHigh
+                };
+
+                if (_lastSwingHigh == null || newHigh.Price < _lastSwingHigh.Price)
+                    _lastLowerHigh = newHigh;
+
+                _lastSwingHigh = newHigh;
+                _bot.Print($"[STRUCT] newSwingHigh t={newHigh.Time:O} price={newHigh.Price}");
+            }
+        }
+    }
+}

--- a/Core/TradeManagement/TrailingProfiles.cs
+++ b/Core/TradeManagement/TrailingProfiles.cs
@@ -1,0 +1,103 @@
+using System;
+
+namespace GeminiV26.Core.TradeManagement
+{
+    public sealed class TrailingProfile
+    {
+        public string Name { get; init; } = "Default";
+        public double StructureBufferAtr { get; init; }
+        public double AtrMultiplierLowVol { get; init; }
+        public double AtrMultiplierNormal { get; init; }
+        public double AtrMultiplierHighVol { get; init; }
+        public double DefensiveAtrMultiplier { get; init; }
+        public double MinSlUpdateDeltaPips { get; init; }
+        public bool AllowLiquidityTrailing { get; init; }
+        public bool AllowTp2Extension { get; init; }
+        public double TrendTp2ExtensionMultiplier { get; init; }
+        public double StrongTrendTp2ExtensionMultiplier { get; init; }
+    }
+
+    public static class TrailingProfiles
+    {
+        public static TrailingProfile Fx => new()
+        {
+            Name = "FX",
+            StructureBufferAtr = 0.35,
+            AtrMultiplierLowVol = 1.10,
+            AtrMultiplierNormal = 1.45,
+            AtrMultiplierHighVol = 1.80,
+            DefensiveAtrMultiplier = 1.95,
+            MinSlUpdateDeltaPips = 1.0,
+            AllowLiquidityTrailing = false,
+            AllowTp2Extension = true,
+            TrendTp2ExtensionMultiplier = 1.22,
+            StrongTrendTp2ExtensionMultiplier = 1.45
+        };
+
+        public static TrailingProfile Index => new()
+        {
+            Name = "INDEX",
+            StructureBufferAtr = 0.45,
+            AtrMultiplierLowVol = 1.35,
+            AtrMultiplierNormal = 1.75,
+            AtrMultiplierHighVol = 2.20,
+            DefensiveAtrMultiplier = 2.40,
+            MinSlUpdateDeltaPips = 3.0,
+            AllowLiquidityTrailing = true,
+            AllowTp2Extension = true,
+            TrendTp2ExtensionMultiplier = 1.23,
+            StrongTrendTp2ExtensionMultiplier = 1.48
+        };
+
+        public static TrailingProfile Crypto => new()
+        {
+            Name = "CRYPTO",
+            StructureBufferAtr = 0.60,
+            AtrMultiplierLowVol = 1.50,
+            AtrMultiplierNormal = 2.05,
+            AtrMultiplierHighVol = 2.75,
+            DefensiveAtrMultiplier = 3.10,
+            MinSlUpdateDeltaPips = 8.0,
+            AllowLiquidityTrailing = true,
+            AllowTp2Extension = true,
+            TrendTp2ExtensionMultiplier = 1.25,
+            StrongTrendTp2ExtensionMultiplier = 1.50
+        };
+
+        public static TrailingProfile Metal => new()
+        {
+            Name = "METAL",
+            StructureBufferAtr = 0.50,
+            AtrMultiplierLowVol = 1.25,
+            AtrMultiplierNormal = 1.70,
+            AtrMultiplierHighVol = 2.25,
+            DefensiveAtrMultiplier = 2.50,
+            MinSlUpdateDeltaPips = 4.0,
+            AllowLiquidityTrailing = true,
+            AllowTp2Extension = true,
+            TrendTp2ExtensionMultiplier = 1.24,
+            StrongTrendTp2ExtensionMultiplier = 1.46
+        };
+
+        public static TrailingProfile ResolveBySymbol(string symbolName)
+        {
+            if (string.IsNullOrWhiteSpace(symbolName))
+                return Fx;
+
+            if (symbolName.StartsWith("XAU", StringComparison.OrdinalIgnoreCase) ||
+                symbolName.StartsWith("XAG", StringComparison.OrdinalIgnoreCase))
+                return Metal;
+
+            if (symbolName.Contains("BTC", StringComparison.OrdinalIgnoreCase) ||
+                symbolName.Contains("ETH", StringComparison.OrdinalIgnoreCase))
+                return Crypto;
+
+            if (symbolName.Contains("US30", StringComparison.OrdinalIgnoreCase) ||
+                symbolName.Contains("NAS", StringComparison.OrdinalIgnoreCase) ||
+                symbolName.Contains("GER", StringComparison.OrdinalIgnoreCase))
+                return Index;
+
+            return Fx;
+        }
+    }
+}

--- a/Core/TradeManagement/TrendTradeManager.cs
+++ b/Core/TradeManagement/TrendTradeManager.cs
@@ -1,0 +1,143 @@
+using System;
+using cAlgo.API;
+using cAlgo.API.Indicators;
+using GeminiV26.Core;
+
+namespace GeminiV26.Core.TradeManagement
+{
+    public enum TradeTrendState
+    {
+        Normal,
+        Trend,
+        StrongTrend
+    }
+
+    public enum AdaptiveTrailingMode
+    {
+        Structure,
+        Volatility,
+        Liquidity
+    }
+
+    public sealed class TrendDecision
+    {
+        public TradeTrendState State { get; init; }
+        public int Score { get; init; }
+        public AdaptiveTrailingMode TrailingMode { get; init; }
+        public bool AllowTp2Extension { get; init; }
+        public double Tp2ExtensionMultiplier { get; init; }
+    }
+
+    public sealed class TrendTradeManager
+    {
+        private readonly Robot _bot;
+        private readonly AverageTrueRange _atr;
+        private readonly ExponentialMovingAverage _ema21;
+        private readonly ExponentialMovingAverage _ema50;
+
+        public TrendTradeManager(Robot bot, Bars bars)
+        {
+            _bot = bot;
+            _atr = _bot.Indicators.AverageTrueRange(14, MovingAverageType.Exponential);
+            _ema21 = _bot.Indicators.ExponentialMovingAverage(bars.ClosePrices, 21);
+            _ema50 = _bot.Indicators.ExponentialMovingAverage(bars.ClosePrices, 50);
+        }
+
+        public TrendDecision Evaluate(Position position, PositionContext ctx, TrailingProfile profile, StructureSnapshot structure)
+        {
+            double atr = _atr.Result.LastValue;
+            if (atr <= 0)
+                atr = Math.Abs(_bot.Symbol.Bid - _bot.Symbol.Ask) * 4.0;
+
+            double priceNow = position.TradeType == TradeType.Buy ? _bot.Symbol.Bid : _bot.Symbol.Ask;
+            double move = position.TradeType == TradeType.Buy
+                ? priceNow - position.EntryPrice
+                : position.EntryPrice - priceNow;
+
+            double currentR = ctx.RiskPriceDistance > 0
+                ? move / ctx.RiskPriceDistance
+                : 0;
+
+            int score = 0;
+
+            bool impulseStrong = currentR >= 1.2;
+            if (impulseStrong)
+                score++;
+
+            bool ema21Respected = position.TradeType == TradeType.Buy
+                ? priceNow >= _ema21.Result.LastValue
+                : priceNow <= _ema21.Result.LastValue;
+            if (ema21Respected)
+                score++;
+
+            bool ema50Respected = position.TradeType == TradeType.Buy
+                ? priceNow >= _ema50.Result.LastValue
+                : priceNow <= _ema50.Result.LastValue;
+            if (ema50Respected)
+                score++;
+
+            bool structureIntact = position.TradeType == TradeType.Buy
+                ? structure.LastHigherLow != null
+                : structure.LastLowerHigh != null;
+            if (structureIntact)
+                score++;
+
+            double pullbackDepth = EstimatePullbackDepth(position, structure, priceNow);
+            bool shallowPullback = atr > 0 && pullbackDepth <= atr * 0.5;
+            if (shallowPullback)
+                score++;
+
+            TradeTrendState state = score switch
+            {
+                <= 1 => TradeTrendState.Normal,
+                <= 3 => TradeTrendState.Trend,
+                _ => TradeTrendState.StrongTrend
+            };
+
+            AdaptiveTrailingMode mode = state switch
+            {
+                TradeTrendState.Normal => AdaptiveTrailingMode.Volatility,
+                TradeTrendState.Trend => AdaptiveTrailingMode.Structure,
+                TradeTrendState.StrongTrend when profile.AllowLiquidityTrailing => AdaptiveTrailingMode.Liquidity,
+                _ => AdaptiveTrailingMode.Structure
+            };
+
+            bool allowTp2Extension = profile.AllowTp2Extension && state != TradeTrendState.Normal;
+            double tp2Multiplier = state switch
+            {
+                TradeTrendState.Trend => profile.TrendTp2ExtensionMultiplier,
+                TradeTrendState.StrongTrend => profile.StrongTrendTp2ExtensionMultiplier,
+                _ => 1.0
+            };
+
+            _bot.Print($"[TTM] state={state} score={score} mode={mode}");
+            if (allowTp2Extension)
+                _bot.Print($"[TTM] TP2 extension allowed multiplier={tp2Multiplier:0.00}");
+
+            return new TrendDecision
+            {
+                State = state,
+                Score = score,
+                TrailingMode = mode,
+                AllowTp2Extension = allowTp2Extension,
+                Tp2ExtensionMultiplier = tp2Multiplier
+            };
+        }
+
+        private static double EstimatePullbackDepth(Position position, StructureSnapshot structure, double priceNow)
+        {
+            if (position.TradeType == TradeType.Buy)
+            {
+                if (structure.LastSwingHigh == null)
+                    return 0;
+
+                return Math.Max(0, structure.LastSwingHigh.Price - priceNow);
+            }
+
+            if (structure.LastSwingLow == null)
+                return 0;
+
+            return Math.Max(0, priceNow - structure.LastSwingLow.Price);
+        }
+    }
+}

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using cAlgo.API;
-using cAlgo.API.Indicators;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.US30
 {
@@ -12,26 +11,19 @@ namespace GeminiV26.Instruments.US30
         private readonly Robot _bot;
         private readonly TradeViabilityMonitor _tvm;
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
-        // ===== TUNING =====
         private const double BeOffsetR = 0.05;
-
-        private const double TrailTight = 1.2;
-        private const double TrailNormal = 1.6;
-        private const double TrailLoose = 2.1;
-
-        private const int AtrPeriod = 14;
-        private readonly AverageTrueRange _atrM5;
-
-        // Indexhez: ne legyen túl “ideges”
-        private const double MinImproveAtrFrac = 0.05;     // 5% ATR
-        private const double MinImprovePipsFrac = 0.5;     // 0.5 pip
 
         public Us30ExitManager(Robot bot)
         {
             _bot = bot;
-            _atrM5 = _bot.Indicators.AverageTrueRange(AtrPeriod, MovingAverageType.Exponential);
             _tvm = new TradeViabilityMonitor(_bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         public void RegisterContext(PositionContext ctx)
@@ -39,9 +31,6 @@ namespace GeminiV26.Instruments.US30
             _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
         }
 
-        // =====================================================
-        // TICK-LEVEL LIFECYCLE (FX-SZERŰ)
-        // =====================================================
         public void OnTick()
         {
             var keys = new List<long>(_contexts.Keys);
@@ -88,31 +77,17 @@ namespace GeminiV26.Instruments.US30
                         if (tp1Done)
                         {
                             MoveToBreakEven(pos, ctx, rDist);
-
-                            if (ctx.TrailingMode == TrailingMode.None)
-                                ctx.TrailingMode = TrailingMode.Normal;
-
-                            _bot.Print($"[US30 TP1 STATE] pos={pos.Id} tp1Hit={ctx.Tp1Hit} be={ctx.BePrice} trailing={ctx.TrailingMode}");
+                            _bot.Print($"[US30 TP1 STATE] pos={pos.Id} tp1Hit={ctx.Tp1Hit} be={ctx.BePrice}");
                         }
 
-                        return; // <<< KRITIKUS
+                        return;
                     }
-
                 }
 
                 if (!ctx.Tp1Hit)
                 {
-                // =========================
-                // TVM – Early Exit (TP1 előtt)
-                // =========================
-                {
                     const int MinBarsBeforeTvm = 4;
-
-                    // SINGLE SOURCE OF TRUTH
-                    ctx.BarsSinceEntryM5 = (int)Math.Max(
-                        1,
-                        (_bot.Server.Time - ctx.EntryTime).TotalSeconds / 300.0
-                    );
+                    ctx.BarsSinceEntryM5 = (int)Math.Max(1, (_bot.Server.Time - ctx.EntryTime).TotalSeconds / 300.0);
 
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
@@ -129,30 +104,33 @@ namespace GeminiV26.Instruments.US30
                             );
 
                             _bot.ClosePosition(pos);
-
-                            // cleanup
                             _contexts.Remove(key);
-
                             return;
                         }
                     }
-                }
-
 
                     continue;
                 }
 
-                ApplyTrailing(pos, ctx);
+                // post-TP1 delegated management
+                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
-                public void OnBar(Position pos)
+
+        public void OnBar(Position pos)
         {
-            // szándékosan üres vagy későbbi TVM-hez használható
+            // reserved
         }
 
-        // =====================================================
-        // TP1 CHECK
-        // =====================================================
         private bool CheckTp1Hit(Position pos, PositionContext ctx, double rDist, double tp1R)
         {
             var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -163,13 +141,9 @@ namespace GeminiV26.Instruments.US30
                 ? pos.EntryPrice + rDist * tp1R
                 : pos.EntryPrice - rDist * tp1R;
 
-            double priceNow = pos.TradeType == TradeType.Buy
-                ? sym.Bid
-                : sym.Ask;
+            double priceNow = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
 
-            bool hit = pos.TradeType == TradeType.Buy
-                ? priceNow >= tp1Price
-                : priceNow <= tp1Price;
+            bool hit = pos.TradeType == TradeType.Buy ? priceNow >= tp1Price : priceNow <= tp1Price;
 
             _bot.Print(
                 $"[US30 TP1 DBG] pos={pos.Id} dir={pos.TradeType} entry={pos.EntryPrice} sl={pos.StopLoss} " +
@@ -179,27 +153,19 @@ namespace GeminiV26.Instruments.US30
             return hit;
         }
 
-        // =====================================================
-        // TP1 EXECUTION
-        // =====================================================
-         private bool ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
             var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (sym == null)
                 return false;
 
-            double frac = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
-                ? ctx.Tp1CloseFraction
-                : 0.5;
-
+            double frac = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1 ? ctx.Tp1CloseFraction : 0.5;
             long minUnits = (long)sym.VolumeInUnitsMin;
-
             long targetUnits = (long)Math.Floor(pos.VolumeInUnits * frac);
             if (targetUnits <= 0)
                 return false;
 
             long closeUnits = (long)sym.NormalizeVolumeInUnits(targetUnits);
-
             if (closeUnits < minUnits)
                 return false;
 
@@ -209,10 +175,7 @@ namespace GeminiV26.Instruments.US30
             if (closeUnits <= 0)
                 return false;
 
-            _bot.Print($"[US30 TP1 EXEC] pos={pos.Id} closeUnits={closeUnits} posVol={pos.VolumeInUnits} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}");
-
             var closeResult = _bot.ClosePosition(pos, closeUnits);
-
             _bot.Print($"[US30 TP1 EXEC RES] pos={pos.Id} success={closeResult.IsSuccessful} err={closeResult.Error}");
 
             if (!closeResult.IsSuccessful)
@@ -221,19 +184,11 @@ namespace GeminiV26.Instruments.US30
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = pos.VolumeInUnits - closeUnits;
             ctx.Tp1Hit = true;
-
             return true;
         }
 
-        // =====================================================
-        // BREAK EVEN
-        // =====================================================
         private void MoveToBreakEven(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
-            if (sym == null)
-                return;
-
             if (ctx.BePrice > 0)
                 return;
 
@@ -249,65 +204,51 @@ namespace GeminiV26.Instruments.US30
                 return;
 
             _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
-
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
         }
-        // =====================================================
-        // TRAILING (FX-SZERŰ, INDEX TUNING)
-        // =====================================================
-        private void ApplyTrailing(Position pos, PositionContext ctx)
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
-            if (sym == null)
-                return;
-
-            double atr = _atrM5.Result.LastValue;
-            if (atr <= 0)
-                return;
-
-            double mult = GetTrailMultiplier(ctx.TrailingMode);
-            double trailDist = atr * mult;
-
-            double desiredSl =
-                pos.TradeType == TradeType.Buy
-                    ? sym.Bid - trailDist
-                    : sym.Ask + trailDist;
-
-            if (ctx.BePrice > 0)
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
             {
-                desiredSl = pos.TradeType == TradeType.Buy
-                    ? Math.Max(desiredSl, ctx.BePrice)
-                    : Math.Min(desiredSl, ctx.BePrice);
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
             }
 
-            double minImprove = Math.Max(
-                sym.PipSize * MinImprovePipsFrac,
-                atr * MinImproveAtrFrac
-            );
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
 
-            bool improve =
-                (pos.TradeType == TradeType.Buy && desiredSl > pos.StopLoss.Value + minImprove) ||
-                (pos.TradeType == TradeType.Sell && desiredSl < pos.StopLoss.Value - minImprove);
-
-            if (!improve)
-                return;
-
-            _bot.ModifyPosition(pos, desiredSl, pos.TakeProfit);
-        }
-
-        private static int Direction(Position pos)
-            => pos.TradeType == TradeType.Buy ? 1 : -1;
-
-        private static double GetTrailMultiplier(TrailingMode mode)
-        {
-            return mode switch
+            if (desiredR <= currentR + 0.0001)
             {
-                TrailingMode.Tight => TrailTight,
-                TrailingMode.Normal => TrailNormal,
-                TrailingMode.Loose => TrailLoose,
-                _ => TrailNormal
-            };
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent healthy-trend pullbacks from causing premature stop-outs after TP1 by replacing distance-based trailing with structure- and regime-aware management.
- Provide a single set of global, reusable engines for post-TP1 trade management while preserving existing instrument-specific ExitManagers and their TP1/partial-close/BE orchestration.
- Allow safe, controlled TP2 extension in genuine trend continuation situations while keeping OnTick execution cheap and non-spamming.

### Description
- Add a new global trade-management module set under `Core/TradeManagement`: `TrendTradeManager` (trend scoring, trailing-mode selection and TP2 decision), `AdaptiveTrailingEngine` (OnTick-safe tighten-only SL updates with min-delta and duplicate-target guards across Structure/Volatility/Liquidity modes), `StructureTracker` (confirmed-bar swing detection and cached snapshots), and `TrailingProfiles` (FX/Index/Crypto/Metal parameter profiles).
- Extend `PositionContext` with post-TP1 runtime fields (trend score/state, trailing mode, TP2 extension state, last trailing/TP2 targets) to prevent repeated modifications and support on-tick-safe operation.
- Integrate the new flow into `Instruments/US30/Us30ExitManager`: after `ctx.Tp1Hit` the manager now resolves a profile, calls `TrendTradeManager.Evaluate(...)`, applies outward-only progression-guarded TP2 extension when allowed, and delegates SL updates to `AdaptiveTrailingEngine`, while preserving the instrument's TP1 partial-close and BE logic.
- Add explicit debug logs for trend decisions (`[TTM]`), trailing mode outputs (`[TRAIL][STRUCT|VOL|LIQ]`), TP2 extension decisions, and skipped-update reasons to aid diagnostics; structure updates are based only on confirmed bars to maintain OnTick safety.
- Note: per repository agent rules, contexts must continue to call `ctx.ComputeFinalConfidence()` immediately after `PositionContext` creation; this PR does not change that requirement.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors.
- Attempted `dotnet build` in the environment but build could not be executed because `dotnet` is not installed in the container, so a compile/run build was not performed here.
- No unit tests were added in this change; functional validation is expected to be performed in the cAlgo/cTrader environment and during instrument-by-instrument migration to the new managers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29c1265f8832883807b02f4e69a86)