### PR TITLE
METAL: improve market-regime detection using ADX and EMA compression

### DIFF
--- a/Instruments/METAL/MetalMarketStateDetector.cs
+++ b/Instruments/METAL/MetalMarketStateDetector.cs
@@ -12,11 +12,17 @@ namespace GeminiV26.Instruments.METAL
         private readonly Robot _bot;
         private readonly Bars _bars;
         private readonly AverageTrueRange _atr;
+        private readonly AverageDirectionalMovementIndexRating _adx;
+        private readonly ExponentialMovingAverage _ema8;
+        private readonly ExponentialMovingAverage _ema21;
 
         // Instrument-szintű threshold (nem EntryTypes!)
         private readonly double _minAtrPips;
 
         private const int ATR_PERIOD = 14;
+        private const int ADX_PERIOD = 14;
+        private const int EMA_FAST_PERIOD = 8;
+        private const int EMA_SLOW_PERIOD = 21;
 
         /// <param name="bot">cTrader Robot instance</param>
         /// <param name="minAtrPips">
@@ -33,6 +39,18 @@ namespace GeminiV26.Instruments.METAL
                 _bars,
                 ATR_PERIOD,
                 MovingAverageType.Exponential);
+
+            _adx = bot.Indicators.AverageDirectionalMovementIndexRating(
+                _bars,
+                ADX_PERIOD);
+
+            _ema8 = bot.Indicators.ExponentialMovingAverage(
+                _bars.ClosePrices,
+                EMA_FAST_PERIOD);
+
+            _ema21 = bot.Indicators.ExponentialMovingAverage(
+                _bars.ClosePrices,
+                EMA_SLOW_PERIOD);
         }
 
         public MetalMarketState Evaluate()
@@ -44,13 +62,49 @@ namespace GeminiV26.Instruments.METAL
             double atrRaw = _atr.Result[i];
             double atrPips = atrRaw / _bot.Symbol.PipSize;
 
-            bool isLowVol = atrPips < _minAtrPips;
+            double adx = _adx.ADX[i];
+            double emaDist = System.Math.Abs(_ema8.Result[i] - _ema21.Result[i]);
+            double emaDistATR = atrRaw > 0 ? emaDist / atrRaw : 0;
 
-            return new MetalMarketState
+            bool lowVol = atrPips < _minAtrPips;
+            bool trend = adx > 30;
+            bool compression = emaDistATR < 0.5;
+            bool hardRange = compression && adx < 25;
+
+            if (adx > 40)
+                hardRange = false;
+
+            _bot.Print(
+                "[XAU MSD] atrPips={0:F1} adx={1:F1} emaDistATR={2:F2} lowVol={3} trend={4} compression={5} hardRange={6}",
+                atrPips,
+                adx,
+                emaDistATR,
+                lowVol,
+                trend,
+                compression,
+                hardRange);
+
+            var state = new MetalMarketState
             {
                 AtrPips = atrPips,
-                IsRange = isLowVol
+                IsRange = lowVol && !trend
             };
+
+            TrySetStateValue(state, "Adx", adx);
+            TrySetStateValue(state, "EmaDistanceAtr", emaDistATR);
+            TrySetStateValue(state, "IsTrend", trend);
+            TrySetStateValue(state, "IsLowVol", lowVol);
+            TrySetStateValue(state, "IsCompression", compression);
+            TrySetStateValue(state, "IsHardRange", hardRange);
+
+            return state;
+        }
+
+        private static void TrySetStateValue(MetalMarketState state, string propertyName, object value)
+        {
+            var property = typeof(MetalMarketState).GetProperty(propertyName);
+            if (property?.CanWrite == true)
+                property.SetValue(state, value);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- ATR-only range detection misclassifies strong trends with short compression as HARD RANGE, causing valid trend entries to be blocked.
- Add ADX and EMA-distance/ATR metrics to better distinguish trend vs compression vs low-volatility range while preserving existing interfaces.

### Description
- Initialize ADX via `AverageDirectionalMovementIndexRating(_bars, 14)` and EMA(8)/EMA(21) via `ExponentialMovingAverage` in the detector constructor while keeping the constructor signature unchanged.
- Compute `adx`, `emaDist`, and `emaDistATR` in `Evaluate()` and derive booleans `lowVol`, `trend` (`adx > 30`), `compression` (`emaDistATR < 0.5`), and `hardRange` (`compression && adx < 25`) with the mandatory override `if (adx > 40) hardRange = false` to avoid misclassifying strong trends.
- Replace the previous `IsRange = isLowVol` rule with `IsRange = lowVol && !trend` and add a debug print using the bot logging style to output ATR/ADX/EMA-compression diagnostics: `"[XAU MSD] atrPips=... adx=... emaDistATR=... lowVol=... trend=... compression=... hardRange=..."`.
- Populate additional regime values (`Adx`, `EmaDistanceAtr`, `IsTrend`, `IsLowVol`, `IsCompression`, `IsHardRange`) into the returned `MetalMarketState` using a guarded reflection helper `TrySetStateValue(...)` so the change is non-breaking when `MetalMarketState` lacks those properties.

### Testing
- Attempted an automated build with `dotnet build -nologo`, which failed because `dotnet` is not available in the execution environment (build could not be completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b31aadfd588328a25fecb69b5d1960)