### PR TITLE
Refactor exit managers to event-driven direction logging

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -52,6 +52,8 @@ namespace GeminiV26.Core
 
         public TradeDirection FinalDirection { get; set; } = TradeDirection.None;
 
+        public bool MissingDirLogged { get; set; }
+
 
         // =========================================================
         // CONFIDENCE PIPELINE (Rulebook 1.0)

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -647,6 +647,7 @@ namespace GeminiV26.Core
                     pctx.FinalDirection = _ctx?.FinalDirection != TradeDirection.None
                         ? _ctx.FinalDirection
                         : FromTradeType(pos.TradeType);
+                    _bot.Print($"[DIR][SET] posId={pctx.PositionId} finalDir={pctx.FinalDirection}");
 
                     if (pctx.FinalDirection == TradeDirection.None)
                     {
@@ -1354,6 +1355,7 @@ namespace GeminiV26.Core
 
                 _ctx.RoutedDirection = selected.Direction;
                 _ctx.FinalDirection = selected.Direction;
+                _bot.Print($"[DIR][SET] posId={_ctx.PositionId} finalDir={_ctx.FinalDirection}");
 
                 if (_ctx.FinalDirection == TradeDirection.None)
                 {

--- a/Core/TradeViabilityMonitor.cs
+++ b/Core/TradeViabilityMonitor.cs
@@ -113,7 +113,12 @@ namespace GeminiV26.Core
         {
             if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][TVM_CTX_ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.AUDNZD
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.AUDNZD
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.AUDNZD
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[AUDNZD][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -225,6 +225,7 @@ namespace GeminiV26.Instruments.AUDNZD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.AUDUSD
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.AUDUSD
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.AUDUSD
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[AUDUSD][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -228,6 +228,7 @@ namespace GeminiV26.Instruments.AUDUSD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -57,9 +57,17 @@ namespace GeminiV26.Instruments.BTCUSD
         // =========================================================
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -94,12 +102,8 @@ namespace GeminiV26.Instruments.BTCUSD
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -269,7 +273,6 @@ namespace GeminiV26.Instruments.BTCUSD
         // =========================================================
         public void Manage(Position pos)
         {
-            _bot.Print("[BTCUSD][INFO] Manage() called, exit handled in OnTick()");
         }
 
         // =========================================================

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -221,6 +221,7 @@ namespace GeminiV26.Instruments.BTCUSD
                                              TrailingMode.Tight;
 
             _positionContexts[posId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -47,9 +47,17 @@ namespace GeminiV26.Instruments.ETHUSD
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -78,12 +86,8 @@ namespace GeminiV26.Instruments.ETHUSD
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
 
@@ -233,7 +237,6 @@ namespace GeminiV26.Instruments.ETHUSD
 
         public void Manage(Position pos)
         {
-            _bot.Print("[ETHUSD][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -220,6 +220,7 @@ namespace GeminiV26.Instruments.ETHUSD
                                              TrailingMode.Tight;
 
             _positionContexts[posId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.EURJPY
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.EURJPY
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.EURJPY
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[EURJPY][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -228,6 +228,7 @@ namespace GeminiV26.Instruments.EURJPY
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.EURUSD
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.EURUSD
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.EURUSD
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[EURUSD][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -220,6 +220,7 @@ namespace GeminiV26.Instruments.EURUSD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.GBPJPY
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.GBPJPY
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.GBPJPY
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[GBPJPY][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -228,6 +228,7 @@ namespace GeminiV26.Instruments.GBPJPY
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.GBPUSD
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.GBPUSD
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.GBPUSD
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[GBPUSD][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -226,6 +226,7 @@ namespace GeminiV26.Instruments.GBPUSD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[positionKey] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
         }
 

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.GER40
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.GER40
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.GER40
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[GER40][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -206,6 +206,7 @@ namespace GeminiV26.Instruments.GER40
             ctx.ComputeFinalConfidence();
 
             _positionContexts[positionKey] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
         }
 

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.NAS100
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.NAS100
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.NAS100
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[NAS100][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.NAS100
             ctx.ComputeFinalConfidence();
 
             _positionContexts[positionKey] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
         }
 

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.NZDUSD
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.NZDUSD
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.NZDUSD
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[NZDUSD][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -228,6 +228,7 @@ namespace GeminiV26.Instruments.NZDUSD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.US30
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.US30
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.US30
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[US30][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -195,6 +195,7 @@ namespace GeminiV26.Instruments.US30
             ctx.ComputeFinalConfidence();
 
             _positionContexts[positionKey] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
         }
 

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.USDCAD
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.USDCAD
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.USDCAD
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[USDCAD][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -228,6 +228,7 @@ namespace GeminiV26.Instruments.USDCAD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.USDCHF
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.USDCHF
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.USDCHF
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[USDCHF][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -228,6 +228,7 @@ namespace GeminiV26.Instruments.USDCHF
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -30,9 +30,17 @@ namespace GeminiV26.Instruments.USDJPY
 
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -61,12 +69,8 @@ namespace GeminiV26.Instruments.USDJPY
                 if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
                     continue;
 
-                _bot.Print($"[DIR][EXIT_CTX] posId={key} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={key}");
                     continue;
-                }
 
                 Position pos = null;
                 foreach (var p in _bot.Positions)
@@ -177,7 +181,6 @@ namespace GeminiV26.Instruments.USDJPY
 
         public void Manage(Position pos)
         {
-            _bot.Print($"[USDJPY][INFO] Manage() called, exit handled in OnTick()");
         }
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -218,6 +218,7 @@ namespace GeminiV26.Instruments.USDJPY
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
         }
 

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -71,9 +71,17 @@ namespace GeminiV26.Instruments.XAUUSD
         // TradeCore/Executor hívja sikeres belépés után
         public void RegisterContext(PositionContext ctx)
         {
-            if (ctx == null || ctx.FinalDirection == TradeDirection.None)
+            if (ctx == null)
+                return;
+
+            if (ctx.FinalDirection == TradeDirection.None)
             {
-                _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx?.PositionId}");
+                if (!ctx.MissingDirLogged)
+                {
+                    _bot.Print($"[DIR][ERROR] Missing FinalDirection posId={ctx.PositionId}");
+                    ctx.MissingDirLogged = true;
+                }
+
                 return;
             }
 
@@ -113,12 +121,8 @@ namespace GeminiV26.Instruments.XAUUSD
         {
             foreach (var ctx in _contexts.Values)
             {
-                _bot.Print($"[DIR][EXIT_CTX] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
                 if (ctx.FinalDirection == TradeDirection.None)
-                {
-                    _bot.Print($"[DIR][POS_CTX_ERROR] Missing FinalDirection posId={ctx.PositionId}");
                     continue;
-                }
 
                 var pos = _bot.Positions.FirstOrDefault(p => p.Id == ctx.PositionId);
                 if (pos == null)

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -308,6 +308,7 @@ namespace GeminiV26.Instruments.XAUUSD
             // 10 REGISTER CONTEXT
             // =====================================================
             _positionContexts[ctx.PositionId] = ctx;
+            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
             _exitManager.RegisterContext(ctx);
 
             _bot.Print(


### PR DESCRIPTION
### Motivation
- Eliminate huge per-tick log spam coming from ExitManager `OnTick` loops and make direction/context logging event-driven only. 
- Ensure missing FinalDirection is reported as a single critical event, not repeatedly every tick. 
- Preserve all trading, execution and risk logic while only changing logging behavior.

### Description
- Added `public bool MissingDirLogged { get; set; }` to `PositionContext` and used it to ensure missing-direction errors are logged once per context. 
- Removed repeated `_bot.Print` calls that printed `[DIR][EXIT_CTX]` / repeated `[DIR][POS_CTX_ERROR]` from all instrument `ExitManager.OnTick()` implementations so OnTick is silent about direction/state. 
- Changed `RegisterContext(PositionContext ctx)` in every `ExitManager` to validate `FinalDirection`, log a single one-time error using `MissingDirLogged` when missing, and otherwise register the context. 
- Added event-driven `[DIR][SET] posId=... finalDir=...` logging at final-direction assignment sites: in `TradeCore` where `_ctx.FinalDirection` is set and in each instrument executor immediately before registering the context with the exit manager. 
- Aligned `TradeViabilityMonitor` missing-direction handling to use the one-time `MissingDirLogged` behavior and removed non-event per-tick Manage/info prints in ExitManagers.

### Testing
- Ran static/diff check with `git diff --check` and confirmed no whitespace/diff-check errors; the check passed. 
- Verified removal of per-tick exit context logs with `rg -n "\[DIR\]\[EXIT_CTX\]|\[DIR\]\[POS_CTX_ERROR\]" Instruments --glob '*ExitManager.cs'` and confirmed none remain. 
- Verified presence of event-driven set logs with `rg -n "\[DIR\]\[SET\]" Core/TradeCore.cs Instruments/*/*InstrumentExecutor.cs` and confirmed the new `[DIR][SET]` lines are present. 
- All automated grep-based assertions used for verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba7d1aa5a08328b61567faf3763ebd)