### PR TITLE
Integrate US30 post-TP1 adaptive exit pipeline into all ExitManagers

### DIFF
--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,9 @@ namespace GeminiV26.Instruments.AUDNZD
     {
         private readonly Robot _bot;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
@@ -31,6 +35,9 @@ namespace GeminiV26.Instruments.AUDNZD
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(_bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         // TradeCore hívja entry után
@@ -191,7 +198,16 @@ namespace GeminiV26.Instruments.AUDNZD
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -369,5 +385,49 @@ namespace GeminiV26.Instruments.AUDNZD
 
             return _bot.Bars.Count - entryIndex;
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,9 @@ namespace GeminiV26.Instruments.AUDUSD
     {
         private readonly Robot _bot;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
@@ -31,6 +35,9 @@ namespace GeminiV26.Instruments.AUDUSD
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(_bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         // TradeCore hívja entry után
@@ -191,7 +198,16 @@ namespace GeminiV26.Instruments.AUDUSD
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -354,5 +370,49 @@ namespace GeminiV26.Instruments.AUDUSD
 
             return _bot.Bars.Count - entryIndex;
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using cAlgo.API.Indicators;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.BTCUSD
 {
@@ -17,6 +18,9 @@ namespace GeminiV26.Instruments.BTCUSD
         // PositionId -> context
         private readonly Dictionary<long, PositionContext> _contexts = new();
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // ===== TP1 / BE =====
         private const double BeOffsetR = 0.05;
@@ -36,6 +40,9 @@ namespace GeminiV26.Instruments.BTCUSD
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
             _atrM5 = _bot.Indicators.AverageTrueRange(
                 AtrPeriod,
                 MovingAverageType.Exponential
@@ -186,7 +193,16 @@ namespace GeminiV26.Instruments.BTCUSD
                 // =========================
                 // Trailing (csak TP1 után)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -309,5 +325,49 @@ namespace GeminiV26.Instruments.BTCUSD
                 _ => TrailNormal
             };
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using cAlgo.API.Indicators;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.ETHUSD
 {
@@ -12,13 +13,16 @@ namespace GeminiV26.Instruments.ETHUSD
     /// </summary>
 
     public class EthUsdExitManager
-    {        
+    {
         private readonly Robot _bot;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
         // PositionId -> context
         private readonly Dictionary<long, PositionContext> _contexts = new();
 
-        // ===== TP1 / BE =====        
+        // ===== TP1 / BE =====
         private const double BeOffsetR = 0.05;
 
         // ===== Trailing =====
@@ -36,6 +40,9 @@ namespace GeminiV26.Instruments.ETHUSD
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
             _atrM5 = _bot.Indicators.AverageTrueRange(
                 AtrPeriod,
                 MovingAverageType.Exponential
@@ -170,7 +177,16 @@ namespace GeminiV26.Instruments.ETHUSD
                 // =========================
                 // Trailing (csak TP1 után)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -241,7 +257,7 @@ namespace GeminiV26.Instruments.ETHUSD
         }
 
         private void ApplyTrailing(Position pos, PositionContext ctx)
-        {            
+        {
             if (!pos.StopLoss.HasValue)
                 return;
 
@@ -293,5 +309,49 @@ namespace GeminiV26.Instruments.ETHUSD
                 _ => TrailNormal
             };
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,9 @@ namespace GeminiV26.Instruments.EURJPY
     {
         private readonly Robot _bot;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
@@ -31,6 +35,9 @@ namespace GeminiV26.Instruments.EURJPY
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(_bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         // TradeCore hívja entry után
@@ -191,7 +198,16 @@ namespace GeminiV26.Instruments.EURJPY
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -354,5 +370,49 @@ namespace GeminiV26.Instruments.EURJPY
 
             return _bot.Bars.Count - entryIndex;
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -14,6 +15,9 @@ namespace GeminiV26.Instruments.EURUSD
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // =========================
         // PARAMÉTEREK
@@ -31,6 +35,9 @@ namespace GeminiV26.Instruments.EURUSD
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         // TradeCore hívja entry után
@@ -116,7 +123,16 @@ namespace GeminiV26.Instruments.EURUSD
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -300,5 +316,49 @@ namespace GeminiV26.Instruments.EURUSD
 
             return _bot.Bars.Count - entryIndex;
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,9 @@ namespace GeminiV26.Instruments.GBPJPY
     {
         private readonly Robot _bot;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
@@ -31,6 +35,9 @@ namespace GeminiV26.Instruments.GBPJPY
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(_bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         // TradeCore hívja entry után
@@ -191,7 +198,16 @@ namespace GeminiV26.Instruments.GBPJPY
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -360,5 +376,49 @@ namespace GeminiV26.Instruments.GBPJPY
 
             return _bot.Bars.Count - entryIndex;
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -1,6 +1,7 @@
 ﻿using cAlgo.API;
 using cAlgo.API.Indicators;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -14,6 +15,9 @@ namespace GeminiV26.Instruments.GBPUSD
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         private const double BeOffsetR = 0.10;
 
@@ -25,6 +29,9 @@ namespace GeminiV26.Instruments.GBPUSD
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         public void RegisterContext(PositionContext ctx)
@@ -85,7 +92,7 @@ namespace GeminiV26.Instruments.GBPUSD
                         pos.TradeType == TradeType.Buy
                             ? pos.EntryPrice + rDist * ctx.Tp1R
                             : pos.EntryPrice - rDist * ctx.Tp1R;
-                    
+
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
                         ExecuteTp1(pos, ctx);
@@ -102,7 +109,16 @@ namespace GeminiV26.Instruments.GBPUSD
                     continue;
                 }
 
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -217,5 +233,49 @@ namespace GeminiV26.Instruments.GBPUSD
             int idx = _bot.Bars.OpenTimes.GetIndexByTime(ctx.EntryTime);
             return idx < 0 ? 0 : _bot.Bars.Count - idx;
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Interfaces;
 using GeminiV26.Data;
 using GeminiV26.Data.Models;
@@ -14,6 +15,9 @@ namespace GeminiV26.Instruments.GER40
         private readonly Robot _bot;
         private readonly EventLogger _eventLogger;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // PositionId -> PositionContext
         private readonly Dictionary<long, PositionContext> _contexts = new();
@@ -23,6 +27,9 @@ namespace GeminiV26.Instruments.GER40
             _bot = bot;
             _eventLogger = new EventLogger(bot.SymbolName);
             _tvm = new TradeViabilityMonitor(_bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         public void RegisterContext(PositionContext ctx)
@@ -127,7 +134,16 @@ namespace GeminiV26.Instruments.GER40
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -180,7 +196,7 @@ namespace GeminiV26.Instruments.GER40
         // TP1 CORE (CTX-ALAPÚ)
         // =====================================================
         private bool CheckTp1Hit(Position pos, PositionContext ctx, double rDist)
-        {   
+        {
             if (ctx.Tp1R <= 0)
                 return false;
 
@@ -337,5 +353,49 @@ namespace GeminiV26.Instruments.GER40
             double steps = Math.Round(price / s.TickSize);
             return Math.Round(steps * s.TickSize, s.Digits);
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Interfaces;
 using GeminiV26.Data;
 using GeminiV26.Data.Models;
@@ -14,6 +15,9 @@ namespace GeminiV26.Instruments.NAS100
         private readonly Robot _bot;
         private readonly EventLogger _eventLogger;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // PositionId -> PositionContext
         private readonly Dictionary<long, PositionContext> _contexts = new();
@@ -23,6 +27,9 @@ namespace GeminiV26.Instruments.NAS100
             _bot = bot;
             _eventLogger = new EventLogger(bot.SymbolName);
             _tvm = new TradeViabilityMonitor(_bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         public void RegisterContext(PositionContext ctx)
@@ -133,7 +140,16 @@ namespace GeminiV26.Instruments.NAS100
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -301,5 +317,49 @@ namespace GeminiV26.Instruments.NAS100
             double steps = Math.Round(price / s.TickSize);
             return Math.Round(steps * s.TickSize, s.Digits);
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,9 @@ namespace GeminiV26.Instruments.NZDUSD
     {
         private readonly Robot _bot;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
@@ -31,6 +35,9 @@ namespace GeminiV26.Instruments.NZDUSD
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(_bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         // TradeCore hívja entry után
@@ -191,7 +198,16 @@ namespace GeminiV26.Instruments.NZDUSD
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -360,5 +376,49 @@ namespace GeminiV26.Instruments.NZDUSD
 
             return _bot.Bars.Count - entryIndex;
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,9 @@ namespace GeminiV26.Instruments.USDCAD
     {
         private readonly Robot _bot;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
@@ -31,6 +35,9 @@ namespace GeminiV26.Instruments.USDCAD
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(_bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         // TradeCore hívja entry után
@@ -191,7 +198,16 @@ namespace GeminiV26.Instruments.USDCAD
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -360,5 +376,49 @@ namespace GeminiV26.Instruments.USDCAD
 
             return _bot.Bars.Count - entryIndex;
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,9 @@ namespace GeminiV26.Instruments.USDCHF
     {
         private readonly Robot _bot;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
@@ -31,6 +35,9 @@ namespace GeminiV26.Instruments.USDCHF
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(_bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         // TradeCore hívja entry után
@@ -191,7 +198,16 @@ namespace GeminiV26.Instruments.USDCHF
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -360,5 +376,49 @@ namespace GeminiV26.Instruments.USDCHF
 
             return _bot.Bars.Count - entryIndex;
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -14,6 +15,9 @@ namespace GeminiV26.Instruments.USDJPY
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
 
         // =========================
         // PARAMÉTEREK
@@ -31,6 +35,9 @@ namespace GeminiV26.Instruments.USDJPY
         {
             _bot = bot;
             _tvm = new TradeViabilityMonitor(bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
         }
 
         // TradeCore hívja entry után
@@ -116,7 +123,16 @@ namespace GeminiV26.Instruments.USDJPY
                 // =========================
                 // TRAILING (TP1 UTÁN)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -279,5 +295,49 @@ namespace GeminiV26.Instruments.USDJPY
 
             return _bot.Bars.Count - entryIndex;
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -1,4 +1,4 @@
-// =========================================================
+﻿// =========================================================
 // GEMINI V26 – XAUUSD ExitManager
 // Phase 3.7.x – RULEBOOK 1.0 COMPLIANT
 //
@@ -19,6 +19,7 @@
 
 using cAlgo.API;
 using GeminiV26.Core;
+using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data;
 using GeminiV26.Data.Models;
 using GeminiV26.EntryTypes.METAL; // XAU_InstrumentProfile + XAU_InstrumentMatrix (EntryTypes/Metal)
@@ -33,13 +34,16 @@ namespace GeminiV26.Instruments.XAUUSD
     {
         private readonly Robot _bot;
         private readonly EventLogger _eventLogger;
-        
+
         // Profile (matrixból) – TP1/BE paraméterek innen jönnek
         private readonly XAU_InstrumentProfile _profile;
         private AverageTrueRange _atr;
 
         private const bool DebugTp1 = false;
         private readonly TradeViabilityMonitor _tvm;
+        private readonly TrendTradeManager _trendTradeManager;
+        private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
+        private readonly StructureTracker _structureTracker;
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
 
@@ -48,10 +52,13 @@ namespace GeminiV26.Instruments.XAUUSD
             _bot = bot;
             _eventLogger = new EventLogger(bot.SymbolName);
             _tvm = new TradeViabilityMonitor(bot);
+            _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
+            _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
+            _structureTracker = new StructureTracker(_bot, _bot.Bars);
 
             // Profile betöltés (SSOT policy)
             _profile = XAU_InstrumentMatrix.Get(bot.SymbolName);
-            
+
             // ATR indikátor – EGYSZER létrehozva
             _atr = bot.Indicators.AverageTrueRange(
                 bot.Bars,
@@ -105,7 +112,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
                 if (ctx.RiskPriceDistance <= 0)
                     continue;
-                    
+
                 if (!pos.StopLoss.HasValue)
                     continue;
 
@@ -119,11 +126,11 @@ namespace GeminiV26.Instruments.XAUUSD
                 // - prefer: ctx.RiskPriceDistance
                 // - fallback: pos.EntryPrice vs pos.StopLoss (végső)
                 // -------------------------------------------------
-               
+
                 double rDist = GetRiskDistance(pos, ctx);
                 if (rDist <= 0)
                     continue;
-                
+
                 // =========================
                 // TP1 (TP1 előtt nincs trailing)
                 // =========================
@@ -193,7 +200,16 @@ namespace GeminiV26.Instruments.XAUUSD
                 // =========================
                 // TRAILING (TP1 után)
                 // =========================
-                ApplyTrailing(pos, ctx);
+                                var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
+                var structure = _structureTracker.GetSnapshot();
+                var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+
+                ctx.PostTp1TrendScore = decision.Score;
+                ctx.PostTp1TrendState = decision.State.ToString();
+                ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+
+                TryExtendTp2(pos, ctx, decision);
+                _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
 
@@ -431,5 +447,49 @@ namespace GeminiV26.Instruments.XAUUSD
                 bot.Print($"[XAU REHYDRATE] pos={pos.Id}");
             }
         }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
+        {
+            if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
+            {
+                if (!decision.AllowTp2Extension)
+                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                return;
+            }
+
+            double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
+            double desiredR = baseR * decision.Tp2ExtensionMultiplier;
+            double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
+
+            if (desiredR <= currentR + 0.0001)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                return;
+            }
+
+            double newTp = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + ctx.RiskPriceDistance * desiredR
+                : pos.EntryPrice - ctx.RiskPriceDistance * desiredR;
+
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price.Value;
+            bool outward = pos.TradeType == TradeType.Buy ? newTp > currentTp : newTp < currentTp;
+            if (!outward)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                return;
+            }
+
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print("[TTM] TP2 extension skipped=same target");
+                return;
+            }
+
+            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            ctx.LastExtendedTp2 = newTp;
+            ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
     }
 }


### PR DESCRIPTION
### Motivation
- Roll out the US30 reference implementation of the adaptive post-TP1 exit system to every instrument-specific ExitManager to avoid premature exits during healthy trends. 
- Keep each instrument's existing TP1 detection, partial close and BE orchestration intact while delegating post-TP1 management to the new global trade-management modules. 
- Respect scope boundaries by not changing global engines, risk sizing, entry logic or TradeCore architecture.

### Description
- Added references to `GeminiV26.Core.TradeManagement` and injected `TrendTradeManager`, `AdaptiveTrailingEngine` and `StructureTracker` (fields + constructor initialization) into each updated ExitManager. 
- Replaced legacy post-TP1 trailing invocation sites (previous `ApplyTrailing(pos, ctx);`) with the US30-style pipeline: `TrailingProfiles.ResolveBySymbol(...)` → `StructureTracker.GetSnapshot()` → `_trendTradeManager.Evaluate(...)` → update `ctx.PostTp1*` fields → `TryExtendTp2(...)` → `_adaptiveTrailingEngine.Apply(...)`. 
- Implemented the US30-equivalent `TryExtendTp2` in each ExitManager with the same progression guards (allow check, no-progression check, outward-only check, duplicate-target guard and logging) and preserved all debug/logging conventions. 
- Preserved pre-TP1 behaviour unchanged (TP1 detection, partial close, BE movement, TVM early-exit checks and OnTick safety rules) and made no modifications to global trade-management modules or other subsystems.

### Testing
- Confirmed programmatic edits across all ExitManagers by scanning for replaced `ApplyTrailing(pos, ctx);` call sites and verifying new adaptive pipeline calls are present; this check succeeded. 
- Verified each modified file contains the new `TrendTradeManager`/`AdaptiveTrailingEngine`/`StructureTracker` fields and a `TryExtendTp2` method via automated file inspections; this check succeeded. 
- Ran `git diff --check` / whitespace and encoding normalization fixes and re-checked for issues; no remaining diff-check problems were detected. 
- Attempted `dotnet build` in the environment but the `dotnet` CLI is not available here, so a full compile/run test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c0e589c88328a9317475abf44176)