### PR TITLE
Allow deep pullback continuation in BTC pullback validation

### DIFF
--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -646,9 +646,46 @@ namespace GeminiV26.EntryTypes.Crypto
 
                 if (pullbackDepth > 0.5)
                 {
-                    Console.WriteLine($"[BTC FILTER] rejected: pullback too deep depth={pullbackDepth:F2}");
-                    ctx.Log?.Invoke($"[BTC FILTER] rejected: pullback too deep depth={pullbackDepth:F2}");
-                    return Block(ctx, "BTC_FILTER_PULLBACK_TOO_DEEP", score, dir);
+                    int compressionBars = Math.Max(0, Math.Min(ctx.PullbackBars_M5, 10));
+                    int compressionStart = Math.Max(0, lastClosed - compressionBars + 1);
+
+                    double compressionHigh = double.MinValue;
+                    double compressionLow = double.MaxValue;
+
+                    for (int i = compressionStart; i <= lastClosed; i++)
+                    {
+                        compressionHigh = Math.Max(compressionHigh, bars[i].High);
+                        compressionLow = Math.Min(compressionLow, bars[i].Low);
+                    }
+
+                    double compressionRange = compressionHigh - compressionLow;
+                    double atr = Math.Max(0, ctx.AtrM5);
+
+                    bool compressionDetected =
+                        compressionBars >= 3 &&
+                        compressionBars <= 10 &&
+                        compressionRange <= atr * 0.6;
+
+                    if (!compressionDetected)
+                    {
+                        ctx.Log?.Invoke("[PB] rejected: deep pullback without compression");
+                        return Block(ctx, "BTC_FILTER_PULLBACK_TOO_DEEP", score, dir);
+                    }
+
+                    TradeDirection impulseDirection =
+                        ctx.ImpulseDirection != TradeDirection.None ? ctx.ImpulseDirection : dir;
+
+                    bool breakoutAligned =
+                        (impulseDirection == TradeDirection.Long && bars[lastClosed].Close > compressionHigh) ||
+                        (impulseDirection == TradeDirection.Short && bars[lastClosed].Close < compressionLow);
+
+                    if (!breakoutAligned)
+                    {
+                        ctx.Log?.Invoke("[PB] rejected: breakout against impulse");
+                        return Block(ctx, "BTC_FILTER_PULLBACK_TOO_DEEP", score, dir);
+                    }
+
+                    ctx.Log?.Invoke("[PB] DeepPullbackContinuation accepted");
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Deep pullbacks were previously rejected unconditionally when `pullbackDepth > 0.5`, which prevents legitimate continuation setups that show compression + aligned breakout after a deep retrace. 
- The change aims to allow those genuine continuation setups while keeping rejections for deep pullbacks that lack compression or break out against the impulse. 

### Description
- Modified `EntryTypes/CRYPTO/BTC_PullbackEntry.cs` deep-pullback branch so `pullbackDepth > 0.5` no longer auto-rejects but performs additional checks. 
- Detects compression using `compressionBars = Math.Max(0, Math.Min(ctx.PullbackBars_M5, 10))`, computes `compressionHigh`/`compressionLow` from `bars[...]`, and requires `compressionBars >= 3 && compressionBars <= 10 && compressionRange <= atr * 0.6` where `atr = Math.Max(0, ctx.AtrM5)`. 
- Verifies breakout alignment by deriving `impulseDirection = ctx.ImpulseDirection != TradeDirection.None ? ctx.ImpulseDirection : dir` and checking `(Long && Close > compressionHigh) || (Short && Close < compressionLow)`. 
- Emits only the requested debug logs: `[PB] rejected: deep pullback without compression`, `[PB] rejected: breakout against impulse`, and `[PB] DeepPullbackContinuation accepted` and otherwise preserves the existing rejection path (`Block(..., "BTC_FILTER_PULLBACK_TOO_DEEP", ...)`). 

### Testing
- Attempted to run the build with `dotnet build -v minimal`, but it failed in this environment with `command not found` because the `dotnet` CLI is not available. 
- No automated unit tests were executed in this environment; change is limited and localized to the existing pullback validation block.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ba35f0cc8328885ea156428c1e18)