### PR TITLE
Centralize risk percent mapping and add global lot-cap safety limiter

### DIFF
--- a/Core/Risk/Exposure/LotCapEngine.cs
+++ b/Core/Risk/Exposure/LotCapEngine.cs
@@ -1,0 +1,23 @@
+namespace GeminiV26.Core.Risk.Exposure
+{
+    public static class LotCapEngine
+    {
+        public const double ReferenceBalance = 10000.0;
+        public const double ReferenceSlDistance = 3.0;
+
+        public static double CalculateLotCap(
+            double balance,
+            double slDistance,
+            double riskPercent)
+        {
+            if (balance <= 0 || slDistance <= 0 || riskPercent <= 0)
+                return 0;
+
+            double riskAmount = balance * riskPercent / 100.0;
+            double riskPosition = riskAmount / slDistance;
+            double cap = riskPosition * 1.2;
+
+            return cap;
+        }
+    }
+}

--- a/Core/Risk/RiskProfiles/RiskProfileEngine.cs
+++ b/Core/Risk/RiskProfiles/RiskProfileEngine.cs
@@ -1,0 +1,13 @@
+namespace GeminiV26.Core.Risk.RiskProfiles
+{
+    public static class RiskProfileEngine
+    {
+        public static double GetRiskPercent(int finalConfidence)
+        {
+            if (finalConfidence >= 90) return 0.70;
+            if (finalConfidence >= 80) return 0.55;
+            if (finalConfidence >= 70) return 0.40;
+            return 0.30;
+        }
+    }
+}

--- a/Instruments/AUDNZD/AudNzdInstrumentRiskSizer.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -32,13 +34,9 @@ namespace GeminiV26.Instruments.AUDNZD
         // =========================
         // RISK %
         // =========================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            double n = NormalizeScore(score);
-
-            // FX – konzervatív, de skálázódó
-            // 0.22% → 0.35%
-            return 0.22 + n * (0.35 - 0.22);
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================
@@ -88,21 +86,13 @@ namespace GeminiV26.Instruments.AUDNZD
         // =========================
         // LOT CAP
         // =========================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         private static double NormalizeScore(int score)

--- a/Instruments/AUDUSD/AudUsdInstrumentRiskSizer.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -32,13 +34,9 @@ namespace GeminiV26.Instruments.AUDUSD
         // =========================
         // RISK %
         // =========================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            double n = NormalizeScore(score);
-
-            // FX – konzervatív, de skálázódó
-            // 0.22% → 0.35%
-            return 0.22 + n * (0.35 - 0.22);
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================
@@ -88,21 +86,13 @@ namespace GeminiV26.Instruments.AUDUSD
         // =========================
         // LOT CAP
         // =========================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         private static double NormalizeScore(int score)

--- a/Instruments/BTCUSD/BtcUsdInstrumentRiskSizer.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentRiskSizer.cs
@@ -29,6 +29,8 @@
 // =========================================================
 
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 
 namespace GeminiV26.Instruments.BTCUSD
@@ -40,10 +42,7 @@ namespace GeminiV26.Instruments.BTCUSD
         // =========================================================
         public double GetRiskPercent(int finalConfidence)
         {
-            if (finalConfidence >= 90) return 1.00;
-            if (finalConfidence >= 80) return 0.75;
-            if (finalConfidence >= 70) return 0.55;
-            return 0.40;
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================================================
@@ -91,21 +90,13 @@ namespace GeminiV26.Instruments.BTCUSD
         // =========================================================
         // LOT CAP (BTC specifikus)
         // =========================================================
-        public double GetLotCap(int confidence)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (confidence - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (confidence >= 80)
-                baseCap += 0.5;
-
-            if (confidence >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
     }
 }

--- a/Instruments/ETHUSD/EthUsdInstrumentRiskSizer.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentRiskSizer.cs
@@ -29,6 +29,8 @@
 // =========================================================
 
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 
 namespace GeminiV26.Instruments.ETHUSD
@@ -40,10 +42,7 @@ namespace GeminiV26.Instruments.ETHUSD
         // =========================================================
         public double GetRiskPercent(int finalConfidence)
         {
-            if (finalConfidence >= 90) return 0.60;
-            if (finalConfidence >= 80) return 0.45;
-            if (finalConfidence >= 70) return 0.30;
-            return 0.22;
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================================================
@@ -94,21 +93,13 @@ namespace GeminiV26.Instruments.ETHUSD
         // =========================================================
         // LOT CAP (ETH specifikus)
         // =========================================================
-        public double GetLotCap(int confidence)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (confidence - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (confidence >= 80)
-                baseCap += 0.5;
-
-            if (confidence >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
     }
 }

--- a/Instruments/EURJPY/EurJpyInstrumentRiskSizer.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -32,13 +34,9 @@ namespace GeminiV26.Instruments.EURJPY
         // =========================
         // RISK %
         // =========================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            double n = NormalizeScore(score);
-
-            // JPY: óvatosabb plafon
-            // 0.22% → 0.32%
-            return 0.22 + n * (0.32 - 0.22);
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================
@@ -95,21 +93,13 @@ namespace GeminiV26.Instruments.EURJPY
         // =========================
         // LOT CAP
         // =========================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         private static double NormalizeScore(int score)

--- a/Instruments/EURUSD/EurUsdInstrumentRiskSizer.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -33,12 +35,9 @@ namespace GeminiV26.Instruments.EURUSD
         // =========================
         // RISK %
         // =========================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            double n = NormalizeScore(score);
-
-            // 0.40% → 0.75% (kicsit erősebb FX London trendhez)
-            return 0.40 + n * (0.75 - 0.40);
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================
@@ -83,21 +82,13 @@ namespace GeminiV26.Instruments.EURUSD
         // =========================
         // LOT CAP – UPGRADED
         // =========================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         // =========================

--- a/Instruments/GBPJPY/GbpJpyInstrumentRiskSizer.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -32,13 +34,9 @@ namespace GeminiV26.Instruments.GBPJPY
         // =========================
         // RISK %
         // =========================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            double n = NormalizeScore(score);
-
-            // GBPJPY: extra volatilis → alacsonyabb plafon
-            // 0.20% → 0.30%
-            return 0.20 + n * (0.30 - 0.20);
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================
@@ -95,21 +93,13 @@ namespace GeminiV26.Instruments.GBPJPY
         // =========================
         // LOT CAP
         // =========================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         private static double NormalizeScore(int score)

--- a/Instruments/GBPUSD/GbpUsdInstrumentRiskSizer.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 ﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -22,15 +24,9 @@ namespace GeminiV26.Instruments.GBPUSD
         //private const double SlWide = 1.95;
         //private const double SlTight = 1.45;
 
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            double n = NormalizeScore(score);
-
-            if (n < 0.15) return 0.0;          // régi <60
-            if (n < 0.40) return RiskLow;      // ~65–70
-            if (n < 0.65) return RiskMed;      // ~75
-            if (n < 0.85) return RiskHigh;     // ~82–85
-            return RiskMax;                    // top setup
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         public double GetStopLossAtrMultiplier(int score, EntryType _ /* FX ignores entry type */)
@@ -73,21 +69,13 @@ namespace GeminiV26.Instruments.GBPUSD
             tp2Ratio = 1.0 - tp1Ratio;
         }
 
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         private static double NormalizeScore(int score)

--- a/Instruments/GER40/Ger40InstrumentRiskSizer.cs
+++ b/Instruments/GER40/Ger40InstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 ﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 
 namespace GeminiV26.Instruments.GER40
@@ -26,11 +28,9 @@ namespace GeminiV26.Instruments.GER40
         // RISK % – score alapján
         // Cél: 1 jó trade = napi 100–200 USD
         // =====================================================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            if (score >= 85) return 1.20;
-            if (score >= 75) return 0.90;
-            return 0.60;
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =====================================================
@@ -79,21 +79,13 @@ namespace GeminiV26.Instruments.GER40
         // =====================================================
         // LOT CAP – HARD LIMIT
         // =====================================================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
     }
 }

--- a/Instruments/NAS100/NasInstrumentRiskSizer.cs
+++ b/Instruments/NAS100/NasInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 ﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 
 namespace GeminiV26.Instruments.NAS100
@@ -26,12 +28,9 @@ namespace GeminiV26.Instruments.NAS100
         // RISK % – score alapján
         // Cél: 1 jó trade = napi 100–200 USD
         // =====================================================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            // Indexeken óvatosabb, mint XAU
-            if (score >= 85) return 0.60;   // top quality
-            if (score >= 75) return 0.45;   // jó setup
-            return 0.35;                    // baseline
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =====================================================
@@ -84,21 +83,13 @@ namespace GeminiV26.Instruments.NAS100
         // =====================================================
         // LOT CAP – HARD LIMIT
         // =====================================================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
     }
 }

--- a/Instruments/NZDUSD/NzdUsdInstrumentRiskSizer.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -32,13 +34,9 @@ namespace GeminiV26.Instruments.NZDUSD
         // =========================
         // RISK %
         // =========================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            double n = NormalizeScore(score);
-
-            // FX – konzervatív, de skálázódó
-            // 0.22% → 0.35%
-            return 0.22 + n * (0.35 - 0.22);
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================
@@ -88,21 +86,13 @@ namespace GeminiV26.Instruments.NZDUSD
         // =========================
         // LOT CAP
         // =========================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         private static double NormalizeScore(int score)

--- a/Instruments/US30/Us30InstrumentRiskSizer.cs
+++ b/Instruments/US30/Us30InstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 ﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 
 namespace GeminiV26.Instruments.US30
@@ -31,13 +33,9 @@ namespace GeminiV26.Instruments.US30
         // =========================
         // RISK %
         // =========================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            if (score < 60) return 0.0;
-            if (score < 70) return RiskLow;
-            if (score < 80) return RiskMed;
-            if (score < 90) return RiskHigh;
-            return RiskMax;
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================
@@ -123,21 +121,13 @@ namespace GeminiV26.Instruments.US30
         // =========================
         // LOT CAP
         // =========================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
     }
 }

--- a/Instruments/USDCAD/UsdCadInstrumentRiskSizer.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -32,13 +34,9 @@ namespace GeminiV26.Instruments.USDCAD
         // =========================
         // RISK %
         // =========================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            double n = NormalizeScore(score);
-
-            // FX – konzervatív, de skálázódó
-            // 0.22% → 0.35%
-            return 0.22 + n * (0.35 - 0.22);
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================
@@ -88,21 +86,13 @@ namespace GeminiV26.Instruments.USDCAD
         // =========================
         // LOT CAP
         // =========================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         private static double NormalizeScore(int score)

--- a/Instruments/USDCHF/UsdChfInstrumentRiskSizer.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -32,13 +34,9 @@ namespace GeminiV26.Instruments.USDCHF
         // =========================
         // RISK %
         // =========================
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            double n = NormalizeScore(score);
-
-            // FX – konzervatív, de skálázódó
-            // 0.22% → 0.35%
-            return 0.25 + n * (0.40 - 0.25);
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================
@@ -88,21 +86,13 @@ namespace GeminiV26.Instruments.USDCHF
         // =========================
         // LOT CAP
         // =========================
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         private static double NormalizeScore(int score)

--- a/Instruments/USDJPY/UsdJpyInstrumentRiskSizer.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentRiskSizer.cs
@@ -1,4 +1,6 @@
 ﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -23,13 +25,9 @@ namespace GeminiV26.Instruments.USDJPY
         private const double SlWide = 1.75;
         private const double SlTight = 1.25;
 
-        public double GetRiskPercent(int score)
+        public double GetRiskPercent(int finalConfidence)
         {
-            double n = NormalizeScore(score);
-
-            // USDJPY – meaningful risk
-            // 0.40% → 0.75%
-            return 0.40 + n * (0.75 - 0.40);
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         public double GetStopLossAtrMultiplier(int score, EntryType entryType)
@@ -81,21 +79,13 @@ namespace GeminiV26.Instruments.USDJPY
             tp2Ratio = 0.55;
         }
 
-        public double GetLotCap(int score)
+        public double GetLotCap(int finalConfidence)
         {
-            double n = (score - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (score >= 80)
-                baseCap += 0.5;
-
-            if (score >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         private static double NormalizeScore(int score)

--- a/Instruments/XAUUSD/XauInstrumentRiskSizer.cs
+++ b/Instruments/XAUUSD/XauInstrumentRiskSizer.cs
@@ -24,6 +24,8 @@
 
 using cAlgo.API;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Risk.Exposure;
+using GeminiV26.Core.Risk.RiskProfiles;
 using GeminiV26.Risk;
 using System;
 
@@ -36,9 +38,7 @@ namespace GeminiV26.Instruments.XAUUSD
         // =========================================================
         public double GetRiskPercent(int finalConfidence)
         {
-            if (finalConfidence >= 85) return 0.40;
-            if (finalConfidence >= 75) return 0.30;
-            return 0.18;
+            return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
         // =========================================================
@@ -95,19 +95,11 @@ namespace GeminiV26.Instruments.XAUUSD
         // =========================================================
         public double GetLotCap(int finalConfidence)
         {
-            double n = (finalConfidence - 55) / 35.0;
-            if (n < 0.0) n = 0.0;
-            if (n > 1.0) n = 1.0;
-
-            double baseCap = 2.0 + n * 1.0;
-
-            if (finalConfidence >= 80)
-                baseCap += 0.5;
-
-            if (finalConfidence >= 85)
-                baseCap += 0.5;
-
-            return baseCap;
+            double riskPercent = RiskProfileEngine.GetRiskPercent(finalConfidence);
+            return LotCapEngine.CalculateLotCap(
+                LotCapEngine.ReferenceBalance,
+                LotCapEngine.ReferenceSlDistance,
+                riskPercent);
         }
 
         // =========================================================


### PR DESCRIPTION
### Motivation
- Remove duplicated risk-percent tables and instrument-specific lot-cap math by centralizing risk profile and creating a single global safety limiter while keeping PositionSizing engines unchanged. 
- Provide a single source of truth for `FinalConfidence -> riskPercent` mapping and a simple safety cap so lot-caps rarely activate in normal operation.

### Description
- Added `Core/Risk/RiskProfiles/RiskProfileEngine.cs` with `public static double GetRiskPercent(int finalConfidence)` implementing the 90/80/70 thresholds and fallback as a percent value. 
- Added `Core/Risk/Exposure/LotCapEngine.cs` with `public static double CalculateLotCap(double balance, double slDistance, double riskPercent)` implementing `riskAmount = balance * riskPercent / 100`, `riskPosition = riskAmount / slDistance` and `cap = riskPosition * 1.2`, plus `ReferenceBalance` and `ReferenceSlDistance` constants for delegation without changing interfaces. 
- Updated all instrument `*InstrumentRiskSizer` classes (16 files) to delegate `GetRiskPercent(...)` to `RiskProfileEngine.GetRiskPercent(...)` and to delegate lot-cap calculation in `GetLotCap(...)` to `LotCapEngine.CalculateLotCap(...)`, while preserving `GetStopLossAtrMultiplier(...)` and `GetTakeProfit(...)` implementations and keeping all interface signatures intact. 

### Testing
- Verified all 16 instrument risk sizers now call `RiskProfileEngine.GetRiskPercent(...)` using a repository-wide pattern search (match count: 16). 
- Verified all 16 instrument risk sizers delegate to `LotCapEngine.CalculateLotCap(...)` using a repository-wide pattern search (match count: 16). 
- Attempted a full `dotnet build` in this environment but it could not be executed because the `dotnet` tooling is not available here (build not performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b53919b0bc8328896a273e894e2fa7)