### PR TITLE
Fix cTrader API thread-safety in background logging flows

### DIFF
--- a/Core/Logging/CsvTradeLogger.cs
+++ b/Core/Logging/CsvTradeLogger.cs
@@ -43,10 +43,11 @@ namespace GeminiV26.Core.Logging
             if (context == null)
                 return;
 
-            _writer.Enqueue(() => WriteRecord(context, position, result));
+            var snapshot = TradeSnapshot.From(position);
+            _writer.Enqueue(() => WriteRecord(context, snapshot, result));
         }
 
-        private void WriteRecord(TradeLogContext context, Position position, TradeLogResult result)
+        private void WriteRecord(TradeLogContext context, TradeSnapshot snapshot, TradeLogResult result)
         {
             string path = null;
             try
@@ -60,7 +61,7 @@ namespace GeminiV26.Core.Logging
 
                 var values = new[]
                 {
-                    Csv(context.TradeId ?? position?.Id.ToString(CultureInfo.InvariantCulture)),
+                    Csv(context.TradeId ?? snapshot?.PositionIdText),
                     Csv(context.Symbol),
                     Csv(context.PositionId?.ToString(CultureInfo.InvariantCulture)),
                     Csv(context.Direction),
@@ -70,7 +71,7 @@ namespace GeminiV26.Core.Logging
                     Csv(context.PendingMeta?.EntryReason ?? pctx?.EntryReason),
                     Csv(pctx?.EntryTime.ToString("O", CultureInfo.InvariantCulture)),
                     CsvNum(pctx?.EntryPrice),
-                    CsvNum(position?.VolumeInUnits ?? pctx?.EntryVolumeInUnits),
+                    CsvNum(snapshot?.VolumeInUnits ?? pctx?.EntryVolumeInUnits),
 
                     CsvNum(pctx?.EntryScore),
                     CsvNum(pctx?.LogicConfidence),
@@ -150,6 +151,24 @@ namespace GeminiV26.Core.Logging
         private static string CsvBool(bool? value)
         {
             return value.HasValue ? value.Value.ToString() : "";
+        }
+
+        private sealed class TradeSnapshot
+        {
+            public string PositionIdText { get; set; }
+            public double? VolumeInUnits { get; set; }
+
+            public static TradeSnapshot From(Position position)
+            {
+                if (position == null)
+                    return null;
+
+                return new TradeSnapshot
+                {
+                    PositionIdText = position.Id.ToString(CultureInfo.InvariantCulture),
+                    VolumeInUnits = position.VolumeInUnits
+                };
+            }
         }
     }
 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -361,12 +361,13 @@ namespace GeminiV26.Core
             _entryRouter = new EntryRouter(_entryTypes);
             _contextBuilder = new EntryContextBuilder(bot);
             _transitionDetector = new TransitionDetector();
-            _flagBreakoutDetector = new FlagBreakoutDetector(_bot.Print);
-            _logWriter = new LogWriter(msg => _bot.Print(msg));
+            Action<string> safePrint = msg => _bot.BeginInvokeOnMainThread(() => _bot.Print(msg));
+            _flagBreakoutDetector = new FlagBreakoutDetector(safePrint);
+            _logWriter = new LogWriter(safePrint);
             _logger = new CompositeTradeLogger(
-                new CsvTradeLogger(_logWriter, msg => _bot.Print(msg)),
-                new CsvAnalyticsLogger(_logWriter, msg => _bot.Print(msg)));
-            _statsTracker = new TradeStatsTracker(_bot.Print);
+                new CsvTradeLogger(_logWriter, safePrint),
+                new CsvAnalyticsLogger(_logWriter, safePrint));
+            _statsTracker = new TradeStatsTracker(safePrint);
             _globalSessionGate = new GlobalSessionGate(_bot);
             _sessionMatrix = new SessionMatrix(new SessionMatrixProvider());
 


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes caused by calling cTrader API (e.g. `Print`, `Position` properties) from background worker threads used by logging.
- Keep trading logic, thresholds, risk sizing and architecture unchanged while making minimal safety fixes around cTrader API usage.

### Description
- Introduced a `safePrint` delegate in `TradeCore` that marshals `Print` calls to the main thread via `_bot.BeginInvokeOnMainThread(() => _bot.Print(msg))` and wired it into `FlagBreakoutDetector`, `LogWriter`, `CsvTradeLogger`, `CsvAnalyticsLogger`, and `TradeStatsTracker`.
- Reworked `CsvTradeLogger.OnTradeClosed` to snapshot required `Position` data (`Id` and `VolumeInUnits`) on the caller thread into a small `TradeSnapshot` object and enqueue that snapshot so the background worker no longer dereferences cTrader `Position` objects.
- Left `LogWriter` worker thread intact (no refactor) but removed all direct cTrader API usage from enqueued actions by either marshaling prints or snapshotting data.
- Changes confined to `Core/TradeCore.cs` and `Core/Logging/CsvTradeLogger.cs` and do not modify strategy rules, scoring, or behavior.

### Testing
- Ran a project-wide regex scan for background-thread constructs and verified the only background worker is `LogWriter` and unsafe cTrader API usage in its paths has been removed; scan succeeded.
- Inspected `LogWriter`, `TradeCore`, and `CsvTradeLogger` source to confirm `Print` is marshalled via `BeginInvokeOnMainThread` and that `Position` access is snapshot before enqueue; inspection succeeded.
- Verified search for `BeginInvokeOnMainThread` and `Print` usages shows the marshaling delegate is used in logging/error print paths; verification succeeded.
- Performed local diffs to confirm the intended code changes were applied to the two files; diff checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3224b5f3c8328b841c5a86f0c0c20)