### PR TITLE
Fix METAL ADX indicator constructor signature

### DIFF
--- a/Instruments/METAL/MetalMarketStateDetector.cs
+++ b/Instruments/METAL/MetalMarketStateDetector.cs
@@ -40,9 +40,7 @@ namespace GeminiV26.Instruments.METAL
                 ATR_PERIOD,
                 MovingAverageType.Exponential);
 
-            _adx = bot.Indicators.AverageDirectionalMovementIndexRating(
-                _bars,
-                ADX_PERIOD);
+            _adx = bot.Indicators.AverageDirectionalMovementIndexRating(ADX_PERIOD);
 
             _ema8 = bot.Indicators.ExponentialMovingAverage(
                 _bars.ClosePrices,


### PR DESCRIPTION
### Motivation
- Fix compile-time errors caused by calling `AverageDirectionalMovementIndexRating` with a `Bars` argument in `MetalMarketStateDetector` by using the correct overload that accepts only the period.

### Description
- Change ADX initialization in `Instruments/METAL/MetalMarketStateDetector.cs` from `AverageDirectionalMovementIndexRating(_bars, ADX_PERIOD)` to `AverageDirectionalMovementIndexRating(ADX_PERIOD)`.

### Testing
- Ran `rg "AverageDirectionalMovementIndexRating\\(\\s*_bars" -n Instruments` and confirmed no remaining usages were found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b31c1404cc8328b78751ef4b14dfcd)