### PR TITLE
Persist detector runtime state and propagate results into EntryContext to restore valid entries

### DIFF
--- a/Core/Entry/FlagBreakoutDetector.cs
+++ b/Core/Entry/FlagBreakoutDetector.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 
 namespace GeminiV26.Core.Entry
 {
     public sealed class FlagBreakoutDetector
     {
         private readonly Action<string> _log;
+        private readonly Dictionary<string, BreakoutRuntimeState> _stateBySymbol = new(StringComparer.OrdinalIgnoreCase);
 
         public FlagBreakoutDetector(Action<string> log)
         {
@@ -15,6 +17,16 @@ namespace GeminiV26.Core.Entry
         {
             if (ctx == null)
                 return;
+
+            string symbol = string.IsNullOrWhiteSpace(ctx.Symbol) ? "__DEFAULT__" : ctx.Symbol;
+            if (!_stateBySymbol.TryGetValue(symbol, out var state))
+            {
+                state = new BreakoutRuntimeState();
+                _stateBySymbol[symbol] = state;
+            }
+
+            ctx.FlagBreakoutConfirmed = state.FlagBreakoutConfirmed;
+            ctx.BreakoutBarsSince = state.BarsSinceBreakout;
 
             if (ctx.FlagBreakoutConfirmed)
             {
@@ -81,8 +93,18 @@ namespace GeminiV26.Core.Entry
                 ctx.BreakoutBarsSince = 0;
             }
 
+            state.FlagBreakoutConfirmed = ctx.FlagBreakoutConfirmed;
+            state.BarsSinceBreakout = Math.Min(Math.Max(0, ctx.BreakoutBarsSince), 999);
+
             _log?.Invoke($"[FLAG_BREAKOUT][RANGE] high={flagHigh:0.#####} low={flagLow:0.#####} bars={flagBars} lastClosedIndex={last}");
             _log?.Invoke($"[FLAG_BREAKOUT][CHECK] direction={ctx.TrendDirection} highBreak={highBreak} lowBreak={lowBreak} closeConfirm={closeConfirm} breakout={breakout} buffer={breakoutBuffer:0.#####} lastClosedIndex={last}");
+            _log?.Invoke($"[TRACE][DETECTOR_STATE] symbol={ctx.Symbol} barsSinceBreakout={state.BarsSinceBreakout} breakoutConfirmed={state.FlagBreakoutConfirmed}");
+        }
+
+        private sealed class BreakoutRuntimeState
+        {
+            public bool FlagBreakoutConfirmed { get; set; }
+            public int BarsSinceBreakout { get; set; } = 999;
         }
     }
 }

--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -1,14 +1,24 @@
 using System;
+using System.Collections.Generic;
 
 namespace GeminiV26.Core.Entry
 {
     public sealed class TransitionDetector
     {
+        private readonly Dictionary<string, TransitionRuntimeState> _stateBySymbol = new(StringComparer.OrdinalIgnoreCase);
+
         public TransitionEvaluation Evaluate(EntryContext ctx)
         {
             if (ctx == null || ctx.M5 == null || ctx.M5.Count < 12 || ctx.AtrM5 <= 0)
             {
                 return new TransitionEvaluation { Reason = "InsufficientData" };
+            }
+
+            string symbol = string.IsNullOrWhiteSpace(ctx.Symbol) ? "__DEFAULT__" : ctx.Symbol;
+            if (!_stateBySymbol.TryGetValue(symbol, out var state))
+            {
+                state = new TransitionRuntimeState();
+                _stateBySymbol[symbol] = state;
             }
 
             var rules = TransitionRules.ForInstrument(ResolveInstrumentType(ctx));
@@ -43,7 +53,7 @@ namespace GeminiV26.Core.Entry
             }
 
             bool hasImpulse = impulseIndex >= 0;
-            int barsSinceImpulse = hasImpulse ? last - impulseIndex : int.MaxValue;
+            int barsSinceImpulse = hasImpulse ? last - impulseIndex : Math.Min(state.BarsSinceImpulse + 1, 999);
             if (hasImpulse && barsSinceImpulse > rules.MaxImpulseAge)
             {
                 hasImpulse = false;
@@ -162,6 +172,24 @@ namespace GeminiV26.Core.Entry
 
             bool isValid = hasImpulse && hasPullback && (hasFlag || relaxedContinuation);
 
+            state.BarsSinceImpulse = hasImpulse ? barsSinceImpulse : Math.Min(state.BarsSinceImpulse + 1, 999);
+            state.BarsSincePullback = hasPullback ? 0 : Math.Min(state.BarsSincePullback + 1, 999);
+            state.BarsSinceFlag = hasFlag ? 0 : Math.Min(state.BarsSinceFlag + 1, 999);
+
+            ctx.HasImpulse_M5 = ctx.HasImpulse_M5 || hasImpulse;
+            ctx.BarsSinceImpulse_M5 = hasImpulse
+                ? Math.Min(ctx.BarsSinceImpulse_M5, barsSinceImpulse)
+                : Math.Min(Math.Max(0, ctx.BarsSinceImpulse_M5), 999);
+
+            if (hasPullback && ctx.AtrM5 > 0)
+            {
+                double impulseAtr = impulseRange / ctx.AtrM5;
+                double detectedPullbackDepthAtr = pullbackDepthR * impulseAtr;
+
+                if (detectedPullbackDepthAtr > 0)
+                    ctx.PullbackDepthAtr_M5 = Math.Max(ctx.PullbackDepthAtr_M5, detectedPullbackDepthAtr);
+            }
+
             double qualityScore = 0.0;
             int bonus = 0;
             if (isValid)
@@ -181,7 +209,7 @@ namespace GeminiV26.Core.Entry
             ctx.Log?.Invoke($"[TRANSITION][QUALITY] impulse={impulseStrength:0.00} compression={compressionScore:0.00} pullback={pullbackQuality:0.00} score={qualityScore:0.00} bonus={bonus}");
             ctx.Log?.Invoke($"[TRANSITION][DECISION] valid={isValid.ToString().ToLowerInvariant()} bonus={bonus} reason={reason}");
 
-            return new TransitionEvaluation
+            var evaluation = new TransitionEvaluation
             {
                 HasImpulse = hasImpulse,
                 HasPullback = hasPullback,
@@ -196,6 +224,18 @@ namespace GeminiV26.Core.Entry
                 BonusScore = bonus,
                 Reason = reason
             };
+
+            ctx.Log?.Invoke(
+                $"[TRACE][DETECTOR_STATE] symbol={ctx.Symbol} impulseSince={state.BarsSinceImpulse} pullbackSince={state.BarsSincePullback} flagSince={state.BarsSinceFlag} valid={evaluation.IsValid} reason={evaluation.Reason}");
+
+            return evaluation;
+        }
+
+        private sealed class TransitionRuntimeState
+        {
+            public int BarsSinceImpulse { get; set; } = 999;
+            public int BarsSincePullback { get; set; } = 999;
+            public int BarsSinceFlag { get; set; } = 999;
         }
 
         private static int FindPullbackEnd(EntryContext ctx, int start, int end, TradeDirection impulseDirection, int minBars)


### PR DESCRIPTION
### Motivation
- After adding `TransitionDetector` and `FlagBreakoutDetector`, the system rebuilt `EntryContext` every bar but did not preserve detector memory, causing every candidate to evaluate with missing/stale structure and become invalid (symptom: `barsSince=2147483647`).
- The intent is to keep detector-derived structure memory across bars so entry evaluators see real continuity (impulse freshness, pullback depth, confirmed flag breakout). Only detectors/state propagation may be changed.

### Description
- Added persistent, per-symbol runtime state to `TransitionDetector` (`_stateBySymbol`) to store bounded counters (`BarsSinceImpulse`, `BarsSincePullback`, `BarsSinceFlag`) and to avoid sentinel `int.MaxValue` behavior when no impulse is found.
- Transition detector now writes useful values back into the `EntryContext` (reinforces `HasImpulse_M5`, normalizes `BarsSinceImpulse_M5`, and merges a detected pullback depth into `PullbackDepthAtr_M5`) so downstream entry types consume real structure memory.
- Added persistent, per-symbol runtime state to `FlagBreakoutDetector` (`_stateBySymbol`) and rehydrate `ctx.FlagBreakoutConfirmed` / `ctx.BreakoutBarsSince` each bar, and persist updates so breakout confirmation/age survive `EntryContext` recreation.
- Added diagnostic trace logs (`[TRACE][DETECTOR_STATE]`) to both detectors to expose runtime state, and kept all changes limited to detectors and their runtime state classes (no scoring, router, risk, session, interface, or entry logic changes).

### Testing
- Ran static checks (`git diff --check`) and repository inspections; no whitespace or diff-check errors were produced.
- Verified pipeline ordering and integration by inspecting `TradeCore.OnBar` to confirm detectors run before entry evaluation and router selection remained unchanged.
- Performed repository-wide searches (`rg`) to confirm entry types consume the propagated fields (e.g. `HasImpulse_M5`, `PullbackDepthAtr_M5`, `FlagBreakoutConfirmed`) and that the router still selects only `IsValid` + score/priority.
- Full build/test could not be executed in this environment because no solution/project file was available in the workspace; runtime logs from added `[TRACE][DETECTOR_STATE]` were added for live verification during next run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d9b1895c8328988662f7f3765cc0)