### PR TITLE
Fix TP1/TP2 lifecycle and trailing activation across ExitManagers

### DIFF
--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -132,10 +132,16 @@ namespace GeminiV26.Instruments.AUDNZD
                     // ---------- TP1 ----------
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
+                        if (!ExecuteTp1(pos, ctx))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
+                            continue;
+                        }
 
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                         ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
 
                         if (ctx.FinalConfidence >= 80)
                         {
@@ -207,6 +213,7 @@ namespace GeminiV26.Instruments.AUDNZD
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -216,15 +223,51 @@ namespace GeminiV26.Instruments.AUDNZD
         // =====================================================
         private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
         {
-            return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * tp1R;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
+            if (tp1R <= 0)
+                return false;
+
+            double tp1Price = ctxTp1PriceOrFallback(pos, rDist, tp1R, out var resolvedTp1);
+            double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+
+            bool hit = pos.TradeType == TradeType.Buy
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
+
+            if (hit)
+            {
+                _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={resolvedTp1}");
+            }
+
+            return hit;
+        }
+
+        private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
+        {
+            tp1Price = 0;
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            {
+                tp1Price = ctx.Tp1Price;
+                return tp1Price;
+            }
+
+            tp1Price = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + rDist * tp1R
+                : pos.EntryPrice - rDist * tp1R;
+
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+                tpCtx.Tp1Price = tp1Price;
+
+            return tp1Price;
         }
 
         // =====================================================
         // TP1 EXECUTION (partial close)
         // =====================================================
-        private void ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
             double fraction =
                 ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
@@ -238,7 +281,7 @@ namespace GeminiV26.Instruments.AUDNZD
             );
 
             if (closeUnits < minUnits)
-                return;
+                return false;
 
             if (closeUnits >= pos.VolumeInUnits)
                 closeUnits = (long)_bot.Symbol.NormalizeVolumeInUnits(
@@ -246,7 +289,7 @@ namespace GeminiV26.Instruments.AUDNZD
                 );
 
             if (closeUnits < minUnits)
-                return;
+                return false;
 
             _bot.ClosePosition(pos, closeUnits);
 
@@ -281,6 +324,8 @@ namespace GeminiV26.Instruments.AUDNZD
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
             ctx.BeActivated = true;
         }
 
@@ -424,6 +469,7 @@ namespace GeminiV26.Instruments.AUDNZD
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -132,10 +132,16 @@ namespace GeminiV26.Instruments.AUDUSD
                     // ---------- TP1 ----------
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
+                        if (!ExecuteTp1(pos, ctx))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
+                            continue;
+                        }
 
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                         ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
 
                         if (ctx.FinalConfidence >= 80)
                         {
@@ -207,6 +213,7 @@ namespace GeminiV26.Instruments.AUDUSD
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -216,33 +223,82 @@ namespace GeminiV26.Instruments.AUDUSD
         // =====================================================
         private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
         {
-            return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * tp1R;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
+            if (tp1R <= 0)
+                return false;
+
+            double tp1Price = ctxTp1PriceOrFallback(pos, rDist, tp1R, out var resolvedTp1);
+            double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+
+            bool hit = pos.TradeType == TradeType.Buy
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
+
+            if (hit)
+            {
+                _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={resolvedTp1}");
+            }
+
+            return hit;
+        }
+
+        private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
+        {
+            tp1Price = 0;
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            {
+                tp1Price = ctx.Tp1Price;
+                return tp1Price;
+            }
+
+            tp1Price = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + rDist * tp1R
+                : pos.EntryPrice - rDist * tp1R;
+
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+                tpCtx.Tp1Price = tp1Price;
+
+            return tp1Price;
         }
 
         // =====================================================
         // TP1 EXECUTION (partial close)
         // =====================================================
-        private void ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
             double fraction = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
                 ? ctx.Tp1CloseFraction
                 : 0.5;
 
-            double minUnits = _bot.Symbol.VolumeInUnitsMin;
-            double closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits * fraction);
+            double rawUnitsD = pos.VolumeInUnits * fraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long normalizedUnits = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits - minUnits);
+            if (normalizedUnits >= pos.VolumeInUnits)
+                normalizedUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            _bot.ClosePosition(pos, closeUnits);
+            var result = _bot.ClosePosition(pos, normalizedUnits);
+            if (!result.IsSuccessful)
+                return false;
+
+            ctx.Tp1ClosedVolumeInUnits = normalizedUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - normalizedUnits);
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={normalizedUnits} remainingUnits={ctx.RemainingVolumeInUnits}");
+            return true;
         }
 
         // =====================================================
@@ -272,6 +328,8 @@ namespace GeminiV26.Instruments.AUDUSD
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
         }
 
         // =====================================================
@@ -409,6 +467,7 @@ namespace GeminiV26.Instruments.AUDUSD
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -132,10 +132,16 @@ namespace GeminiV26.Instruments.EURJPY
                     // ---------- TP1 ----------
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
+                        if (!ExecuteTp1(pos, ctx))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
+                            continue;
+                        }
 
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                         ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
 
                         if (ctx.FinalConfidence >= 80)
                         {
@@ -207,6 +213,7 @@ namespace GeminiV26.Instruments.EURJPY
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -216,33 +223,82 @@ namespace GeminiV26.Instruments.EURJPY
         // =====================================================
         private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
         {
-            return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * tp1R;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
+            if (tp1R <= 0)
+                return false;
+
+            double tp1Price = ctxTp1PriceOrFallback(pos, rDist, tp1R, out var resolvedTp1);
+            double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+
+            bool hit = pos.TradeType == TradeType.Buy
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
+
+            if (hit)
+            {
+                _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={resolvedTp1}");
+            }
+
+            return hit;
+        }
+
+        private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
+        {
+            tp1Price = 0;
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            {
+                tp1Price = ctx.Tp1Price;
+                return tp1Price;
+            }
+
+            tp1Price = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + rDist * tp1R
+                : pos.EntryPrice - rDist * tp1R;
+
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+                tpCtx.Tp1Price = tp1Price;
+
+            return tp1Price;
         }
 
         // =====================================================
         // TP1 EXECUTION (partial close)
         // =====================================================
-        private void ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
             double fraction = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
                 ? ctx.Tp1CloseFraction
                 : 0.5;
 
-            double minUnits = _bot.Symbol.VolumeInUnitsMin;
-            double closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits * fraction);
+            double rawUnitsD = pos.VolumeInUnits * fraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long normalizedUnits = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits - minUnits);
+            if (normalizedUnits >= pos.VolumeInUnits)
+                normalizedUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            _bot.ClosePosition(pos, closeUnits);
+            var result = _bot.ClosePosition(pos, normalizedUnits);
+            if (!result.IsSuccessful)
+                return false;
+
+            ctx.Tp1ClosedVolumeInUnits = normalizedUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - normalizedUnits);
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={normalizedUnits} remainingUnits={ctx.RemainingVolumeInUnits}");
+            return true;
         }
 
         // =====================================================
@@ -272,6 +328,8 @@ namespace GeminiV26.Instruments.EURJPY
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
         }
 
         // =====================================================
@@ -409,6 +467,7 @@ namespace GeminiV26.Instruments.EURJPY
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -98,10 +98,16 @@ namespace GeminiV26.Instruments.EURUSD
                 {
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
+                        if (!ExecuteTp1(pos, ctx))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
+                            continue;
+                        }
 
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                         ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
 
                         if (ctx.FinalConfidence >= 80)
                         {
@@ -132,6 +138,7 @@ namespace GeminiV26.Instruments.EURUSD
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -141,33 +148,82 @@ namespace GeminiV26.Instruments.EURUSD
         // =====================================================
         private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
         {
-            return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * tp1R;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
+            if (tp1R <= 0)
+                return false;
+
+            double tp1Price = ctxTp1PriceOrFallback(pos, rDist, tp1R, out var resolvedTp1);
+            double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+
+            bool hit = pos.TradeType == TradeType.Buy
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
+
+            if (hit)
+            {
+                _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={resolvedTp1}");
+            }
+
+            return hit;
+        }
+
+        private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
+        {
+            tp1Price = 0;
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            {
+                tp1Price = ctx.Tp1Price;
+                return tp1Price;
+            }
+
+            tp1Price = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + rDist * tp1R
+                : pos.EntryPrice - rDist * tp1R;
+
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+                tpCtx.Tp1Price = tp1Price;
+
+            return tp1Price;
         }
 
         // =====================================================
         // TP1 EXECUTION (partial close)
         // =====================================================
-        private void ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
             double fraction = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
                 ? ctx.Tp1CloseFraction
                 : 0.5;
 
-            double minUnits = _bot.Symbol.VolumeInUnitsMin;
-            double closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits * fraction);
+            double rawUnitsD = pos.VolumeInUnits * fraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long normalizedUnits = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits - minUnits);
+            if (normalizedUnits >= pos.VolumeInUnits)
+                normalizedUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            _bot.ClosePosition(pos, closeUnits);
+            var result = _bot.ClosePosition(pos, normalizedUnits);
+            if (!result.IsSuccessful)
+                return false;
+
+            ctx.Tp1ClosedVolumeInUnits = normalizedUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - normalizedUnits);
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={normalizedUnits} remainingUnits={ctx.RemainingVolumeInUnits}");
+            return true;
         }
 
         // =====================================================
@@ -190,6 +246,8 @@ namespace GeminiV26.Instruments.EURUSD
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
         }
 
         // =====================================================
@@ -355,6 +413,7 @@ namespace GeminiV26.Instruments.EURUSD
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -132,10 +132,16 @@ namespace GeminiV26.Instruments.GBPJPY
                     // ---------- TP1 ----------
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
+                        if (!ExecuteTp1(pos, ctx))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
+                            continue;
+                        }
 
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                         ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
 
                         if (ctx.FinalConfidence >= 80)
                         {
@@ -207,6 +213,7 @@ namespace GeminiV26.Instruments.GBPJPY
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -216,33 +223,82 @@ namespace GeminiV26.Instruments.GBPJPY
         // =====================================================
         private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
         {
-            return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * tp1R;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
+            if (tp1R <= 0)
+                return false;
+
+            double tp1Price = ctxTp1PriceOrFallback(pos, rDist, tp1R, out var resolvedTp1);
+            double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+
+            bool hit = pos.TradeType == TradeType.Buy
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
+
+            if (hit)
+            {
+                _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={resolvedTp1}");
+            }
+
+            return hit;
+        }
+
+        private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
+        {
+            tp1Price = 0;
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            {
+                tp1Price = ctx.Tp1Price;
+                return tp1Price;
+            }
+
+            tp1Price = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + rDist * tp1R
+                : pos.EntryPrice - rDist * tp1R;
+
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+                tpCtx.Tp1Price = tp1Price;
+
+            return tp1Price;
         }
 
         // =====================================================
         // TP1 EXECUTION (partial close)
         // =====================================================
-        private void ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
             double fraction = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
                 ? ctx.Tp1CloseFraction
                 : 0.5;
 
-            double minUnits = _bot.Symbol.VolumeInUnitsMin;
-            double closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits * fraction);
+            double rawUnitsD = pos.VolumeInUnits * fraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long normalizedUnits = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits - minUnits);
+            if (normalizedUnits >= pos.VolumeInUnits)
+                normalizedUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            _bot.ClosePosition(pos, closeUnits);
+            var result = _bot.ClosePosition(pos, normalizedUnits);
+            if (!result.IsSuccessful)
+                return false;
+
+            ctx.Tp1ClosedVolumeInUnits = normalizedUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - normalizedUnits);
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={normalizedUnits} remainingUnits={ctx.RemainingVolumeInUnits}");
+            return true;
         }
 
         // =====================================================
@@ -278,6 +334,8 @@ namespace GeminiV26.Instruments.GBPJPY
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
         }
 
         // =====================================================
@@ -415,6 +473,7 @@ namespace GeminiV26.Instruments.GBPJPY
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -95,9 +95,14 @@ namespace GeminiV26.Instruments.GBPUSD
 
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
+                        if (!ExecuteTp1(pos, ctx))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
+                            continue;
+                        }
 
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                         ApplyBreakEven(pos, ctx);
                         ctx.TrailingMode = ctx.FinalConfidence >= 80
                             ? TrailingMode.Loose
@@ -118,6 +123,7 @@ namespace GeminiV26.Instruments.GBPUSD
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -128,36 +134,59 @@ namespace GeminiV26.Instruments.GBPUSD
         private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
         {
             var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null || tp1R <= 0)
+                return false;
+
+            _contexts.TryGetValue(pos.Id, out var ctx);
+            double tp1Price = ctx != null && ctx.Tp1Price > 0
+                ? ctx.Tp1Price
+                : (pos.TradeType == TradeType.Buy
+                    ? pos.EntryPrice + rDist * tp1R
+                    : pos.EntryPrice - rDist * tp1R);
+
+            if (ctx != null && ctx.Tp1Price <= 0)
+                ctx.Tp1Price = tp1Price;
 
             return pos.TradeType == TradeType.Buy
-                ? sym.Bid >= pos.EntryPrice + rDist * tp1R
-                : sym.Ask <= pos.EntryPrice - rDist * tp1R;
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
         }
 
         // =====================================================
         // TP1 EXECUTION
         // =====================================================
-        private void ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
             var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
 
             double fraction = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
                 ? ctx.Tp1CloseFraction
                 : 0.5;
 
-            double minUnits = sym.VolumeInUnitsMin;
-            double closeUnits = sym.NormalizeVolumeInUnits(pos.VolumeInUnits * fraction);
+            double rawUnitsD = pos.VolumeInUnits * fraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long normalizedUnits = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = sym.NormalizeVolumeInUnits(pos.VolumeInUnits - minUnits);
+            if (normalizedUnits >= pos.VolumeInUnits)
+                normalizedUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            _bot.ClosePosition(pos, closeUnits);
+            var result = _bot.ClosePosition(pos, normalizedUnits);
+            if (!result.IsSuccessful)
+                return false;
+
+            ctx.Tp1ClosedVolumeInUnits = normalizedUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - normalizedUnits);
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={normalizedUnits} remainingUnits={ctx.RemainingVolumeInUnits}");
+            return true;
         }
 
         // =====================================================
@@ -175,6 +204,8 @@ namespace GeminiV26.Instruments.GBPUSD
             _bot.ModifyPosition(pos, Normalize(bePrice, pos.SymbolName), pos.TakeProfit);
 
             ctx.BePrice = bePrice;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
         }
 
         // =====================================================
@@ -272,6 +303,7 @@ namespace GeminiV26.Instruments.GBPUSD
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -82,8 +82,13 @@ namespace GeminiV26.Instruments.GER40
                 {
                     if (CheckTp1Hit(pos, ctx, rDist))
                     {
-                        ExecuteTp1(pos, ctx, rDist);
+                        if (!ExecuteTp1(pos, ctx, rDist))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType}");
+                            continue;
+                        }
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType}");
                         continue;
                     }
 
@@ -143,6 +148,8 @@ namespace GeminiV26.Instruments.GER40
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -200,27 +207,48 @@ namespace GeminiV26.Instruments.GER40
             if (ctx.Tp1R <= 0)
                 return false;
 
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
+            double tp1Price = ctx.Tp1Price > 0
+                ? ctx.Tp1Price
+                : (pos.TradeType == TradeType.Buy
+                    ? pos.EntryPrice + rDist * ctx.Tp1R
+                    : pos.EntryPrice - rDist * ctx.Tp1R);
+
+            if (ctx.Tp1Price <= 0)
+                ctx.Tp1Price = tp1Price;
+
             return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * ctx.Tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * ctx.Tp1R;
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
         }
 
-        private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
+        private bool ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            double closeVol =
-                _bot.Symbol.NormalizeVolumeInUnits(
-                    pos.VolumeInUnits * ctx.Tp1CloseFraction,
-                    RoundingMode.Down
-                );
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
 
-            if (closeVol >= _bot.Symbol.VolumeInUnitsMin)
-                _bot.ClosePosition(pos, closeVol);
+            double rawUnitsD = pos.VolumeInUnits * ctx.Tp1CloseFraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long closeVol = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+
+            if (closeVol < sym.VolumeInUnitsMin)
+                return false;
+
+            var result = _bot.ClosePosition(pos, closeVol);
+            if (!result.IsSuccessful)
+                return false;
 
             ctx.Tp1ClosedVolumeInUnits = closeVol;
             ctx.RemainingVolumeInUnits =
                 Math.Max(0, pos.VolumeInUnits - closeVol);
 
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={closeVol} remainingUnits={ctx.RemainingVolumeInUnits}");
             ApplyBreakEven(pos, ctx, rDist);
+            return true;
         }
 
         // =====================================================
@@ -392,6 +420,8 @@ namespace GeminiV26.Instruments.GER40
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -88,8 +88,13 @@ namespace GeminiV26.Instruments.NAS100
                             $"entry={pos.EntryPrice} SL={pos.StopLoss} rDist={rDist} " +
                             $"TP1@={tp1Price} bid={_bot.Symbol.Bid} ask={_bot.Symbol.Ask}"
                         );
-                        ExecuteTp1(pos, ctx, rDist);
+                        if (!ExecuteTp1(pos, ctx, rDist))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType}");
+                            continue;
+                        }
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType}");
                         continue;
                     }
 
@@ -149,6 +154,8 @@ namespace GeminiV26.Instruments.NAS100
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -203,27 +210,48 @@ namespace GeminiV26.Instruments.NAS100
         // =====================================================
         private bool CheckTp1Hit(Position pos, PositionContext ctx, double rDist)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null || ctx.Tp1R <= 0)
+                return false;
+
+            double tp1Price = ctx.Tp1Price > 0
+                ? ctx.Tp1Price
+                : (pos.TradeType == TradeType.Buy
+                    ? pos.EntryPrice + rDist * ctx.Tp1R
+                    : pos.EntryPrice - rDist * ctx.Tp1R);
+
+            if (ctx.Tp1Price <= 0)
+                ctx.Tp1Price = tp1Price;
+
             return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * ctx.Tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * ctx.Tp1R;
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
         }
 
-        private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
+        private bool ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            double closeVol =
-                _bot.Symbol.NormalizeVolumeInUnits(
-                    pos.VolumeInUnits * ctx.Tp1CloseFraction,
-                    RoundingMode.Down
-                );
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
 
-            if (closeVol >= _bot.Symbol.VolumeInUnitsMin)
-                _bot.ClosePosition(pos, closeVol);
+            double rawUnitsD = pos.VolumeInUnits * ctx.Tp1CloseFraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long closeVol = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+
+            if (closeVol < sym.VolumeInUnitsMin)
+                return false;
+
+            var result = _bot.ClosePosition(pos, closeVol);
+            if (!result.IsSuccessful)
+                return false;
 
             ctx.Tp1ClosedVolumeInUnits = closeVol;
             ctx.RemainingVolumeInUnits =
                 Math.Max(0, pos.VolumeInUnits - closeVol);
 
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={closeVol} remainingUnits={ctx.RemainingVolumeInUnits}");
             ApplyBreakEven(pos, ctx, rDist);
+            return true;
         }
 
         // =====================================================
@@ -239,6 +267,8 @@ namespace GeminiV26.Instruments.NAS100
             ctx.BePrice = bePrice;
 
             _bot.ModifyPosition(pos, Normalize(bePrice), pos.TakeProfit);
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
 
             _eventLogger.Log(new EventRecord
             {
@@ -356,6 +386,8 @@ namespace GeminiV26.Instruments.NAS100
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -132,10 +132,16 @@ namespace GeminiV26.Instruments.NZDUSD
                     // ---------- TP1 ----------
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
+                        if (!ExecuteTp1(pos, ctx))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
+                            continue;
+                        }
 
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                         ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
 
                         if (ctx.FinalConfidence >= 80)
                         {
@@ -207,6 +213,7 @@ namespace GeminiV26.Instruments.NZDUSD
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -216,33 +223,82 @@ namespace GeminiV26.Instruments.NZDUSD
         // =====================================================
         private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
         {
-            return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * tp1R;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
+            if (tp1R <= 0)
+                return false;
+
+            double tp1Price = ctxTp1PriceOrFallback(pos, rDist, tp1R, out var resolvedTp1);
+            double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+
+            bool hit = pos.TradeType == TradeType.Buy
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
+
+            if (hit)
+            {
+                _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={resolvedTp1}");
+            }
+
+            return hit;
+        }
+
+        private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
+        {
+            tp1Price = 0;
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            {
+                tp1Price = ctx.Tp1Price;
+                return tp1Price;
+            }
+
+            tp1Price = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + rDist * tp1R
+                : pos.EntryPrice - rDist * tp1R;
+
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+                tpCtx.Tp1Price = tp1Price;
+
+            return tp1Price;
         }
 
         // =====================================================
         // TP1 EXECUTION (partial close)
         // =====================================================
-        private void ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
             double fraction = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
                 ? ctx.Tp1CloseFraction
                 : 0.5;
 
-            double minUnits = _bot.Symbol.VolumeInUnitsMin;
-            double closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits * fraction);
+            double rawUnitsD = pos.VolumeInUnits * fraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long normalizedUnits = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits - minUnits);
+            if (normalizedUnits >= pos.VolumeInUnits)
+                normalizedUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            _bot.ClosePosition(pos, closeUnits);
+            var result = _bot.ClosePosition(pos, normalizedUnits);
+            if (!result.IsSuccessful)
+                return false;
+
+            ctx.Tp1ClosedVolumeInUnits = normalizedUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - normalizedUnits);
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={normalizedUnits} remainingUnits={ctx.RemainingVolumeInUnits}");
+            return true;
         }
 
         // =====================================================
@@ -278,6 +334,8 @@ namespace GeminiV26.Instruments.NZDUSD
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
         }
 
         // =====================================================
@@ -415,6 +473,7 @@ namespace GeminiV26.Instruments.NZDUSD
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -76,6 +76,7 @@ namespace GeminiV26.Instruments.US30
 
                         if (tp1Done)
                         {
+                            _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                             MoveToBreakEven(pos, ctx, rDist);
                             _bot.Print($"[US30 TP1 STATE] pos={pos.Id} tp1Hit={ctx.Tp1Hit} be={ctx.BePrice}");
                         }
@@ -122,6 +123,7 @@ namespace GeminiV26.Instruments.US30
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -179,7 +181,12 @@ namespace GeminiV26.Instruments.US30
             _bot.Print($"[US30 TP1 EXEC RES] pos={pos.Id} success={closeResult.IsSuccessful} err={closeResult.Error}");
 
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} tp1={ctx.Tp1Price}");
                 return false;
+            }
+
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={closeUnits} remainingUnits={pos.VolumeInUnits - closeUnits}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = pos.VolumeInUnits - closeUnits;
@@ -206,6 +213,8 @@ namespace GeminiV26.Instruments.US30
             _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
         }
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
@@ -246,6 +255,7 @@ namespace GeminiV26.Instruments.US30
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -132,10 +132,16 @@ namespace GeminiV26.Instruments.USDCAD
                     // ---------- TP1 ----------
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
+                        if (!ExecuteTp1(pos, ctx))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
+                            continue;
+                        }
 
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                         ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
 
                         if (ctx.FinalConfidence >= 80)
                         {
@@ -207,6 +213,7 @@ namespace GeminiV26.Instruments.USDCAD
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -216,33 +223,82 @@ namespace GeminiV26.Instruments.USDCAD
         // =====================================================
         private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
         {
-            return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * tp1R;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
+            if (tp1R <= 0)
+                return false;
+
+            double tp1Price = ctxTp1PriceOrFallback(pos, rDist, tp1R, out var resolvedTp1);
+            double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+
+            bool hit = pos.TradeType == TradeType.Buy
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
+
+            if (hit)
+            {
+                _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={resolvedTp1}");
+            }
+
+            return hit;
+        }
+
+        private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
+        {
+            tp1Price = 0;
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            {
+                tp1Price = ctx.Tp1Price;
+                return tp1Price;
+            }
+
+            tp1Price = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + rDist * tp1R
+                : pos.EntryPrice - rDist * tp1R;
+
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+                tpCtx.Tp1Price = tp1Price;
+
+            return tp1Price;
         }
 
         // =====================================================
         // TP1 EXECUTION (partial close)
         // =====================================================
-        private void ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
             double fraction = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
                 ? ctx.Tp1CloseFraction
                 : 0.5;
 
-            double minUnits = _bot.Symbol.VolumeInUnitsMin;
-            double closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits * fraction);
+            double rawUnitsD = pos.VolumeInUnits * fraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long normalizedUnits = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits - minUnits);
+            if (normalizedUnits >= pos.VolumeInUnits)
+                normalizedUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            _bot.ClosePosition(pos, closeUnits);
+            var result = _bot.ClosePosition(pos, normalizedUnits);
+            if (!result.IsSuccessful)
+                return false;
+
+            ctx.Tp1ClosedVolumeInUnits = normalizedUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - normalizedUnits);
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={normalizedUnits} remainingUnits={ctx.RemainingVolumeInUnits}");
+            return true;
         }
 
         // =====================================================
@@ -278,6 +334,8 @@ namespace GeminiV26.Instruments.USDCAD
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
         }
 
         // =====================================================
@@ -415,6 +473,7 @@ namespace GeminiV26.Instruments.USDCAD
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -132,10 +132,16 @@ namespace GeminiV26.Instruments.USDCHF
                     // ---------- TP1 ----------
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
+                        if (!ExecuteTp1(pos, ctx))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
+                            continue;
+                        }
 
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                         ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
 
                         if (ctx.FinalConfidence >= 80)
                         {
@@ -207,6 +213,7 @@ namespace GeminiV26.Instruments.USDCHF
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -216,33 +223,82 @@ namespace GeminiV26.Instruments.USDCHF
         // =====================================================
         private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
         {
-            return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * tp1R;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
+            if (tp1R <= 0)
+                return false;
+
+            double tp1Price = ctxTp1PriceOrFallback(pos, rDist, tp1R, out var resolvedTp1);
+            double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+
+            bool hit = pos.TradeType == TradeType.Buy
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
+
+            if (hit)
+            {
+                _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={resolvedTp1}");
+            }
+
+            return hit;
+        }
+
+        private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
+        {
+            tp1Price = 0;
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            {
+                tp1Price = ctx.Tp1Price;
+                return tp1Price;
+            }
+
+            tp1Price = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + rDist * tp1R
+                : pos.EntryPrice - rDist * tp1R;
+
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+                tpCtx.Tp1Price = tp1Price;
+
+            return tp1Price;
         }
 
         // =====================================================
         // TP1 EXECUTION (partial close)
         // =====================================================
-        private void ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
             double fraction = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
                 ? ctx.Tp1CloseFraction
                 : 0.5;
 
-            double minUnits = _bot.Symbol.VolumeInUnitsMin;
-            double closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits * fraction);
+            double rawUnitsD = pos.VolumeInUnits * fraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long normalizedUnits = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits - minUnits);
+            if (normalizedUnits >= pos.VolumeInUnits)
+                normalizedUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            _bot.ClosePosition(pos, closeUnits);
+            var result = _bot.ClosePosition(pos, normalizedUnits);
+            if (!result.IsSuccessful)
+                return false;
+
+            ctx.Tp1ClosedVolumeInUnits = normalizedUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - normalizedUnits);
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={normalizedUnits} remainingUnits={ctx.RemainingVolumeInUnits}");
+            return true;
         }
 
         // =====================================================
@@ -278,6 +334,8 @@ namespace GeminiV26.Instruments.USDCHF
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
         }
 
         // =====================================================
@@ -415,6 +473,7 @@ namespace GeminiV26.Instruments.USDCHF
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -98,10 +98,16 @@ namespace GeminiV26.Instruments.USDJPY
                 {
                     if (CheckTp1Hit(pos, rDist, ctx.Tp1R))
                     {
-                        ExecuteTp1(pos, ctx);
+                        if (!ExecuteTp1(pos, ctx))
+                        {
+                            _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
+                            continue;
+                        }
 
                         ctx.Tp1Hit = true;
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} tp1={ctx.Tp1Price}");
                         ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
 
                         if (ctx.FinalConfidence >= 80)
                         {
@@ -132,6 +138,7 @@ namespace GeminiV26.Instruments.USDJPY
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -141,33 +148,82 @@ namespace GeminiV26.Instruments.USDJPY
         // =====================================================
         private bool CheckTp1Hit(Position pos, double rDist, double tp1R)
         {
-            return pos.TradeType == TradeType.Buy
-                ? _bot.Symbol.Bid >= pos.EntryPrice + rDist * tp1R
-                : _bot.Symbol.Ask <= pos.EntryPrice - rDist * tp1R;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
+            if (tp1R <= 0)
+                return false;
+
+            double tp1Price = ctxTp1PriceOrFallback(pos, rDist, tp1R, out var resolvedTp1);
+            double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+
+            bool hit = pos.TradeType == TradeType.Buy
+                ? sym.Bid >= tp1Price
+                : sym.Ask <= tp1Price;
+
+            if (hit)
+            {
+                _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={resolvedTp1}");
+            }
+
+            return hit;
+        }
+
+        private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
+        {
+            tp1Price = 0;
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            {
+                tp1Price = ctx.Tp1Price;
+                return tp1Price;
+            }
+
+            tp1Price = pos.TradeType == TradeType.Buy
+                ? pos.EntryPrice + rDist * tp1R
+                : pos.EntryPrice - rDist * tp1R;
+
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+                tpCtx.Tp1Price = tp1Price;
+
+            return tp1Price;
         }
 
         // =====================================================
         // TP1 EXECUTION (partial close)
         // =====================================================
-        private void ExecuteTp1(Position pos, PositionContext ctx)
+        private bool ExecuteTp1(Position pos, PositionContext ctx)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return false;
+
             double fraction = ctx.Tp1CloseFraction > 0 && ctx.Tp1CloseFraction < 1
                 ? ctx.Tp1CloseFraction
                 : 0.5;
 
-            double minUnits = _bot.Symbol.VolumeInUnitsMin;
-            double closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits * fraction);
+            double rawUnitsD = pos.VolumeInUnits * fraction;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long normalizedUnits = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits - minUnits);
+            if (normalizedUnits >= pos.VolumeInUnits)
+                normalizedUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits < minUnits)
-                return;
+            if (normalizedUnits < minUnits)
+                return false;
 
-            _bot.ClosePosition(pos, closeUnits);
+            var result = _bot.ClosePosition(pos, normalizedUnits);
+            if (!result.IsSuccessful)
+                return false;
+
+            ctx.Tp1ClosedVolumeInUnits = normalizedUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - normalizedUnits);
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={normalizedUnits} remainingUnits={ctx.RemainingVolumeInUnits}");
+            return true;
         }
 
         // =====================================================
@@ -197,6 +253,8 @@ namespace GeminiV26.Instruments.USDJPY
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} be={bePrice}");
         }
 
         // =====================================================
@@ -334,6 +392,7 @@ namespace GeminiV26.Instruments.USDJPY
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? _bot.Symbols.GetSymbol(pos.SymbolName)?.Bid : _bot.Symbols.GetSymbol(pos.SymbolName)?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -138,9 +138,14 @@ namespace GeminiV26.Instruments.XAUUSD
                 {
                     double tp1R = ResolveTp1R(ctx);
 
-                    double tp1Price = pos.TradeType == TradeType.Buy
-                        ? pos.EntryPrice + rDist * tp1R
-                        : pos.EntryPrice - rDist * tp1R;
+                    double tp1Price = ctx.Tp1Price > 0
+                        ? ctx.Tp1Price
+                        : (pos.TradeType == TradeType.Buy
+                            ? pos.EntryPrice + rDist * tp1R
+                            : pos.EntryPrice - rDist * tp1R);
+
+                    if (ctx.Tp1Price <= 0)
+                        ctx.Tp1Price = tp1Price;
 
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
@@ -157,6 +162,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
                     if (hit)
                     {
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={priceNow} tp1={tp1Price}");
                         ExecuteTp1(pos, ctx, rDist);
                         return;
                     }
@@ -209,6 +215,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -226,23 +233,29 @@ namespace GeminiV26.Instruments.XAUUSD
             double frac = ctx.Tp1CloseFraction;
             if (frac <= 0 || frac >= 1) frac = 0.40;
 
-            double closeVolume =
-                sym.NormalizeVolumeInUnits(
-                    pos.VolumeInUnits * frac,
-                    RoundingMode.Down
-                );
+            double rawUnitsD = pos.VolumeInUnits * frac;
+            long flooredUnits = (long)Math.Floor(rawUnitsD);
+            long closeVolume = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
 
             if (closeVolume < sym.VolumeInUnitsMin)
                 return;
 
-            _bot.ClosePosition(pos, closeVolume);
+            var closeResult = _bot.ClosePosition(pos, closeVolume);
+            if (!closeResult.IsSuccessful)
+            {
+                _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} tp1={ctx.Tp1Price}");
+                return;
+            }
+
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={closeVolume}");
 
             // TP1 state (SSOT) – csak itt állítjuk
             ctx.Tp1Hit = true;
 
             // Remaining volume (analytics + rehydrate friendliness)
+            ctx.Tp1ClosedVolumeInUnits = closeVolume;
             ctx.RemainingVolumeInUnits =
-                Math.Max(0, ctx.EntryVolumeInUnits - closeVolume);
+                Math.Max(0, pos.VolumeInUnits - closeVolume);
 
             // BE (profilból)
             ApplyBreakEven(pos, ctx, rDist);
@@ -277,6 +290,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
             ctx.BePrice = bePrice;
             double newSl = bePrice;
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} be={bePrice}");
 
             _bot.ModifyPosition(
                 pos,
@@ -457,6 +471,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 return;
             }
 
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
             double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
             double desiredR = baseR * decision.Tp2ExtensionMultiplier;
             double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;
@@ -486,6 +501,7 @@ namespace GeminiV26.Instruments.XAUUSD
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");


### PR DESCRIPTION
### Motivation
- TP1 was not reliably detected or executed which prevented partial close, BE move and activation of trailing/TP2, leaving trades unmanaged. 
- The goal was to make TP1 detection directionally correct (Buy uses Bid, Sell uses Ask), ensure the TP1 lifecycle executes exactly once and only when partial close succeeds, and to enable trailing/TP2 only after TP1. 
- Clear runtime instrumentation was required to make the TP1 → BE → trailing → TP2 lifecycle observable in live/demo.

### Description
- Standardized TP1 detection to use symbol-side prices with persisted TP1 price fallback and explicit checks (Buy: Bid >= TP1, Sell: Ask <= TP1) and added defensive null/tp1R checks. 
- Made TP1 execution return a success boolean and gated advancing of TP1 state on successful partial close, updated `ctx.Tp1ClosedVolumeInUnits` and `ctx.RemainingVolumeInUnits` using integer-normalized volume logic (`raw -> Math.Floor -> NormalizeVolumeInUnits`) to respect instrument min/step rules. 
- Ensured trailing/TP2 paths are only invoked after `ctx.Tp1Hit` and fixed TP2 extension reachability; added explicit runtime logs for the stages `[EXIT] TP1 HIT`, `[EXIT] PARTIAL CLOSE executed` / failure, `[EXIT] BE MOVE applied`, `[EXIT] TRAILING ACTIVE`, and `[EXIT] TP2 EXTENDED`. 
- Files modified: Instruments/XAUUSD/XauExitManager.cs, Instruments/NAS100/NasExitManager.cs, Instruments/GER40/Ger40ExitManager.cs, Instruments/US30/Us30ExitManager.cs, Instruments/EURUSD/EurUsdExitManager.cs, Instruments/USDJPY/UsdJpyExitManager.cs, Instruments/GBPUSD/GbpUsdExitManager.cs, Instruments/AUDUSD/AudUsdExitManager.cs, Instruments/NZDUSD/NzdUsdExitManager.cs, Instruments/USDCAD/UsdCadExitManager.cs, Instruments/USDCHF/UsdChfExitManager.cs, Instruments/EURJPY/EurJpyExitManager.cs, Instruments/GBPJPY/GbpJpyExitManager.cs, and Instruments/AUDNZD/AudNzdExitManager.cs. 
- No architecture refactor, file renames, or changes outside ExitManagers were performed and no Entry/TradeCore/RiskSizer logic was modified.

### Testing
- Performed a codebase audit with `rg`/`rg --files` to verify TP1 checks, ExecuteTp1 signature changes, trailing gating and presence of the new log lines across all updated ExitManagers and confirmed the new patterns are present. 
- Attempted a full build with `dotnet build -v minimal` to validate compilation but `dotnet` was not available in the environment so a runtime build could not be executed. 
- Confirmed via static diffs and `git` commit that the changes are limited to ExitManagers and include the new guard/logging/volume normalization logic across XAU, index, and all FX managers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b42cfa2564832886c7470ac970c2ed)