### PR TITLE
Ensure EntryContext.Session inherits Global SessionGate bucket

### DIFF
--- a/Core/Entry/SessionResolver.cs
+++ b/Core/Entry/SessionResolver.cs
@@ -1,0 +1,26 @@
+using GeminiV26.Core;
+
+namespace GeminiV26.Core.Entry
+{
+    public static class SessionResolver
+    {
+        public static FxSession FromBucket(SessionBucket bucket)
+        {
+            switch (bucket)
+            {
+                case SessionBucket.Asia:
+                    return FxSession.Asia;
+
+                case SessionBucket.London:
+                case SessionBucket.LondonNyOverlap:
+                    return FxSession.London;
+
+                case SessionBucket.NewYork:
+                    return FxSession.NewYork;
+
+                default:
+                    return FxSession.Off;
+            }
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -875,61 +875,10 @@ namespace GeminiV26.Core
                 sessionCfg.MinAtrMultiplier);
 
             // =========================
-            // FX SESSION INJECT
+            // SESSION INJECT (STRICT FROM GLOBAL GATE BUCKET)
             // =========================
-            if (isFxSymbol) // ADDED: use instrument classification, not detector presence
-            {
-                if (IsSymbol("EURUSD"))
-                {
-                    if (_eurUsdSessionGate is EurUsdSessionGate sg) _ctx.Session = sg.GetSession();
-                    else _bot.Print("[TC] WARN: EURUSD session gate missing or wrong type");
-                }
-                else if (IsSymbol("USDJPY"))
-                {
-                    if (_usdJpySessionGate is UsdJpySessionGate sg) _ctx.Session = sg.GetSession();
-                    else _bot.Print("[TC] WARN: USDJPY session gate missing or wrong type");
-                }
-                else if (IsSymbol("GBPUSD"))
-                {
-                    if (_gbpUsdSessionGate is GbpUsdSessionGate sg) _ctx.Session = sg.GetSession();
-                    else _bot.Print("[TC] WARN: GBPUSD session gate missing or wrong type");
-                }
-                else if (IsSymbol("AUDUSD"))
-                {
-                    if (_audUsdSessionGate is AudUsdSessionGate sg) _ctx.Session = sg.GetSession();
-                    else _bot.Print("[TC] WARN: AUDUSD session gate missing or wrong type");
-                }
-                else if (IsSymbol("AUDNZD"))
-                {
-                    if (_audNzdSessionGate is AudNzdSessionGate sg) _ctx.Session = sg.GetSession();
-                    else _bot.Print("[TC] WARN: AUDNZD session gate missing or wrong type");
-                }
-                else if (IsSymbol("EURJPY"))
-                {
-                    if (_eurJpySessionGate is EurJpySessionGate sg) _ctx.Session = sg.GetSession();
-                    else _bot.Print("[TC] WARN: EURJPY session gate missing or wrong type");
-                }
-                else if (IsSymbol("GBPJPY"))
-                {
-                    if (_gbpJpySessionGate is GbpJpySessionGate sg) _ctx.Session = sg.GetSession();
-                    else _bot.Print("[TC] WARN: GBPJPY session gate missing or wrong type");
-                }
-                else if (IsSymbol("NZDUSD"))
-                {
-                    if (_nzdUsdSessionGate is NzdUsdSessionGate sg) _ctx.Session = sg.GetSession();
-                    else _bot.Print("[TC] WARN: NZDUSD session gate missing or wrong type");
-                }
-                else if (IsSymbol("USDCAD"))
-                {
-                    if (_usdCadSessionGate is UsdCadSessionGate sg) _ctx.Session = sg.GetSession();
-                    else _bot.Print("[TC] WARN: USDCAD session gate missing or wrong type");
-                }
-                else if (IsSymbol("USDCHF"))
-                {
-                    if (_usdChfSessionGate is UsdChfSessionGate sg) _ctx.Session = sg.GetSession();
-                    else _bot.Print("[TC] WARN: USDCHF session gate missing or wrong type");
-                }
-            }
+            _ctx.Session = SessionResolver.FromBucket(sessionDecision.Bucket);
+            _bot.Print("[CTX_SESSION_ASSIGN] sessionFromGate={0} sessionAssigned={1}", sessionDecision.Bucket, _ctx.Session);
 
             TradeType xauBias = TradeType.Buy;   // default
             int xauBiasConfidence = 0;


### PR DESCRIPTION
### Motivation
- Logs showed `SessionGate` producing a bucket (e.g. `NewYork`) but `EntryContext` receiving a different session (e.g. `Asia`), proving session assignment diverged after gate resolution.
- The entry context must strictly inherit the already-decided session bucket from the global gate to keep a single source of truth for session behavior.

### Description
- Added `Core/Entry/SessionResolver.cs` with `SessionResolver.FromBucket(SessionBucket)` to map `SessionBucket` → `FxSession` (`Asia`, `London`/`LondonNyOverlap`, `NewYork`, otherwise `Off`).
- Replaced the prior per-symbol `GetSession()` injection in `TradeCore` with `EntryContext.Session = SessionResolver.FromBucket(sessionDecision.Bucket)` so the context strictly inherits the global gate bucket.
- Inserted a debug log at assignment: `[CTX_SESSION_ASSIGN] sessionFromGate={0} sessionAssigned={1}` for runtime verification.
- Change is scoped to session assignment behavior and does not modify `XAU_FlagEntry`, session gate/matrix logic, scoring, or entry strategies.

### Testing
- Verified presence of new symbols with a code search: `rg -n "CTX_SESSION_ASSIGN|SessionResolver.FromBucket"` which located the new assignment and resolver.
- Ran a whitespace/syntax check using `git diff --check` which reported no issues.
- Confirmed the modified `TradeCore` now prints the debug line and that the resolver file exists by listing the modified files; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b315be2a4483288bf3e7fd6b4cbf14)