### PR TITLE
Apply MissingImpulse 6-point penalty to FlagEntry scoring across instruments

### DIFF
--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -172,6 +172,18 @@ namespace GeminiV26.EntryTypes.Crypto
                 score -= HtfAgainstPenalty;
             }
 
+            bool missingImpulse =
+                string.Equals(ctx.Transition?.Reason, "MissingImpulse", StringComparison.Ordinal);
+
+            if (missingImpulse)
+            {
+                score = Math.Max(0, score - 6);
+
+                ctx.Log?.Invoke(
+                    "[FLAG][PENALTY] Missing impulse detected → score penalty applied " +
+                    $"symbol={ctx.Symbol} entry={EntryType.Crypto_Flag} penalty=6 score={score}");
+            }
+
             if (score < MinScore)
                 return Invalid(ctx, $"LOW_SCORE({score})");
 

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -836,6 +836,18 @@ namespace GeminiV26.EntryTypes.FX
             if (!hasTrigger && !ctx.IsAtrExpanding_M5 && score < tuning.MinScore + 2)
                 ApplyPenalty(3);
 
+            bool missingImpulse =
+                string.Equals(ctx.Transition?.Reason, "MissingImpulse", StringComparison.Ordinal);
+
+            if (missingImpulse)
+            {
+                score = Math.Max(0, score - 6);
+
+                ctx.Log?.Invoke(
+                    "[FLAG][PENALTY] Missing impulse detected → score penalty applied " +
+                    $"symbol={ctx.Symbol} entry={EntryType.FX_Flag} penalty=6 score={score}");
+            }
+
             // FINAL MIN SCORE
             int min = tuning.MinScore;
 

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -413,6 +413,18 @@ namespace GeminiV26.EntryTypes.INDEX
 
             score = (int)Math.Round(score * scoreMultiplier);
 
+            bool missingImpulse =
+                string.Equals(ctx.Transition?.Reason, "MissingImpulse", StringComparison.Ordinal);
+
+            if (missingImpulse)
+            {
+                score = Math.Max(0, score - 6);
+
+                ctx.Log?.Invoke(
+                    "[FLAG][PENALTY] Missing impulse detected → score penalty applied " +
+                    $"symbol={ctx.Symbol} entry={Type} penalty=6 score={score}");
+            }
+
             ctx.Log?.Invoke(
                 $"[IDX_FLAG][FINAL] dir={dir} score={score} flagATR={flagAtr:F2} slopeATR={flagSlopeAtr:F2} " +
                 $"emaDistATR={distFromEmaAtr:F2} fatigue={fatigueCount}/{fatigueThreshold}"

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -319,6 +319,18 @@ namespace GeminiV26.EntryTypes.METAL
                 // ignore if field not present
             }
 
+            bool missingImpulse =
+                string.Equals(ctx.Transition?.Reason, "MissingImpulse", StringComparison.Ordinal);
+
+            if (missingImpulse)
+            {
+                score = Math.Max(0, score - 6);
+
+                ctx.Log?.Invoke(
+                    "[FLAG][PENALTY] Missing impulse detected → score penalty applied " +
+                    $"symbol={ctx.Symbol} entry={EntryType.XAU_Flag} penalty=6 score={score}");
+            }
+
             bool nearThreshold = score >= (minScore - 3);
             bool strongContext =
                 ctx.MarketState?.IsTrend == true &&


### PR DESCRIPTION
### Motivation
- Some flag setups reach consolidation without a proper impulse identified by `ctx.Transition?.Reason == "MissingImpulse"`, which should reduce quality but not hard-block the entry.
- The goal is to penalize these cases by a fixed score deduction while preserving existing pipeline behavior and return semantics.

### Description
- Added a `missingImpulse` detection using `string.Equals(ctx.Transition?.Reason, "MissingImpulse", StringComparison.Ordinal)` in each FlagEntry implementation (`FX_FlagEntry`, `Index_FlagEntry`, `BTC_FlagEntry`, `XAU_FlagEntry`).
- When detected, apply `score = Math.Max(0, score - 6)` to reduce the score by 6 with a floor at 0 and keep evaluation flow unchanged.
- Emit a standardized log line starting with `[FLAG][PENALTY] Missing impulse detected → score penalty applied` that includes `symbol`, `entry type`, `penalty`, and the updated `score`.
- The penalty is applied after the base/quality score calculation and before the final min-score validation / `EntryEvaluation` is returned in each module, and no other modules or pipeline logic were modified.

### Testing
- Confirmed the penalty was added to the four target files: `EntryTypes/FX/FX_FlagEntry.cs`, `EntryTypes/INDEX/Index_FlagEntry.cs`, `EntryTypes/CRYPTO/BTC_FlagEntry.cs`, and `EntryTypes/METAL/XAU_FlagEntry.cs` using repository search (`rg`) and inspected surrounding context with file excerpts.
- Verified occurrences of the new log message and `missingImpulse` check across the four files with `rg -n "Missing impulse detected|missingImpulse|Transition\?\.Reason"` which returned entries in all modified files.
- Attempted an automated build with `dotnet build` but it could not run in this environment because `dotnet` is not installed, so compilation was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e7b1390c8328bd998193eac48e22)