### PR TITLE
Neutralize transition projection and fix flag-bars source

### DIFF
--- a/Core/Entry/FlagBreakoutDetector.cs
+++ b/Core/Entry/FlagBreakoutDetector.cs
@@ -86,7 +86,9 @@ namespace GeminiV26.Core.Entry
                 return;
             }
 
-            int flagBars = Math.Max(0, ctx.Transition.FlagBars);
+            int flagBars = Math.Max(
+                ctx.FlagBarsLong_M5,
+                ctx.FlagBarsShort_M5);
             int lastClosed = ctx.M5.Count - 2;
             if (flagBars <= 0)
             {

--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -72,44 +72,33 @@ namespace GeminiV26.Core.Entry
             ctx.TransitionLong = BuildEvaluation(longSide);
             ctx.TransitionShort = BuildEvaluation(shortSide);
 
-            // =========================================================
-            // Backward compatibility layer
-            // Neutrális projection: csak akkor tükrözünk vissza irányt,
-            // ha az egyik oldal érdemben tradable state-ben van, a másik nem.
-            // =========================================================
-            if (longSide.IsTradable && !shortSide.IsTradable)
-            {
-                ApplyLegacyProjection(ctx, longSide, TradeDirection.Long);
-            }
-            else if (!longSide.IsTradable && shortSide.IsTradable)
-            {
-                ApplyLegacyProjection(ctx, shortSide, TradeDirection.Short);
-            }
-            else
-            {
-                ctx.HasImpulse_M5 = longSide.HasImpulse || shortSide.HasImpulse;
-                ctx.BarsSinceImpulse_M5 = Math.Min(
-                    longSide.HasImpulse ? longSide.BarsSinceImpulse : 999,
-                    shortSide.HasImpulse ? shortSide.BarsSinceImpulse : 999);
+            ctx.HasImpulse_M5 = longSide.HasImpulse || shortSide.HasImpulse;
 
-                ctx.TransitionValid = false;
-                ctx.TransitionScoreBonus = 0;
-                ctx.Transition = new TransitionEvaluation
-                {
-                    HasImpulse = ctx.HasImpulse_M5,
-                    HasPullback = longSide.HasPullback || shortSide.HasPullback,
-                    HasFlag = longSide.HasFlag || shortSide.HasFlag,
-                    BarsSinceImpulse = ctx.BarsSinceImpulse_M5 >= 999 ? -1 : ctx.BarsSinceImpulse_M5,
-                    PullbackBars = Math.Max(longSide.PullbackBars, shortSide.PullbackBars),
-                    FlagBars = Math.Max(longSide.FlagBars, shortSide.FlagBars),
-                    PullbackDepthR = Math.Max(longSide.PullbackDepthR, shortSide.PullbackDepthR),
-                    CompressionScore = Math.Max(longSide.CompressionScore, shortSide.CompressionScore),
-                    QualityScore = Math.Max(longSide.QualityScore, shortSide.QualityScore),
-                    IsValid = false,
-                    BonusScore = 0,
-                    Reason = "NoDirectionalConsensus"
-                };
-            }
+            ctx.BarsSinceImpulse_M5 = Math.Min(
+                longSide.HasImpulse ? longSide.BarsSinceImpulse : 999,
+                shortSide.HasImpulse ? shortSide.BarsSinceImpulse : 999);
+
+            // 🚫 HARD RULE: Transition NEVER creates tradable signal
+            ctx.TransitionValid = false;
+            ctx.TransitionScoreBonus = 0;
+
+            // 🚫 PURE NEUTRAL AGGREGATION (NO DIRECTION)
+            ctx.Transition = new TransitionEvaluation
+            {
+                HasImpulse = ctx.HasImpulse_M5,
+                HasPullback = longSide.HasPullback || shortSide.HasPullback,
+                HasFlag = longSide.HasFlag || shortSide.HasFlag,
+                BarsSinceImpulse = ctx.BarsSinceImpulse_M5 >= 999 ? -1 : ctx.BarsSinceImpulse_M5,
+                PullbackBars = Math.Max(longSide.PullbackBars, shortSide.PullbackBars),
+                FlagBars = Math.Max(longSide.FlagBars, shortSide.FlagBars),
+                PullbackDepthR = Math.Max(longSide.PullbackDepthR, shortSide.PullbackDepthR),
+                CompressionScore = Math.Max(longSide.CompressionScore, shortSide.CompressionScore),
+                QualityScore = Math.Max(longSide.QualityScore, shortSide.QualityScore),
+
+                IsValid = false,
+                BonusScore = 0,
+                Reason = "Neutral_NoProjection"
+            };
 
             // =========================================================
             // PullbackDepthAtr backward fill
@@ -435,14 +424,29 @@ namespace GeminiV26.Core.Entry
             SideEvaluation side,
             TradeDirection direction)
         {
-            ctx.HasImpulse_M5 = side.HasImpulse;
-            ctx.BarsSinceImpulse_M5 = side.HasImpulse ? side.BarsSinceImpulse : 999;
+            // LEGACY DISABLED — DO NOT PROJECT DIRECTION
 
-            ctx.TransitionValid = side.IsTradable;
-            ctx.TransitionScoreBonus = side.BonusScore;
-            ctx.Transition = BuildEvaluation(side);
+            ctx.TransitionValid = false;
+            ctx.TransitionScoreBonus = 0;
 
-            ctx.Log?.Invoke($"[DIR][TRANSITION_LEGACY] sym={ctx.Symbol} projectedSide={direction} trendPreserved={ctx.TrendDirection} impulsePreserved={ctx.ImpulseDirection}");
+            ctx.Transition = new TransitionEvaluation
+            {
+                HasImpulse = side.HasImpulse,
+                HasPullback = side.HasPullback,
+                HasFlag = side.HasFlag,
+                BarsSinceImpulse = side.HasImpulse ? side.BarsSinceImpulse : -1,
+                PullbackBars = side.PullbackBars,
+                FlagBars = side.FlagBars,
+                PullbackDepthR = side.PullbackDepthR,
+                CompressionScore = side.CompressionScore,
+                QualityScore = side.QualityScore,
+
+                IsValid = false,
+                BonusScore = 0,
+                Reason = "LegacyDisabled"
+            };
+
+            ctx.Log?.Invoke("[TRANSITION_LEGACY_DISABLED]");
         }
 
         private static TransitionEvaluation BuildEvaluation(SideEvaluation side)


### PR DESCRIPTION
### Motivation

- Prevent directional leakage from the transition detector into `ctx.Transition` which caused counter-trend entries by ensuring transition remains a pure descriptive, neutral layer.
- Remove legacy projection and any directional projection paths so `ctx.Transition` never implies tradable state, bonus score, or direction.
- Ensure flag breakout uses explicit directional M5 fields rather than aggregated transition output.

### Description

- Removed the backward-compatibility projection path in `Core/Entry/TransitionDetector.cs` and replaced it with a single neutral aggregation block that sets `ctx.HasImpulse_M5`, `ctx.BarsSinceImpulse_M5`, `ctx.TransitionValid = false`, `ctx.TransitionScoreBonus = 0`, and `ctx.Transition` with `IsValid = false`, `BonusScore = 0` and `Reason = "Neutral_NoProjection"`.
- Neutralized `ApplyLegacyProjection(...)` in `Core/Entry/TransitionDetector.cs` so it no longer uses `side.IsTradable`, `side.BonusScore`, or `BuildEvaluation(side)` and instead writes a descriptive non-tradable `TransitionEvaluation` with `IsValid = false`, `BonusScore = 0`, and `Reason = "LegacyDisabled"`, and emits the `[TRANSITION_LEGACY_DISABLED]` log line.
- Updated `Core/Entry/FlagBreakoutDetector.cs` to compute `flagBars` from `ctx.FlagBarsLong_M5` and `ctx.FlagBarsShort_M5` instead of reading `ctx.Transition.FlagBars`.
- Preserved `BuildEvaluation` and other helpers untouched; no method signatures or public APIs were changed and no new dependencies introduced.

### Testing

- Ran targeted static checks to ensure forbidden legacy usage was removed from the legacy projection (`rg` searches verified no uses of `side.IsTradable`, `side.BonusScore`, or `BuildEvaluation(side)` in the neutralized legacy method). 
- Verified neutrality markers are present (`IsValid = false`, `BonusScore = 0`, and distinct `Reason` values `Neutral_NoProjection` / `LegacyDisabled`) via `rg` checks.
- Attempted a full repository build validation but `dotnet`, `csc`, and `mcs` are not available in the environment, so a compile was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba921b3b388328ab204ac1f3a74575)