### PR TITLE
Add new market-state signals: Crypto Expansion, FX Compression, Index Momentum, Metal Spike

### DIFF
--- a/Instruments/CRYPTO/CryptoMarketState.cs
+++ b/Instruments/CRYPTO/CryptoMarketState.cs
@@ -18,5 +18,6 @@ namespace GeminiV26.Instruments.CRYPTO
 
         public bool IsLowVol { get; init; }
         public bool IsTrend { get; init; }
+        public bool IsExpansion { get; init; }
     }
 }

--- a/Instruments/CRYPTO/CryptoMarketStateDetector.cs
+++ b/Instruments/CRYPTO/CryptoMarketStateDetector.cs
@@ -41,16 +41,18 @@ namespace GeminiV26.Instruments.CRYPTO
                 return null;
 
             double atr = _atr.Result[i];
+            double atrPrev = _atr.Result[i - 5];
             double adx = _dms.ADX[i];
 
             bool isHighVol = atr > 100;
             bool isLowVol = atr < 40;
             bool isTrend = adx >= 18;
+            bool isExpansion = atr > atrPrev * 1.2;
 
             _bot.Print(
                 $"[CRYPTO MSD] {_bot.SymbolName} | " +
                 $"ATR={atr:F1} ADX={adx:F1} " +
-                $"HighVol={isHighVol} LowVol={isLowVol} Trend={isTrend}");
+                $"HighVol={isHighVol} LowVol={isLowVol} Trend={isTrend} Expansion={isExpansion}");
 
             return new CryptoMarketState
             {
@@ -59,7 +61,8 @@ namespace GeminiV26.Instruments.CRYPTO
                 Adx = adx,
                 IsHighVol = isHighVol,
                 IsLowVol = isLowVol,
-                IsTrend = isTrend
+                IsTrend = isTrend,
+                IsExpansion = isExpansion
             };
         }
     }

--- a/Instruments/FX/FxMarketState.cs
+++ b/Instruments/FX/FxMarketState.cs
@@ -18,5 +18,6 @@
         // === Értelmezett állapotjelzők ===
         public bool IsLowVol { get; init; }
         public bool IsTrend { get; init; }
+        public bool IsCompression { get; init; }
     }
 }

--- a/Instruments/FX/FxMarketStateDetector.cs
+++ b/Instruments/FX/FxMarketStateDetector.cs
@@ -19,6 +19,8 @@ namespace GeminiV26.Instruments.FX
 
         private readonly AverageTrueRange _atr;
         private readonly DirectionalMovementSystem _adx;
+        private readonly ExponentialMovingAverage _ema8;
+        private readonly ExponentialMovingAverage _ema21;
 
         private readonly FxInstrumentProfile _profile;
 
@@ -41,6 +43,9 @@ namespace GeminiV26.Instruments.FX
             _adx = bot.Indicators.DirectionalMovementSystem(
                 _bars,
                 ADX_PERIOD);
+
+            _ema8 = bot.Indicators.ExponentialMovingAverage(_bars.ClosePrices, 8);
+            _ema21 = bot.Indicators.ExponentialMovingAverage(_bars.ClosePrices, 21);
 
             string raw = symbol ?? string.Empty;
             string key = NormalizeFxSymbol(raw);
@@ -81,23 +86,27 @@ namespace GeminiV26.Instruments.FX
             double atrRaw = _atr.Result[i];
             double atrPips = atrRaw / _bot.Symbol.PipSize;
             double adx = _adx.ADX[i];
+            double emaDist = Math.Abs(_ema8.Result[i] - _ema21.Result[i]);
+            double emaDistAtr = atrRaw > 0 ? emaDist / atrRaw : 0;
 
             // === PROFIL VEZÉRELT ÉRTELMEZÉS ===
             bool isLowVol = atrPips < _profile.MinAtrPips;
             bool isTrend = adx >= _profile.MinAdxTrend;
+            bool isCompression = emaDistAtr < 0.4;
 
             // === DEBUG (szándékosan marad) ===
             _bot.Print(
                 $"[FX MSD] {_bot.SymbolName} | " +
                 $"atrPips={atrPips:F2} adx={adx:F1} | " +
-                $"lowVol={isLowVol} trend={isTrend}");
+                $"lowVol={isLowVol} trend={isTrend} compression={isCompression}");
 
             return new FxMarketState
             {
                 AtrPips = atrPips,
                 Adx = adx,
                 IsLowVol = isLowVol,
-                IsTrend = isTrend
+                IsTrend = isTrend,
+                IsCompression = isCompression
             };
         }
     }

--- a/Instruments/INDEX/IndexMarketState.cs
+++ b/Instruments/INDEX/IndexMarketState.cs
@@ -16,6 +16,7 @@ namespace GeminiV26.Instruments.INDEX
         public bool IsLowVol { get; set; }
         public bool IsTrend { get; set; }
         public bool IsRange { get; set; }
+        public bool IsMomentum { get; set; }
 
         public double AtrPoints { get; set; }
         public double RangePoints { get; set; }

--- a/Instruments/INDEX/IndexMarketStateDetector.cs
+++ b/Instruments/INDEX/IndexMarketStateDetector.cs
@@ -56,6 +56,7 @@ namespace GeminiV26.Instruments.INDEX
             double atrRaw = _atr.Result[i];
             double atrPoints = atrRaw;
             double adx = _adx.ADX[i];
+            double body = Math.Abs(_bars.ClosePrices[i] - _bars.OpenPrices[i]);
 
             // =====================================================
             // PROFILE-DRIVEN THRESHOLDS (FALLBACK SAFE)
@@ -73,11 +74,12 @@ namespace GeminiV26.Instruments.INDEX
 
             bool isLowVol = atrPoints < minAtrPoints;
             bool isTrend = adx >= minAdxTrend;
+            bool isMomentum = body > atrRaw * 0.8;
 
             _bot.Print(
                 $"[INDEX MSD] {_bot.SymbolName} | " +
                 $"atrPts={atrPoints:F1} adx={adx:F1} | " +
-                $"lowVol={isLowVol} trend={isTrend} | " +
+                $"lowVol={isLowVol} trend={isTrend} momentum={isMomentum} | " +
                 $"minAtr={minAtrPoints} minAdx={minAdxTrend}");
 
             return new IndexMarketState
@@ -85,7 +87,8 @@ namespace GeminiV26.Instruments.INDEX
                 AtrPoints = atrPoints,
                 Adx = adx,
                 IsLowVol = isLowVol,
-                IsTrend = isTrend
+                IsTrend = isTrend,
+                IsMomentum = isMomentum
             };
         }
     }

--- a/Instruments/METAL/MetalMarketState.cs
+++ b/Instruments/METAL/MetalMarketState.cs
@@ -17,6 +17,7 @@ namespace GeminiV26.Instruments.METAL
         public bool IsCompression { get; set; }
         public bool IsHardRange { get; set; }
         public bool IsRange { get; set; }
+        public bool IsSpike { get; set; }
 
         public double EmaDistanceAtr { get; set; }
 

--- a/Instruments/METAL/MetalMarketStateDetector.cs
+++ b/Instruments/METAL/MetalMarketStateDetector.cs
@@ -62,25 +62,33 @@ namespace GeminiV26.Instruments.METAL
 
             double adx = _adx.ADX[i];
             double emaDist = System.Math.Abs(_ema8.Result[i] - _ema21.Result[i]);
+            double high = _bars.HighPrices[i];
+            double low = _bars.LowPrices[i];
+            double body = System.Math.Abs(_bars.ClosePrices[i] - _bars.OpenPrices[i]);
+
+            double upperWick = high - System.Math.Max(_bars.ClosePrices[i], _bars.OpenPrices[i]);
+            double lowerWick = System.Math.Min(_bars.ClosePrices[i], _bars.OpenPrices[i]) - low;
             double emaDistATR = atrRaw > 0 ? emaDist / atrRaw : 0;
 
             bool lowVol = atrPips < _minAtrPips;
             bool trend = adx > 30;
             bool compression = emaDistATR < 0.5;
             bool hardRange = compression && adx < 25;
+            bool isSpike = upperWick > body * 2 || lowerWick > body * 2;
 
             if (adx > 40)
                 hardRange = false;
 
             _bot.Print(
-                "[XAU MSD] atrPips={0:F1} adx={1:F1} emaDistATR={2:F2} lowVol={3} trend={4} compression={5} hardRange={6}",
+                "[XAU MSD] atrPips={0:F1} adx={1:F1} emaDistATR={2:F2} lowVol={3} trend={4} compression={5} hardRange={6} spike={7}",
                 atrPips,
                 adx,
                 emaDistATR,
                 lowVol,
                 trend,
                 compression,
-                hardRange);
+                hardRange,
+                isSpike);
 
             return new MetalMarketState
             {
@@ -91,7 +99,8 @@ namespace GeminiV26.Instruments.METAL
                 IsCompression = compression,
                 IsHardRange = hardRange,
                 IsRange = lowVol && !trend,
-                EmaDistanceAtr = emaDistATR
+                EmaDistanceAtr = emaDistATR,
+                IsSpike = isSpike
             };
         }
     }


### PR DESCRIPTION
### Motivation
- Add lightweight environment signals for better analytics and debugging across crypto, FX, index and metal detectors.
- Keep all changes strictly additive and backward-compatible so existing behavior remains unchanged.
- Surface the new signals in detector logs to aid realtime diagnostics.

### Description
- Crypto: compute `atrPrev = _atr.Result[i - 5]`, set `IsExpansion = atr > atrPrev * 1.2`, append `Expansion={isExpansion}` to the log, and add `IsExpansion` to `CryptoMarketState`.
- FX: introduce `ExponentialMovingAverage` instances for 8 and 21 periods, compute `emaDistAtr = |EMA8-EMA21|/ATR`, derive `IsCompression = emaDistAtr < 0.4`, include `compression={isCompression}` in logs, and add `IsCompression` to `FxMarketState`.
- Index: compute candle `body = |Close-Open|`, set `IsMomentum = body > atrRaw * 0.8`, ensure `lowVol` is explicitly computed and printed, include `momentum={isMomentum}` in logs, and add `IsMomentum` to `IndexMarketState`.
- Metal: compute upper/lower wicks and candle body, set `IsSpike = upperWick > body*2 || lowerWick > body*2`, append `spike={isSpike}` to logs, and add `IsSpike` to `MetalMarketState`.
- Changes limited to the requested detector and model files and are additive only (no renames/refactors or logic removals).

### Testing
- Verified the modified file set is limited to the requested detectors and corresponding MarketState models and matches the intended scope (file-scope check passed).
- Inspected diffs for each modified file to confirm the new signals are calculated, logged, and returned in the state objects (diff verification passed).
- Scanned workspace for project/solution files to run a compile but none were discoverable in this snapshot, so a local build was not executed (build step not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f7deebb0832885c499451d335b33)