### PR TITLE
Make Transition and FlagBreakout score-only enhancers

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1644,7 +1644,12 @@ namespace GeminiV26.Core
 
         private void ApplyTransitionScoreBoost(EntryContext ctx, List<EntryEvaluation> symbolSignals)
         {
-            if (ctx == null || symbolSignals == null || !ctx.TransitionValid || !ctx.FlagBreakoutConfirmed || ctx.TransitionScoreBonus <= 0)
+            if (ctx == null || symbolSignals == null)
+                return;
+
+            int transitionBonus = ctx.TransitionValid ? Math.Max(0, ctx.TransitionScoreBonus) : 0;
+            int flagBreakoutBonus = ctx.FlagBreakoutConfirmed ? 10 : 0;
+            if (transitionBonus <= 0 && flagBreakoutBonus <= 0)
                 return;
 
             foreach (var entry in symbolSignals)
@@ -1652,7 +1657,13 @@ namespace GeminiV26.Core
                 if (entry == null || !entry.IsValid)
                     continue;
 
-                int boost = GetTransitionBoost(entry.Type, ctx.TransitionScoreBonus);
+                int boost = 0;
+                if (transitionBonus > 0)
+                    boost += GetTransitionBoost(entry.Type, transitionBonus);
+
+                if (flagBreakoutBonus > 0)
+                    boost += GetFlagBreakoutBoost(entry.Type, flagBreakoutBonus);
+
                 if (boost <= 0)
                     continue;
 
@@ -1660,8 +1671,32 @@ namespace GeminiV26.Core
                 if (entry.Score > 100)
                     entry.Score = 100;
 
-                entry.Reason = $"{entry.Reason} [TRANSITION+{boost}]";
-                _bot.Print($"[ENTRY][TRANSITION] score boost applied type={entry.Type} boost={boost} score={entry.Score}");
+                entry.Reason = $"{entry.Reason} [STRUCTURE+{boost}]";
+                _bot.Print($"[ENTRY][STRUCTURE] score boost applied type={entry.Type} boost={boost} score={entry.Score} transition={ctx.TransitionValid} breakout={ctx.FlagBreakoutConfirmed}");
+            }
+        }
+
+        private static int GetFlagBreakoutBoost(EntryType type, int maxBonus)
+        {
+            switch (type)
+            {
+                case EntryType.FX_Flag:
+                case EntryType.FX_FlagContinuation:
+                case EntryType.Index_Flag:
+                case EntryType.Crypto_Flag:
+                case EntryType.TC_Flag:
+                case EntryType.XAU_Flag:
+                    return maxBonus;
+
+                case EntryType.FX_Pullback:
+                case EntryType.Index_Pullback:
+                case EntryType.Crypto_Pullback:
+                case EntryType.TC_Pullback:
+                case EntryType.XAU_Pullback:
+                    return Math.Min(maxBonus, 8);
+
+                default:
+                    return 0;
             }
         }
 


### PR DESCRIPTION
### Motivation
- TransitionDetector and FlagBreakoutDetector must not act as gates that block entries, they should only add positive scoring signals to favor setups.
- Existing logic treated detector validity as a precondition that could prevent score boost application; this change ensures detectors only enhance scores and never block entry flow.

### Description
- Updated `ApplyTransitionScoreBoost` in `Core/TradeCore.cs` to stop using `ctx.TransitionValid` / `ctx.FlagBreakoutConfirmed` as hard preconditions and to return only on null inputs.
- Compute independent bonuses: `transitionBonus` from `ctx.TransitionValid` / `ctx.TransitionScoreBonus` and `flagBreakoutBonus` (fixed `10` when `ctx.FlagBreakoutConfirmed`), then add both (when applicable) to each eligible entry's `Score` using `GetTransitionBoost(...)` and new `GetFlagBreakoutBoost(...)` type mappings, capping `Score` at `100` and appending a `[STRUCTURE+N]` reason tag.
- Preserved architecture, public interfaces, enums, exit/risk logic and all scoring thresholds; `TradeRouter.SelectEntry` and router logic were not changed.

### Testing
- Performed a repository-wide pattern search with `rg` to verify usages of transition/flag fields and to ensure no other detector-based hard-gates were introduced (search completed successfully).
- Attempted an automated build with `dotnet build`, but the environment lacks the `dotnet` CLI so the build could not be executed (failed due to missing tool), therefore no compile/run tests were performed in this environment.
- Verified the changed file locally via diff/inspection to ensure the new helper `GetFlagBreakoutBoost(...)` and the adjusted `ApplyTransitionScoreBoost(...)` structure are present and follow the intended non-blocking score-only behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2cda0a8e08328bb3024329ceb55a3)