### PR TITLE
Fix nullable TP1 price handling in ExitManager implementations

### DIFF
--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -248,9 +248,9 @@ namespace GeminiV26.Instruments.AUDNZD
         private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
         {
             tp1Price = 0;
-            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0)
             {
-                tp1Price = ctx.Tp1Price;
+                tp1Price = ctx.Tp1Price.Value;
                 return tp1Price;
             }
 
@@ -258,7 +258,7 @@ namespace GeminiV26.Instruments.AUDNZD
                 ? pos.EntryPrice + rDist * tp1R
                 : pos.EntryPrice - rDist * tp1R;
 
-            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && (!tpCtx.Tp1Price.HasValue || tpCtx.Tp1Price.Value <= 0))
                 tpCtx.Tp1Price = tp1Price;
 
             return tp1Price;

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -248,9 +248,9 @@ namespace GeminiV26.Instruments.AUDUSD
         private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
         {
             tp1Price = 0;
-            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0)
             {
-                tp1Price = ctx.Tp1Price;
+                tp1Price = ctx.Tp1Price.Value;
                 return tp1Price;
             }
 
@@ -258,7 +258,7 @@ namespace GeminiV26.Instruments.AUDUSD
                 ? pos.EntryPrice + rDist * tp1R
                 : pos.EntryPrice - rDist * tp1R;
 
-            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && (!tpCtx.Tp1Price.HasValue || tpCtx.Tp1Price.Value <= 0))
                 tpCtx.Tp1Price = tp1Price;
 
             return tp1Price;

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -125,13 +125,13 @@ namespace GeminiV26.Instruments.BTCUSD
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = 0.5;
 
-                    double tp1Price = ctx.Tp1Price > 0
-                        ? ctx.Tp1Price
+                    double tp1Price = ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0
+                        ? ctx.Tp1Price.Value
                         : (pos.TradeType == TradeType.Buy
                             ? pos.EntryPrice + rDist * ctx.Tp1R
                             : pos.EntryPrice - rDist * ctx.Tp1R);
 
-                    if (ctx.Tp1Price <= 0)
+                    if (!ctx.Tp1Price.HasValue || ctx.Tp1Price.Value <= 0)
                         ctx.Tp1Price = tp1Price;
 
                     double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -125,13 +125,13 @@ namespace GeminiV26.Instruments.ETHUSD
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = 0.5;
 
-                    double tp1Price = ctx.Tp1Price > 0
-                        ? ctx.Tp1Price
+                    double tp1Price = ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0
+                        ? ctx.Tp1Price.Value
                         : (pos.TradeType == TradeType.Buy
                             ? pos.EntryPrice + rDist * ctx.Tp1R
                             : pos.EntryPrice - rDist * ctx.Tp1R);
 
-                    if (ctx.Tp1Price <= 0)
+                    if (!ctx.Tp1Price.HasValue || ctx.Tp1Price.Value <= 0)
                         ctx.Tp1Price = tp1Price;
 
                     double currentPrice = pos.TradeType == TradeType.Buy ? sym.Bid : sym.Ask;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -248,9 +248,9 @@ namespace GeminiV26.Instruments.EURJPY
         private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
         {
             tp1Price = 0;
-            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0)
             {
-                tp1Price = ctx.Tp1Price;
+                tp1Price = ctx.Tp1Price.Value;
                 return tp1Price;
             }
 
@@ -258,7 +258,7 @@ namespace GeminiV26.Instruments.EURJPY
                 ? pos.EntryPrice + rDist * tp1R
                 : pos.EntryPrice - rDist * tp1R;
 
-            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && (!tpCtx.Tp1Price.HasValue || tpCtx.Tp1Price.Value <= 0))
                 tpCtx.Tp1Price = tp1Price;
 
             return tp1Price;

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -173,9 +173,9 @@ namespace GeminiV26.Instruments.EURUSD
         private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
         {
             tp1Price = 0;
-            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0)
             {
-                tp1Price = ctx.Tp1Price;
+                tp1Price = ctx.Tp1Price.Value;
                 return tp1Price;
             }
 
@@ -183,7 +183,7 @@ namespace GeminiV26.Instruments.EURUSD
                 ? pos.EntryPrice + rDist * tp1R
                 : pos.EntryPrice - rDist * tp1R;
 
-            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && (!tpCtx.Tp1Price.HasValue || tpCtx.Tp1Price.Value <= 0))
                 tpCtx.Tp1Price = tp1Price;
 
             return tp1Price;

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -248,9 +248,9 @@ namespace GeminiV26.Instruments.GBPJPY
         private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
         {
             tp1Price = 0;
-            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0)
             {
-                tp1Price = ctx.Tp1Price;
+                tp1Price = ctx.Tp1Price.Value;
                 return tp1Price;
             }
 
@@ -258,7 +258,7 @@ namespace GeminiV26.Instruments.GBPJPY
                 ? pos.EntryPrice + rDist * tp1R
                 : pos.EntryPrice - rDist * tp1R;
 
-            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && (!tpCtx.Tp1Price.HasValue || tpCtx.Tp1Price.Value <= 0))
                 tpCtx.Tp1Price = tp1Price;
 
             return tp1Price;

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -138,13 +138,13 @@ namespace GeminiV26.Instruments.GBPUSD
                 return false;
 
             _contexts.TryGetValue(pos.Id, out var ctx);
-            double tp1Price = ctx != null && ctx.Tp1Price > 0
-                ? ctx.Tp1Price
+            double tp1Price = ctx != null && ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0
+                ? ctx.Tp1Price.Value
                 : (pos.TradeType == TradeType.Buy
                     ? pos.EntryPrice + rDist * tp1R
                     : pos.EntryPrice - rDist * tp1R);
 
-            if (ctx != null && ctx.Tp1Price <= 0)
+            if (ctx != null && (!ctx.Tp1Price.HasValue || ctx.Tp1Price.Value <= 0))
                 ctx.Tp1Price = tp1Price;
 
             return pos.TradeType == TradeType.Buy

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -211,13 +211,13 @@ namespace GeminiV26.Instruments.GER40
             if (sym == null)
                 return false;
 
-            double tp1Price = ctx.Tp1Price > 0
-                ? ctx.Tp1Price
+            double tp1Price = ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0
+                ? ctx.Tp1Price.Value
                 : (pos.TradeType == TradeType.Buy
                     ? pos.EntryPrice + rDist * ctx.Tp1R
                     : pos.EntryPrice - rDist * ctx.Tp1R);
 
-            if (ctx.Tp1Price <= 0)
+            if (!ctx.Tp1Price.HasValue || ctx.Tp1Price.Value <= 0)
                 ctx.Tp1Price = tp1Price;
 
             return pos.TradeType == TradeType.Buy

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -214,13 +214,13 @@ namespace GeminiV26.Instruments.NAS100
             if (sym == null || ctx.Tp1R <= 0)
                 return false;
 
-            double tp1Price = ctx.Tp1Price > 0
-                ? ctx.Tp1Price
+            double tp1Price = ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0
+                ? ctx.Tp1Price.Value
                 : (pos.TradeType == TradeType.Buy
                     ? pos.EntryPrice + rDist * ctx.Tp1R
                     : pos.EntryPrice - rDist * ctx.Tp1R);
 
-            if (ctx.Tp1Price <= 0)
+            if (!ctx.Tp1Price.HasValue || ctx.Tp1Price.Value <= 0)
                 ctx.Tp1Price = tp1Price;
 
             return pos.TradeType == TradeType.Buy

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -248,9 +248,9 @@ namespace GeminiV26.Instruments.NZDUSD
         private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
         {
             tp1Price = 0;
-            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0)
             {
-                tp1Price = ctx.Tp1Price;
+                tp1Price = ctx.Tp1Price.Value;
                 return tp1Price;
             }
 
@@ -258,7 +258,7 @@ namespace GeminiV26.Instruments.NZDUSD
                 ? pos.EntryPrice + rDist * tp1R
                 : pos.EntryPrice - rDist * tp1R;
 
-            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && (!tpCtx.Tp1Price.HasValue || tpCtx.Tp1Price.Value <= 0))
                 tpCtx.Tp1Price = tp1Price;
 
             return tp1Price;

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -248,9 +248,9 @@ namespace GeminiV26.Instruments.USDCAD
         private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
         {
             tp1Price = 0;
-            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0)
             {
-                tp1Price = ctx.Tp1Price;
+                tp1Price = ctx.Tp1Price.Value;
                 return tp1Price;
             }
 
@@ -258,7 +258,7 @@ namespace GeminiV26.Instruments.USDCAD
                 ? pos.EntryPrice + rDist * tp1R
                 : pos.EntryPrice - rDist * tp1R;
 
-            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && (!tpCtx.Tp1Price.HasValue || tpCtx.Tp1Price.Value <= 0))
                 tpCtx.Tp1Price = tp1Price;
 
             return tp1Price;

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -248,9 +248,9 @@ namespace GeminiV26.Instruments.USDCHF
         private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
         {
             tp1Price = 0;
-            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0)
             {
-                tp1Price = ctx.Tp1Price;
+                tp1Price = ctx.Tp1Price.Value;
                 return tp1Price;
             }
 
@@ -258,7 +258,7 @@ namespace GeminiV26.Instruments.USDCHF
                 ? pos.EntryPrice + rDist * tp1R
                 : pos.EntryPrice - rDist * tp1R;
 
-            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && (!tpCtx.Tp1Price.HasValue || tpCtx.Tp1Price.Value <= 0))
                 tpCtx.Tp1Price = tp1Price;
 
             return tp1Price;

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -173,9 +173,9 @@ namespace GeminiV26.Instruments.USDJPY
         private double ctxTp1PriceOrFallback(Position pos, double rDist, double tp1R, out double tp1Price)
         {
             tp1Price = 0;
-            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price > 0)
+            if (_contexts.TryGetValue(pos.Id, out var ctx) && ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0)
             {
-                tp1Price = ctx.Tp1Price;
+                tp1Price = ctx.Tp1Price.Value;
                 return tp1Price;
             }
 
@@ -183,7 +183,7 @@ namespace GeminiV26.Instruments.USDJPY
                 ? pos.EntryPrice + rDist * tp1R
                 : pos.EntryPrice - rDist * tp1R;
 
-            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && tpCtx.Tp1Price <= 0)
+            if (_contexts.TryGetValue(pos.Id, out var tpCtx) && (!tpCtx.Tp1Price.HasValue || tpCtx.Tp1Price.Value <= 0))
                 tpCtx.Tp1Price = tp1Price;
 
             return tp1Price;

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -138,13 +138,13 @@ namespace GeminiV26.Instruments.XAUUSD
                 {
                     double tp1R = ResolveTp1R(ctx);
 
-                    double tp1Price = ctx.Tp1Price > 0
-                        ? ctx.Tp1Price
+                    double tp1Price = ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0
+                        ? ctx.Tp1Price.Value
                         : (pos.TradeType == TradeType.Buy
                             ? pos.EntryPrice + rDist * tp1R
                             : pos.EntryPrice - rDist * tp1R);
 
-                    if (ctx.Tp1Price <= 0)
+                    if (!ctx.Tp1Price.HasValue || ctx.Tp1Price.Value <= 0)
                         ctx.Tp1Price = tp1Price;
 
                     if (ctx.Tp1R <= 0)


### PR DESCRIPTION
### Motivation
- Several `ExitManager` implementations used nullable `double?` values like `ctx.Tp1Price` directly in comparisons/ternaries and assignments, which caused compile/type errors when assigning to non-nullable `double` variables.
- The intent is to preserve the existing exit behavior while making the code null-safe by only accessing `.Value` after checking `.HasValue`.

### Description
- Replaced patterns like `ctx.Tp1Price > 0 ? ctx.Tp1Price : fallback` with `ctx.Tp1Price.HasValue && ctx.Tp1Price.Value > 0 ? ctx.Tp1Price.Value : fallback` in all affected `*ExitManager.cs` files.
- Updated cached/fallback logic in `ctxTp1PriceOrFallback` and similar helpers to return `ctx.Tp1Price.Value` only after `HasValue` checks and to set `ctx.Tp1Price = tp1Price` when appropriate using safe conditionals (`!ctx.Tp1Price.HasValue || ctx.Tp1Price.Value <= 0`).
- Fixed accidental double-`.Value` occurrences and added parentheses in mixed `&&`/`||` conditions to preserve evaluation and avoid null access.
- Changes touch the TP1 handling across 15 exit manager files (e.g. `BTCUSD`, `ETHUSD`, `EURUSD`, `USDJPY`, `USDCAD`, `XAUUSD`, `NAS100`, `GER40`, `GBPUSD`, `GBPJPY`, `AUDUSD`, `AUDNZD`, `NZDUSD`, `USDCHF`, `AUDUSD`).

### Testing
- Ran targeted pattern searches with `rg` to verify there are no remaining direct comparisons/ternary usages of `ctx.Tp1Price` that would access nullable values without `HasValue` (ripgrep checks succeeded).
- Performed repository diff checks to ensure only the intended nullable-handling edits were introduced (no style or unrelated changes detected).
- Attempted to run a full build with `dotnet build` but the environment does not have `dotnet` installed, so a full compile could not be executed in this container (build needs to be run in CI or a developer machine).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b431bae9148328b7c29739bb4dcf16)