### PR TITLE
Fix XAU metal market-state propagation into entry context

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -702,7 +702,7 @@ namespace GeminiV26.Core
             {
                 xauState = _xauMarketStateDetector.Evaluate();
                 if (xauState != null)
-                    _bot.Print($"[XAU MarketState] {rawSym} Range={xauState.IsRange}");
+                    _bot.Print($"[XAU MarketState] {rawSym} Range={xauState.IsRange} Trend={xauState.IsTrend} ADX={xauState.Adx:F1} HardRange={xauState.IsHardRange}");
             }
             else if (isIndex)
             {
@@ -838,6 +838,37 @@ namespace GeminiV26.Core
             {
                 _bot.Print("[TC] BLOCKED: EntryContext not ready");
                 return;
+            }
+
+
+            if (isMetalSymbol)
+            {
+                if (xauState == null && _xauMarketStateDetector != null)
+                    xauState = _xauMarketStateDetector.Evaluate();
+
+                if (xauState != null)
+                {
+                    _ctx.MarketState = new IndexMarketState
+                    {
+                        AtrPoints = xauState.AtrPips,
+                        Adx = xauState.Adx,
+                        IsLowVol = xauState.IsLowVol,
+                        IsTrend = xauState.IsTrend,
+                        IsRange = xauState.IsRange,
+                        RangePoints = xauState.RangeWidth
+                    };
+
+                    _bot.Print(
+                        "[XAU STATE ASSIGN] trend={0} adx={1:F1} range={2} hardRange={3}",
+                        xauState.IsTrend,
+                        xauState.Adx,
+                        xauState.IsRange,
+                        xauState.IsHardRange);
+                }
+                else
+                {
+                    _bot.Print("[XAU STATE ASSIGN] trend= adx= range= hardRange=");
+                }
             }
 
             _ctx.LastUpdateUtc = DateTime.UtcNow;

--- a/Instruments/METAL/MetalMarketState.cs
+++ b/Instruments/METAL/MetalMarketState.cs
@@ -9,7 +9,19 @@ namespace GeminiV26.Instruments.METAL
     /// </summary>
     public sealed class MetalMarketState
     {
-        public double AtrPips { get; init; }
-        public bool IsRange { get; init; }
+        public double AtrPips { get; set; }
+        public double Adx { get; set; }
+
+        public bool IsLowVol { get; set; }
+        public bool IsTrend { get; set; }
+        public bool IsCompression { get; set; }
+        public bool IsHardRange { get; set; }
+        public bool IsRange { get; set; }
+
+        public double EmaDistanceAtr { get; set; }
+
+        // Backward-compatible aliases for old consumers
+        public double Atr => AtrPips;
+        public double RangeWidth => EmaDistanceAtr;
     }
 }

--- a/Instruments/METAL/MetalMarketStateDetector.cs
+++ b/Instruments/METAL/MetalMarketStateDetector.cs
@@ -82,27 +82,17 @@ namespace GeminiV26.Instruments.METAL
                 compression,
                 hardRange);
 
-            var state = new MetalMarketState
+            return new MetalMarketState
             {
                 AtrPips = atrPips,
-                IsRange = lowVol && !trend
+                Adx = adx,
+                IsLowVol = lowVol,
+                IsTrend = trend,
+                IsCompression = compression,
+                IsHardRange = hardRange,
+                IsRange = lowVol && !trend,
+                EmaDistanceAtr = emaDistATR
             };
-
-            TrySetStateValue(state, "Adx", adx);
-            TrySetStateValue(state, "EmaDistanceAtr", emaDistATR);
-            TrySetStateValue(state, "IsTrend", trend);
-            TrySetStateValue(state, "IsLowVol", lowVol);
-            TrySetStateValue(state, "IsCompression", compression);
-            TrySetStateValue(state, "IsHardRange", hardRange);
-
-            return state;
-        }
-
-        private static void TrySetStateValue(MetalMarketState state, string propertyName, object value)
-        {
-            var property = typeof(MetalMarketState).GetProperty(propertyName);
-            if (property?.CanWrite == true)
-                property.SetValue(state, value);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Repair the XAU (Metal) market-state pipeline so detector output (ADX / trend / range / compression / ATR) is reliably available to downstream entry logic in the same bar.
- Eliminate fragile reflection-based assignments that caused fields to be missing or default when `XAU_PullbackEntry` consumed `ctx.MarketState`.
- Add trace logging to prove detector → context propagation without changing any strategy thresholds or trading rules.

### Description
- Extended `Instruments/METAL/MetalMarketState.cs` with strongly-typed, writable properties: `AtrPips`, `Adx`, `IsLowVol`, `IsTrend`, `IsCompression`, `IsHardRange`, `IsRange`, `EmaDistanceAtr`, and provided backward-compatible aliases `Atr` and `RangeWidth`.
- Replaced the reflection-based `TrySetStateValue` usage in `Instruments/METAL/MetalMarketStateDetector.cs` with an explicit, compile-safe return of a fully populated `MetalMarketState` instance while preserving the improved regime logic (lowVol, trend/adx thresholds, compression, hardRange rules and `adx > 40` override).
- Populated the entry `EntryContext.MarketState` for METAL symbols inside `Core/TradeCore.cs` by mapping the detector `xauState` into an `IndexMarketState` snapshot so downstream entry checks (e.g. `XAU_PullbackEntry`) read the same values computed by the detector.
- Added and expanded logging to make the full path visible in one bar: enhanced `[XAU MarketState]` output and a new `[XAU STATE ASSIGN]` trace showing `trend`, `adx`, `range` and `hardRange` at assignment time.
- Preserved all thresholds, risk sizing, routing, session and detector scoring logic per guardrails.

### Testing
- Attempted an automated build with `dotnet build GeminiV26.csproj`, but the environment lacks `dotnet` so the build could not be executed (failed: `dotnet` not found).
- No automated unit tests were configured/executed in this environment; changes are limited to type/property wiring and runtime log traces to enable verification in a live or build-capable environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3200b61e48328b52f80d02065b6b1)