### PR TITLE
Fix hard-loss guard monetary limit scaling to stop instant exits

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2061,8 +2061,23 @@ namespace GeminiV26.Core
                 if (!_positionContexts.TryGetValue(pos.Id, out var ctx))
                     continue;
 
-                double slPips = ctx.RiskPriceDistance / _bot.Symbol.PipSize;
-                double slRisk = slPips * _bot.Symbol.PipValue * ctx.EntryVolumeInUnits;
+                // A hard-loss guard monetary limitjét ugyanazzal a dimenzióval számoljuk,
+                // mint a risk sizing: price-distance × value-per-price × volume(units).
+                // A korábbi pips × pipValue × units képlet instrumentenként félreskálázódott,
+                // ezért gyakorlatilag 0-hoz közeli limitet adott és azonnali zárást okozott.
+                double valuePerPricePerUnit =
+                    _bot.Symbol.TickSize > 0
+                        ? (_bot.Symbol.TickValue / _bot.Symbol.TickSize)
+                        : 0.0;
+
+                double volumeUnits = pos.VolumeInUnits > 0
+                    ? pos.VolumeInUnits
+                    : ctx.EntryVolumeInUnits;
+
+                double slRisk = ctx.RiskPriceDistance * valuePerPricePerUnit * volumeUnits;
+                if (slRisk <= 0 || double.IsNaN(slRisk) || double.IsInfinity(slRisk))
+                    continue;
+
                 double hardLimit = -(slRisk * 1.5);
 
 


### PR DESCRIPTION
### Motivation
- Logs showed immediate `[HARD LOSS EXIT]` right after entry with `limit=-0.00`, indicating the hard-loss threshold was being computed in the wrong units and under‑scaled for some instruments.
- The hard-loss check must use the same monetary/dimensional basis as the risk sizer so it reflects a real monetary loss, not a near-zero threshold that closes trades immediately.

### Description
- Replaced the pips-based formula with a monetary calculation: `slRisk = RiskPriceDistance * (TickValue / TickSize) * VolumeInUnits` in `Core/TradeCore.cs` to align with risk sizing semantics.
- Prefer the live position volume (`pos.VolumeInUnits`) and fall back to `ctx.EntryVolumeInUnits` when the live volume is not present.
- Added defensive guards to skip the hard-loss decision when `slRisk` is zero/invalid/NaN/infinite so no spurious closes occur.
- Updated logging to continue printing the hard-loss information using the corrected `hardLimit` dimension.

### Testing
- Ran repository searches (`rg`) and file reads (`sed`, `nl`) to validate the patched logic location and surrounding context, and they showed the corrected calculation in `Core/TradeCore.cs` (inspection succeeded).
- Verified the code diff locally via file inspection, confirming the new `valuePerPricePerUnit`, `volumeUnits`, `slRisk` computation and guard.
- Attempted `dotnet build` but it could not be executed in this environment (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3cc3f90d88328b99684b619bb522b)