### PR TITLE
Fix TP1/TP2 lifecycle handling for BTCUSD and ETHUSD exit managers

### DIFF
--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -86,10 +86,6 @@ namespace GeminiV26.Instruments.BTCUSD
             // Snapshot kulcsok: biztonságosabb, mint közvetlen foreach a dict-en
             var keys = new List<long>(_contexts.Keys);
 
-            // M1 bar a wick-realitáshoz (TP1 touch)
-            var m1 = _bot.MarketData.GetBars(TimeFrame.Minute);
-            Bar m1Bar = m1 != null && m1.Count > 0 ? m1.LastBar : default;
-
             foreach (var key in keys)
             {
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
@@ -112,6 +108,10 @@ namespace GeminiV26.Instruments.BTCUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
+                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                if (sym == null)
+                    continue;
+
                 // R-distance az eredeti SL alapján (ctx.EntryPrice vs eredeti SL távolság)
                 double rDist = ctx.RiskPriceDistance;
                 if (rDist <= 0)
@@ -122,27 +122,26 @@ namespace GeminiV26.Instruments.BTCUSD
                 // =========================
                 if (!ctx.Tp1Hit)
                 {
-                    double tp1Price =
-                        ctx.EntryPrice + Direction(pos) * rDist * ctx.Tp1R;
+                    if (ctx.Tp1R <= 0)
+                        ctx.Tp1R = 0.5;
 
-                    // Ha nincs M1 bar, fallback tick alapra
-                    bool reached;
-                    if (m1 != null && m1.Count > 0)
-                    {
-                        reached = pos.TradeType == TradeType.Buy
-                            ? m1Bar.High >= tp1Price
-                            : m1Bar.Low <= tp1Price;
-                    }
-                    else
-                    {
-                        reached =
-                            (pos.TradeType == TradeType.Buy && _bot.Symbol.Bid >= tp1Price) ||
-                            (pos.TradeType == TradeType.Sell && _bot.Symbol.Ask <= tp1Price);
-                    }
+                    double tp1Price = ctx.Tp1Price > 0
+                        ? ctx.Tp1Price
+                        : (pos.TradeType == TradeType.Buy
+                            ? pos.EntryPrice + rDist * ctx.Tp1R
+                            : pos.EntryPrice - rDist * ctx.Tp1R);
+
+                    if (ctx.Tp1Price <= 0)
+                        ctx.Tp1Price = tp1Price;
+
+                    double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+                    bool reached = pos.TradeType == TradeType.Buy
+                        ? sym.Bid >= tp1Price
+                        : sym.Ask <= tp1Price;
 
                     if (reached)
                     {
-                        _bot.Print("[BTCUSD][TP1][HIT] TP1 HIT (OnTick)");
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={tp1Price}");
                         ExecuteTp1(pos, ctx, rDist);
 
                         // KRITIKUS: TP1 után azonnal kilépünk ebből a tickből,
@@ -202,6 +201,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -216,31 +216,37 @@ namespace GeminiV26.Instruments.BTCUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return;
+
             // 1) Partial close (crypto-safe)
             double frac = ctx.Tp1CloseFraction;
             if (frac <= 0 || frac >= 1)
                 frac = 0.5;
 
-            double minUnits = _bot.Symbol.VolumeInUnitsMin;
-
-            // Position.VolumeInUnits lehet double crypto instrumenten
-            double targetUnits = pos.VolumeInUnits * frac;
-
-            // Normalize a symbol step-re (crypto: 0.01, 0.001, stb.)
-            double closeUnits = _bot.Symbol.NormalizeVolumeInUnits(targetUnits);
+            long closeUnits = (long)sym.NormalizeVolumeInUnits(
+                (long)Math.Floor(pos.VolumeInUnits * frac),
+                RoundingMode.Down
+            );
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
             if (closeUnits < minUnits)
-                closeUnits = minUnits;
+                return;
 
-            // Ne zárjuk ki véletlen fullra (maradjon legalább minUnits)
             if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = _bot.Symbol.NormalizeVolumeInUnits(pos.VolumeInUnits - minUnits);
+                closeUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits >= minUnits && closeUnits > 0)
-            {
-                _bot.ClosePosition(pos, closeUnits);
-                ctx.Tp1ClosedVolumeInUnits = closeUnits;
-            }
+            if (closeUnits < minUnits)
+                return;
+
+            var closeResult = _bot.ClosePosition(pos, closeUnits);
+            if (!closeResult.IsSuccessful)
+                return;
+
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={closeUnits}");
+            ctx.Tp1ClosedVolumeInUnits = closeUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
 
             // 2) TP1 state
             ctx.Tp1Hit = true;
@@ -259,6 +265,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
             // ModifyPosition: SL -> BE, TP marad (TP2)
             _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} be={bePrice}");
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -364,6 +371,8 @@ namespace GeminiV26.Instruments.BTCUSD
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -108,6 +108,10 @@ namespace GeminiV26.Instruments.ETHUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
+                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                if (sym == null)
+                    continue;
+
                 // R-distance az eredeti SL alapján
                 double rDist = ctx.RiskPriceDistance;
                 if (rDist <= 0)
@@ -118,16 +122,26 @@ namespace GeminiV26.Instruments.ETHUSD
                 // =========================
                 if (!ctx.Tp1Hit)
                 {
-                    double tp1Price =
-                        ctx.EntryPrice + Direction(pos) * rDist * ctx.Tp1R;
+                    if (ctx.Tp1R <= 0)
+                        ctx.Tp1R = 0.5;
 
-                    bool reached =
-                        (pos.TradeType == TradeType.Buy && _bot.Symbol.Bid >= tp1Price) ||
-                        (pos.TradeType == TradeType.Sell && _bot.Symbol.Ask <= tp1Price);
+                    double tp1Price = ctx.Tp1Price > 0
+                        ? ctx.Tp1Price
+                        : (pos.TradeType == TradeType.Buy
+                            ? pos.EntryPrice + rDist * ctx.Tp1R
+                            : pos.EntryPrice - rDist * ctx.Tp1R);
+
+                    if (ctx.Tp1Price <= 0)
+                        ctx.Tp1Price = tp1Price;
+
+                    double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
+                    bool reached = pos.TradeType == TradeType.Buy
+                        ? sym.Bid >= tp1Price
+                        : sym.Ask <= tp1Price;
 
                     if (reached)
                     {
-                        _bot.Print("[ETHUSD][TP1][HIT] TP1 HIT (OnTick)");
+                        _bot.Print($"[EXIT] TP1 HIT symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={currentPrice} tp1={tp1Price}");
                         ExecuteTp1(pos, ctx, rDist);
 
                         // TP1 után ne fussunk tovább ebben a tickben (BTC-vel konzisztens)
@@ -186,6 +200,7 @@ namespace GeminiV26.Instruments.ETHUSD
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
+                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
             }
         }
@@ -202,33 +217,39 @@ namespace GeminiV26.Instruments.ETHUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (sym == null)
+                return;
+
             // 1) Partial close (crypto-safe)
             // NAS logika: ctx.Tp1CloseFraction (ha nincs értelmes, 0.5)
             double frac = ctx.Tp1CloseFraction;
             if (frac <= 0 || frac >= 1)
                 frac = 0.5;
 
-            double minUnits = _bot.Symbol.VolumeInUnitsMin;
-
-            // Position.VolumeInUnits lehet double crypto instrumenten
-            double targetUnits = pos.VolumeInUnits * frac;
-
-            // Normalize a symbol step-re (crypto: 0.01, 0.001, stb.)
-            double closeUnits = _bot.Symbol.NormalizeVolumeInUnits(targetUnits);
+            long closeUnits = (long)sym.NormalizeVolumeInUnits(
+                (long)Math.Floor(pos.VolumeInUnits * frac),
+                RoundingMode.Down
+            );
+            long minUnits = (long)sym.VolumeInUnitsMin;
 
             if (closeUnits < minUnits)
-                closeUnits = minUnits;
+                return;
 
             // Ne zárjuk ki véletlen fullra (maradjon legalább minUnits)
             if (closeUnits >= pos.VolumeInUnits)
-                closeUnits = _bot.Symbol.NormalizeVolumeInUnits(
-                    pos.VolumeInUnits - minUnits);
+                closeUnits = (long)sym.NormalizeVolumeInUnits((long)Math.Floor(pos.VolumeInUnits - minUnits), RoundingMode.Down);
 
-            if (closeUnits >= minUnits && closeUnits > 0)
-            {
-                _bot.ClosePosition(pos, closeUnits);
-                ctx.Tp1ClosedVolumeInUnits = closeUnits;
-            }
+            if (closeUnits < minUnits)
+                return;
+
+            var closeResult = _bot.ClosePosition(pos, closeUnits);
+            if (!closeResult.IsSuccessful)
+                return;
+
+            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} closedUnits={closeUnits}");
+            ctx.Tp1ClosedVolumeInUnits = closeUnits;
+            ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
 
             // 2) TP1 state
             ctx.Tp1Hit = true;
@@ -247,6 +268,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
             // ModifyPosition: SL -> BE, TP marad (TP2)
             _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask)} be={bePrice}");
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -348,6 +370,8 @@ namespace GeminiV26.Instruments.ETHUSD
             }
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(pos.TradeType == TradeType.Buy ? sym?.Bid : sym?.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
             _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");


### PR DESCRIPTION
### Motivation
- Crypto ExitManagers missed the corrected TP1/TP2 lifecycle fixes applied to other instruments, causing inconsistent TP1 detection, partial close behavior, BE moves, trailing activation and TP2 extension handling.
- The change aligns BTCUSD and ETHUSD with the already-corrected ExitManager pattern used by other instruments so behavior is identical across instrument classes.

### Description
- Updated TP1 detection to prefer stored `ctx.Tp1Price` and use the correct side checks: LONG uses `sym.Bid >= tp1Price` and SHORT uses `sym.Ask <= tp1Price`, and log `[EXIT] TP1 HIT` when triggered.
- Implemented the single TP1 lifecycle: perform a crypto-safe partial close, set `ctx.Tp1Hit = true`, persist `ctx.Tp1ClosedVolumeInUnits` and `ctx.RemainingVolumeInUnits`, move SL to BE, set `ctx.BePrice`/`ctx.BeMode`, and set default trailing mode if unset, plus debugging logs for each step.
- Ensured adaptive trailing activation is gated behind `ctx.Tp1Hit` so trailing only runs after TP1, and kept `TryExtendTp2` reachable after TP1 while adding explicit `[EXIT] TP2 EXTENDED` logging.
- Standardized volume normalization and close behavior to match other corrected ExitManagers and added the required debug prints (e.g. `[EXIT] PARTIAL CLOSE executed`, `[EXIT] BE MOVE applied`, `[EXIT] TRAILING ACTIVE`).

```csharp
// Corrected TP1 detection pattern used in both managers
double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;
bool reached = pos.TradeType == TradeType.Buy
    ? sym.Bid >= tp1Price
    : sym.Ask <= tp1Price;
```

### Testing
- Attempted automated build with `dotnet build GeminiV26.csproj -v minimal`, which failed because `dotnet` is not available in this environment (build not executed).
- Verified changes with automated repository commands `git diff` and `git status` which succeeded and show only the requested files modified.
- Ran automated text inspections (`rg`/`sed`) to confirm the presence of new TP1 checks, partial close volume tracking and log lines, which succeeded.

Modified files:
- `Instruments/BTCUSD/BtcUsdExitManager.cs`
- `Instruments/ETHUSD/EthUsdExitManager.cs`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4302e10148328840cc7b7760149cd)