### PR TITLE
Enable FX impulse continuation evaluation with ADX safety filter

### DIFF
--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -20,11 +20,6 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            return Invalid(ctx, "FX_RESET_DISABLED_IMPULSE_CONT");
-        }
-/*
-        public EntryEvaluation Evaluate(EntryContext ctx)
-        {
             if (!ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
@@ -66,6 +61,9 @@ namespace GeminiV26.EntryTypes.FX
             // =====================================================
             // IMPULSE CONDITIONS (REAL CONTEXT FIELDS)
             // =====================================================
+            if (ctx.Adx_M5 < 22)
+                return Invalid(ctx, "WeakTrend");
+
             if (!ctx.HasImpulse_M5)
                 return Invalid(ctx, "NoImpulse");
 
@@ -110,7 +108,7 @@ namespace GeminiV26.EntryTypes.FX
                     $"m1={ctx.M1TriggerInTrendDirection}"
             };
         }
-*/
+
         private EntryEvaluation Invalid(EntryContext ctx, string reason)
             => new()
             {


### PR DESCRIPTION
### Motivation
- The FX impulse-continuation entry was intentionally disabled by an early return, preventing the implemented logic from ever running. 
- The change restores the original evaluation logic to allow impulse continuation entries when market conditions match the existing guards. 
- An extra safety check on ADX is required to avoid impulse entries in weak FX trend environments.

### Description
- Removed the hard-disable return and reactivated the existing `Evaluate(EntryContext ctx)` implementation so the entry logic is applied. 
- Added an early safety filter `if (ctx.Adx_M5 < 22) return Invalid(ctx, "WeakTrend");` before the impulse checks. 
- Preserved all original guards and scoring flow including `MinPullbackAtr`, `MaxPullbackAtr`, `IsAtrExpanding_M5`, trend slope checks, `HasImpulse_M5`, and scoring/`MinScore` gating. 
- Kept class name, public API, and file-local constants unchanged.

### Testing
- Applied the patch to `EntryTypes/FX/FX_ImpulseContinuationEntry.cs` and confirmed the file was updated successfully. 
- Inspected the resulting source with `sed -n '1,260p' EntryTypes/FX/FX_ImpulseContinuationEntry.cs` and `nl -ba EntryTypes/FX/FX_ImpulseContinuationEntry.cs | sed -n '1,240p'` to verify the active `Evaluate` method and the new ADX check. 
- Verified workspace file listings to ensure only the target file was modified; all inspections completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b547a584832881cb202f0d9e0f74)