### PR TITLE
Apply BTC DeepPullbackContinuation logic to FX / INDEX / METAL pullbacks

### DIFF
--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -149,6 +149,53 @@ namespace GeminiV26.EntryTypes.FX
             if (!ctx.LastClosedBarInTrendDirection)
                 ApplyPenalty(ref score, ref penalty, 6, penaltyBudget, ctx, "PB_LASTBAR_NOT_TREND_DIR");
 
+            if (ctx.PullbackDepthAtr_M5 > 0.5)
+            {
+                var bars = ctx.M5;
+                int lastClosed = bars.Count - 2;
+
+                int compressionBars = Math.Max(0, Math.Min(ctx.PullbackBars_M5, 10));
+                int compressionStart = Math.Max(0, lastClosed - compressionBars + 1);
+
+                double compressionHigh = double.MinValue;
+                double compressionLow = double.MaxValue;
+
+                for (int i = compressionStart; i <= lastClosed; i++)
+                {
+                    compressionHigh = Math.Max(compressionHigh, bars[i].High);
+                    compressionLow = Math.Min(compressionLow, bars[i].Low);
+                }
+
+                double compressionRange = compressionHigh - compressionLow;
+                double atr = Math.Max(0, ctx.AtrM5);
+
+                bool compressionDetected =
+                    compressionBars >= 3 &&
+                    compressionBars <= 10 &&
+                    compressionRange <= atr * 0.6;
+
+                if (!compressionDetected)
+                {
+                    ctx.Log?.Invoke("[PB] rejected: deep pullback without compression");
+                    return Block(ctx, "PB_TOO_DEEP", score);
+                }
+
+                TradeDirection impulseDirection =
+                    ctx.ImpulseDirection != TradeDirection.None ? ctx.ImpulseDirection : dir;
+
+                bool breakoutAligned =
+                    (impulseDirection == TradeDirection.Long && bars[lastClosed].Close > compressionHigh) ||
+                    (impulseDirection == TradeDirection.Short && bars[lastClosed].Close < compressionLow);
+
+                if (!breakoutAligned)
+                {
+                    ctx.Log?.Invoke("[PB] rejected: breakout against impulse");
+                    return Block(ctx, "PB_TOO_DEEP", score);
+                }
+
+                ctx.Log?.Invoke("[PB] DeepPullbackContinuation accepted");
+            }
+
             // Depth gates (keep your original hard extreme)
             if (ctx.PullbackDepthAtr_M5 > 1.6)
                 return Block(ctx, "PB_TOO_DEEP_EXTREME", score);

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -102,6 +102,53 @@ namespace GeminiV26.EntryTypes.INDEX
             if (ctx.IsAtrExpanding_M5 && ctx.PullbackDepthAtr_M5 > 0.6)
                 score -= 6;
 
+            if (ctx.PullbackDepthAtr_M5 > 0.5)
+            {
+                var bars = ctx.M5;
+                int lastClosed = bars.Count - 2;
+
+                int compressionBars = Math.Max(0, Math.Min(ctx.PullbackBars_M5, 10));
+                int compressionStart = Math.Max(0, lastClosed - compressionBars + 1);
+
+                double compressionHigh = double.MinValue;
+                double compressionLow = double.MaxValue;
+
+                for (int i = compressionStart; i <= lastClosed; i++)
+                {
+                    compressionHigh = Math.Max(compressionHigh, bars[i].High);
+                    compressionLow = Math.Min(compressionLow, bars[i].Low);
+                }
+
+                double compressionRange = compressionHigh - compressionLow;
+                double atr = Math.Max(0, ctx.AtrM5);
+
+                bool compressionDetected =
+                    compressionBars >= 3 &&
+                    compressionBars <= 10 &&
+                    compressionRange <= atr * 0.6;
+
+                if (!compressionDetected)
+                {
+                    ctx.Log?.Invoke("[PB] rejected: deep pullback without compression");
+                    return null;
+                }
+
+                TradeDirection impulseDirection =
+                    ctx.ImpulseDirection != TradeDirection.None ? ctx.ImpulseDirection : dir;
+
+                bool breakoutAligned =
+                    (impulseDirection == TradeDirection.Long && bars[lastClosed].Close > compressionHigh) ||
+                    (impulseDirection == TradeDirection.Short && bars[lastClosed].Close < compressionLow);
+
+                if (!breakoutAligned)
+                {
+                    ctx.Log?.Invoke("[PB] rejected: breakout against impulse");
+                    return null;
+                }
+
+                ctx.Log?.Invoke("[PB] DeepPullbackContinuation accepted");
+            }
+
             if (ctx.PullbackDepthAtr_M5 <= 0 ||
                 ctx.PullbackDepthAtr_M5 > maxPullbackDepthAtr)
                 return null;

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -103,6 +103,53 @@ namespace GeminiV26.EntryTypes.METAL
             // =========================
             // PULLBACK QUALITY
             // =========================
+            if (ctx.PullbackDepthAtr_M5 > 0.5)
+            {
+                var bars = ctx.M5;
+                int lastClosed = bars.Count - 2;
+
+                int compressionBars = Math.Max(0, Math.Min(ctx.PullbackBars_M5, 10));
+                int compressionStart = Math.Max(0, lastClosed - compressionBars + 1);
+
+                double compressionHigh = double.MinValue;
+                double compressionLow = double.MaxValue;
+
+                for (int i = compressionStart; i <= lastClosed; i++)
+                {
+                    compressionHigh = Math.Max(compressionHigh, bars[i].High);
+                    compressionLow = Math.Min(compressionLow, bars[i].Low);
+                }
+
+                double compressionRange = compressionHigh - compressionLow;
+                double atr = Math.Max(0, ctx.AtrM5);
+
+                bool compressionDetected =
+                    compressionBars >= 3 &&
+                    compressionBars <= 10 &&
+                    compressionRange <= atr * 0.6;
+
+                if (!compressionDetected)
+                {
+                    ctx.Log?.Invoke("[PB] rejected: deep pullback without compression");
+                    return RejectDecision(ctx, score, "PULLBACK_TOO_DEEP", reasons);
+                }
+
+                TradeDirection impulseDirection =
+                    ctx.ImpulseDirection != TradeDirection.None ? ctx.ImpulseDirection : dir;
+
+                bool breakoutAligned =
+                    (impulseDirection == TradeDirection.Long && bars[lastClosed].Close > compressionHigh) ||
+                    (impulseDirection == TradeDirection.Short && bars[lastClosed].Close < compressionLow);
+
+                if (!breakoutAligned)
+                {
+                    ctx.Log?.Invoke("[PB] rejected: breakout against impulse");
+                    return RejectDecision(ctx, score, "PULLBACK_TOO_DEEP", reasons);
+                }
+
+                ctx.Log?.Invoke("[PB] DeepPullbackContinuation accepted");
+            }
+
             if (ctx.PullbackDepthAtr_M5 > 1.8)
             {
                 bool htfAligned =


### PR DESCRIPTION
### Motivation
- Ensure pullback entries for FX, INDEX and METAL mirror the BTC behavior so deep pullbacks are not auto-rejected when they satisfy continuation conditions. 
- Fix inconsistent handling where only BTC allowed deep pullback continuation while other instruments still hard-rejected deep pullbacks.

### Description
- Added an identical DeepPullbackContinuation block (guarded by `PullbackDepthAtr_M5 > 0.5`) to `FX_PullbackEntry`, `Index_PullbackEntry`, and `XAU_PullbackEntry` that performs compression detection and breakout-alignment checks. 
- Compression is detected using the same rule: `compressionBars` between 3 and 10 and `compressionRange <= atr * 0.6`; missing compression logs and rejects with `[PB] rejected: deep pullback without compression`. 
- Breakout alignment is checked against `ImpulseDirection` (fallback to `dir`); opposing breakout logs and rejects with `[PB] rejected: breakout against impulse`. 
- When both checks pass the code logs `[PB] DeepPullbackContinuation accepted` and allows the existing pullback flow to continue; no other logic, parameters, enums or modules were modified. 

### Testing
- Attempted `dotnet build` in the environment but it failed due to missing SDK (`bash: command not found: dotnet`).
- Performed local repository checks: file diffs and status were reviewed to confirm only the three targeted pullback entry files were modified and the required log messages/behavior were added. 
- No other automated tests were available/run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2bbbe8d2883288fce7f1dd1d1eb2e)