### PR TITLE
Fix FlagEntry fallback when both directions are invalid

### DIFF
--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -95,8 +95,17 @@ namespace GeminiV26.EntryTypes.Crypto
             var longEval = EvaluateSide(ctx, TradeDirection.Long, hi, lo, rangeAtr, lastClosed);
             var shortEval = EvaluateSide(ctx, TradeDirection.Short, hi, lo, rangeAtr, lastClosed);
 
-            if (longEval.IsValid && !shortEval.IsValid) return longEval;
-            if (!longEval.IsValid && shortEval.IsValid) return shortEval;
+            bool buyValid = longEval.IsValid;
+            bool sellValid = shortEval.IsValid;
+
+            if (!buyValid && !sellValid)
+            {
+                ctx.Log?.Invoke($"[FLAG][REJECT] No valid direction buyValid={buyValid} sellValid={sellValid}");
+                return Invalid(ctx, "FLAG_DIRECTION_INVALID");
+            }
+
+            if (buyValid && !sellValid) return longEval;
+            if (!buyValid && sellValid) return shortEval;
 
             return longEval.Score >= shortEval.Score ? longEval : shortEval;
         }

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -47,15 +47,21 @@ namespace GeminiV26.EntryTypes.FX
             ApplyScoreModifier(longEval, matrix);
             ApplyScoreModifier(shortEval, matrix);
 
+            bool buyValid = longEval.IsValid;
+            bool sellValid = shortEval.IsValid;
+
+            if (!buyValid && !sellValid)
+            {
+                ctx.Log?.Invoke($"[FLAG][REJECT] No valid direction buyValid={buyValid} sellValid={sellValid}");
+                return Invalid(ctx, TradeDirection.None, "FLAG_DIRECTION_INVALID", Math.Max(longEval.Score, shortEval.Score));
+            }
+
             // Prefer VALID; if both valid -> higher score wins
-            if (longEval.IsValid && shortEval.IsValid)
+            if (buyValid && sellValid)
                 return (longEval.Score >= shortEval.Score) ? longEval : shortEval;
 
-            if (longEval.IsValid) return longEval;
-            if (shortEval.IsValid) return shortEval;
-
-            // If none valid -> return the "better" one (higher score), so TR logs show the closest candidate
-            return (longEval.Score >= shortEval.Score) ? longEval : shortEval;
+            if (buyValid) return longEval;
+            return shortEval;
         }
 
         // =====================================================

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -102,13 +102,20 @@ namespace GeminiV26.EntryTypes.INDEX
             longEval.Score += (int)Math.Round(matrix.EntryScoreModifier);
             shortEval.Score += (int)Math.Round(matrix.EntryScoreModifier);
 
-            if (longEval.IsValid && shortEval.IsValid)
+            bool buyValid = longEval.IsValid;
+            bool sellValid = shortEval.IsValid;
+
+            if (!buyValid && !sellValid)
+            {
+                ctx.Log?.Invoke($"[FLAG][REJECT] No valid direction buyValid={buyValid} sellValid={sellValid}");
+                return Reject(ctx, "FLAG_DIRECTION_INVALID", Math.Max(longEval.Score, shortEval.Score), TradeDirection.None);
+            }
+
+            if (buyValid && sellValid)
                 return longEval.Score >= shortEval.Score ? longEval : shortEval;
 
-            if (longEval.IsValid) return longEval;
-            if (shortEval.IsValid) return shortEval;
-
-            return longEval.Score >= shortEval.Score ? longEval : shortEval;
+            if (buyValid) return longEval;
+            return shortEval;
         }
 
         private EntryEvaluation EvaluateDir(

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -119,6 +119,20 @@ namespace GeminiV26.EntryTypes.METAL
             var sellEval = EvaluateSide(TradeDirection.Short, ctx, session, tag, tuning, profile, hi, lo, rangeAtr, lastBar, last, baseReasons);
             ctx.Log?.Invoke($"[XAU_FLAG][SIDE_CHECK] buyValid={buyEval.IsValid} sellValid={sellEval.IsValid}");
 
+            if (!buyEval.IsValid && !sellEval.IsValid)
+            {
+                ctx.Log?.Invoke($"[FLAG][REJECT] No valid direction buyValid={buyEval.IsValid} sellValid={sellEval.IsValid}");
+
+                return InvalidDecisionNone(
+                    ctx, session, tag,
+                    tuning.BaseScore, tuning.MinScore,
+                    "FLAG_DIRECTION_INVALID",
+                    baseReasons,
+                    buyEval,
+                    sellEval
+                );
+            }
+
             // ===== decision =====
             if (buyEval.IsValid && !sellEval.IsValid) return buyEval;
             if (!buyEval.IsValid && sellEval.IsValid) return sellEval;
@@ -145,7 +159,7 @@ namespace GeminiV26.EntryTypes.METAL
             var bias = ResolveHtfBias(ctx);
             ctx.Log?.Invoke($"[XAU_FLAG][FALLBACK_CHECK] score={fallbackScore} min={minScore} bias={bias}");
 
-            if (!buyEval.IsValid && !sellEval.IsValid && fallbackScore >= minScore)
+            if (fallbackScore >= minScore)
             {
                 if (bias == TradeDirection.Short || bias == TradeDirection.Long)
                 {


### PR DESCRIPTION
### Motivation
- Prevent FlagEntry implementations from accepting a direction via fallback when both `buyValid` and `sellValid` are false, which previously allowed trades like `HTF_BIAS_FALLBACK_SELL` despite both side evaluations being invalid.
- Ensure fallback direction logic (HTF bias, session profile fallback, direction overrides) only runs when at least one side was previously considered valid.

### Description
- Added an early two-side validity guard to `FX_FlagEntry`, `Index_FlagEntry`, `BTC_FlagEntry`, and `XAU_FlagEntry` that logs `[FLAG][REJECT] No valid direction buyValid={buyValid} sellValid={sellValid}` and immediately returns an invalid evaluation (`FLAG_DIRECTION_INVALID`) when both sides are invalid.
- Moved/ensured the new guard executes before any fallback logic such as HTF bias fallback (notably in `XAU_FlagEntry`) so no fallback can produce a valid direction when both `buyValid` and `sellValid` are false.
- Changes are localized to the four FlagEntry implementations and do not modify `TradeCore`, `EntryRouter`, `RiskSizer`, `ExitManager`, or scoring logic.

### Testing
- Searched and inspected modified files and verified the new guard and log lines exist in `EntryTypes/FX/FX_FlagEntry.cs`, `EntryTypes/INDEX/Index_FlagEntry.cs`, `EntryTypes/CRYPTO/BTC_FlagEntry.cs`, and `EntryTypes/METAL/XAU_FlagEntry.cs` using `rg`/file checks, which succeeded.
- Committed the changes and verified the working tree is clean with `git status` and commit output, which succeeded.
- Attempted a `dotnet build` for compile verification but it failed in this environment because `dotnet` is not installed (`bash: command not found: dotnet`), so a full compile/test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f436b3788328b1be2c125d41b5b2)