### PR TITLE
Improve post-TP1 trend trade management (runner mode, TP2 extension, hybrid trailing)

### DIFF
--- a/Core/TradeManagement/AdaptiveTrailingEngine.cs
+++ b/Core/TradeManagement/AdaptiveTrailingEngine.cs
@@ -33,27 +33,49 @@ namespace GeminiV26.Core.TradeManagement
             }
 
             bool isLong = ctx.FinalDirection == TradeDirection.Long;
+            string direction = isLong ? "LONG" : "SHORT";
             double oldSl = pos.StopLoss.Value;
-            double newSl;
-            bool valid = true;
+            double newSl = 0;
+            string trailMode = "FALLBACK";
+            string reason = string.Empty;
+            bool valid = false;
+            bool forceFallback = ctx.Tp1Hit
+                && !ctx.LastTrailingStopTarget.HasValue
+                && ctx.BarsSinceEntryM5 >= profile.ForceVolatilityTrailAfterBars;
 
-            switch (decision.TrailingMode)
+            if (!forceFallback)
             {
-                case AdaptiveTrailingMode.Structure:
-                    valid = TryBuildStructureStop(isLong, structure, profile, atr, out newSl);
-                    if (!valid)
-                        return;
-                    break;
+                valid = TryBuildStructureStop(isLong, structure, profile, atr, decision.SlAtrMultiplier, out newSl, out string structureReason, out int anchorBarsAgo);
+                if (valid)
+                {
+                    trailMode = "STRUCTURE";
+                    reason = $"structure_anchor barsAgo={anchorBarsAgo}";
+                    _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=STRUCTURE slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason={reason}");
+                }
+                else
+                {
+                    reason = structureReason;
+                }
+            }
+            else
+            {
+                reason = $"forced_update barsSinceEntry={ctx.BarsSinceEntryM5}";
+            }
 
-                case AdaptiveTrailingMode.Liquidity:
-                    valid = TryBuildLiquidityStop(isLong, structure, profile, atr, out newSl);
-                    if (!valid)
-                        return;
-                    break;
+            if (!valid)
+            {
+                BuildVolatilityStop(isLong, profile, atr, decision.SlAtrMultiplier, out newSl, out string regime, out double multiplier);
+                trailMode = "VOLATILITY_FALLBACK";
+                reason = string.IsNullOrWhiteSpace(reason) ? $"fallback regime={regime}" : $"{reason} regime={regime}";
+                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=VOLATILITY_FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason={reason} multiplier={multiplier:0.00}");
+                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason={reason}");
+            }
 
-                default:
-                    BuildVolatilityStop(isLong, profile, atr, out newSl, out _, out _);
-                    break;
+            if (trailMode == "VOLATILITY_FALLBACK")
+            {
+                newSl = isLong
+                    ? Math.Max(newSl, oldSl)
+                    : Math.Min(newSl, oldSl);
             }
 
             if (ctx.BePrice > 0)
@@ -67,20 +89,48 @@ namespace GeminiV26.Core.TradeManagement
 
             if (newSl <= 0)
                 return;
-                
+
+            if (!ImprovesStop(isLong, newSl, oldSl) && trailMode == "STRUCTURE")
+            {
+                BuildVolatilityStop(isLong, profile, atr, decision.SlAtrMultiplier, out double fallbackSl, out string fallbackRegime, out double fallbackMultiplier);
+                fallbackSl = isLong
+                    ? Math.Max(fallbackSl, oldSl)
+                    : Math.Min(fallbackSl, oldSl);
+
+                if (ctx.BePrice > 0)
+                {
+                    fallbackSl = isLong
+                        ? Math.Max(fallbackSl, ctx.BePrice)
+                        : Math.Min(fallbackSl, ctx.BePrice);
+                }
+
+                fallbackSl = Normalize(fallbackSl);
+                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=VOLATILITY_FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(fallbackSl)} tp={FormatPrice(pos.TakeProfit)} reason=structure_static regime={fallbackRegime} multiplier={fallbackMultiplier:0.00}");
+                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(fallbackSl)} tp={FormatPrice(pos.TakeProfit)} reason=structure_static");
+
+                if (ImprovesStop(isLong, fallbackSl, oldSl))
+                {
+                    newSl = fallbackSl;
+                    trailMode = "VOLATILITY_FALLBACK";
+                }
+            }
+
             if (!ImprovesStop(isLong, newSl, oldSl))
-            {                
+            {
+                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=no_improvement");
                 return;
             }
 
             double minDelta = Math.Max(profile.MinSlUpdateDeltaPips * _bot.Symbol.PipSize, atr * 0.05);
             if (Math.Abs(newSl - oldSl) < minDelta)
             {
+                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=below_min_delta minDelta={minDelta:0.00000}");
                 return;
             }
 
             if (ctx.LastTrailingStopTarget.HasValue && Math.Abs(ctx.LastTrailingStopTarget.Value - newSl) < (_bot.Symbol.PipSize * 0.1))
             {
+                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=duplicate_target");
                 return;
             }
 
@@ -89,94 +139,69 @@ namespace GeminiV26.Core.TradeManagement
             if (!result.IsSuccessful)
             {
                 _bot.Print($"[TRAIL] modify FAILED pos={pos.Id} error={result.Error}");
+                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=modify_failed error={result.Error}");
                 return;
             }
 
             ctx.LastTrailingStopTarget = newSl;
             ctx.LastStopLossPrice = newSl;
+            ctx.TrailingActivated = true;
             _bot.Print($"[TRAIL] modified pos={pos.Id} oldSL={oldSl} newSL={newSl}");
+            _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slNew={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=updated");
         }
 
-        private bool TryBuildStructureStop(bool isLong, StructureSnapshot structure, TrailingProfile profile, double atr, out double newSl)
+        private bool TryBuildStructureStop(bool isLong, StructureSnapshot structure, TrailingProfile profile, double atr, double slAtrMultiplier, out double newSl, out string reason, out int anchorBarsAgo)
         {
-            double buffer = atr * profile.StructureBufferAtr;
-            if (isLong)
-            {
-                if (structure.LastHigherLow == null && structure.LastSwingLow == null)
-                {
-                    newSl = 0;
-                    return false;
-                }
-
-                double anchor;
-
-                if (structure.LastHigherLow != null)
-                    anchor = structure.LastHigherLow.Price;
-                else if (structure.LastSwingLow != null)
-                    anchor = structure.LastSwingLow.Price;
-                else
-                {
-                    newSl = 0;
-                    return false;
-                }
-                
-                newSl = anchor - buffer;
-                return true;
-            }
-
-            if (structure.LastLowerHigh == null && structure.LastSwingHigh == null)
-            {
-                newSl = 0;
-                return false;
-            }
-
-            double sellAnchor;
-
-            if (structure.LastLowerHigh != null)
-                sellAnchor = structure.LastLowerHigh.Price;
-            else if (structure.LastSwingHigh != null)
-                sellAnchor = structure.LastSwingHigh.Price;
-            else
-            {
-                newSl = 0;
-                return false;
-            }
-
-            newSl = sellAnchor + buffer;
-            return true;
-        }
-
-        private bool TryBuildLiquidityStop(bool isLong, StructureSnapshot structure, TrailingProfile profile, double atr, out double newSl)
-        {
-            double buffer = atr * (profile.StructureBufferAtr * 0.8);
+            double buffer = atr * profile.StructureBufferAtr * Math.Max(1.0, slAtrMultiplier / profile.TrendSlAtrMultiplier);
+            int lastClosedBarIndex = Math.Max(0, _bot.Bars.Count - 2);
 
             if (isLong)
             {
-                if (structure.LastSwingLow == null)
+                StructurePoint anchor = structure.LastHigherLow ?? structure.LastSwingLow;
+                if (anchor == null)
                 {
                     newSl = 0;
+                    reason = "no_structure_anchor";
+                    anchorBarsAgo = int.MaxValue;
                     return false;
                 }
 
-                double liquidityLevel = structure.LastSwingLow.Price;
-                
-                newSl = liquidityLevel - buffer;
+                anchorBarsAgo = Math.Max(0, lastClosedBarIndex - anchor.Index);
+                if (anchorBarsAgo > profile.StructureFallbackBars)
+                {
+                    newSl = 0;
+                    reason = $"structure_stale barsAgo={anchorBarsAgo}";
+                    return false;
+                }
+
+                newSl = anchor.Price - buffer;
+                reason = "structure_valid";
                 return true;
             }
 
-            if (structure.LastSwingHigh == null)
+            StructurePoint sellAnchor = structure.LastLowerHigh ?? structure.LastSwingHigh;
+            if (sellAnchor == null)
             {
                 newSl = 0;
+                reason = "no_structure_anchor";
+                anchorBarsAgo = int.MaxValue;
                 return false;
             }
 
-            double shortLiquidityLevel = structure.LastSwingHigh.Price;
-          
-            newSl = shortLiquidityLevel + buffer;
+            anchorBarsAgo = Math.Max(0, lastClosedBarIndex - sellAnchor.Index);
+            if (anchorBarsAgo > profile.StructureFallbackBars)
+            {
+                newSl = 0;
+                reason = $"structure_stale barsAgo={anchorBarsAgo}";
+                return false;
+            }
+
+            newSl = sellAnchor.Price + buffer;
+            reason = "structure_valid";
             return true;
         }
 
-        private void BuildVolatilityStop(bool isLong, TrailingProfile profile, double atr, out double newSl, out string regime, out double multiplier)
+        private void BuildVolatilityStop(bool isLong, TrailingProfile profile, double atr, double slAtrMultiplier, out double newSl, out string regime, out double multiplier)
         {
             var s = _bot.Symbol;
             double atrPips = atr / s.PipSize;
@@ -196,12 +221,18 @@ namespace GeminiV26.Core.TradeManagement
                 regime = "Normal";
                 multiplier = profile.AtrMultiplierNormal;
             }
-            
+
+            multiplier = slAtrMultiplier;
             double price = isLong ? s.Bid : s.Ask;
-            
+
             newSl = isLong
                 ? price - atr * multiplier
                 : price + atr * multiplier;
+
+            if (isLong)
+                newSl = Math.Max(newSl, _bot.Symbol.Bid - atr * multiplier);
+            else
+                newSl = Math.Min(newSl, _bot.Symbol.Ask + atr * multiplier);
         }
 
         private bool ImprovesStop(bool isLong, double candidate, double current)
@@ -216,6 +247,11 @@ namespace GeminiV26.Core.TradeManagement
             var s = _bot.Symbol;
             double steps = Math.Round(price / s.TickSize);
             return Math.Round(steps * s.TickSize, s.Digits);
+        }
+
+        private static string FormatPrice(double? price)
+        {
+            return price.HasValue ? price.Value.ToString("0.#####") : "NA";
         }
     }
 }

--- a/Core/TradeManagement/TrailingProfiles.cs
+++ b/Core/TradeManagement/TrailingProfiles.cs
@@ -16,6 +16,15 @@ namespace GeminiV26.Core.TradeManagement
         public bool AllowTp2Extension { get; init; }
         public double TrendTp2ExtensionMultiplier { get; init; }
         public double StrongTrendTp2ExtensionMultiplier { get; init; }
+        public double LowConfidenceSlAtrMultiplier { get; init; }
+        public double TrendSlAtrMultiplier { get; init; }
+        public double StrongTrendSlAtrMultiplier { get; init; }
+        public double LowConfidenceTpAtrMultiplier { get; init; }
+        public double TrendTpAtrMultiplier { get; init; }
+        public double StrongTrendTpAtrMultiplier { get; init; }
+        public double Tp2MinDeltaAtr { get; init; }
+        public int StructureFallbackBars { get; init; }
+        public int ForceVolatilityTrailAfterBars { get; init; }
     }
 
     public static class TrailingProfiles
@@ -32,7 +41,16 @@ namespace GeminiV26.Core.TradeManagement
             AllowLiquidityTrailing = false,
             AllowTp2Extension = true,
             TrendTp2ExtensionMultiplier = 1.22,
-            StrongTrendTp2ExtensionMultiplier = 1.45
+            StrongTrendTp2ExtensionMultiplier = 1.45,
+            LowConfidenceSlAtrMultiplier = 1.0,
+            TrendSlAtrMultiplier = 1.5,
+            StrongTrendSlAtrMultiplier = 2.0,
+            LowConfidenceTpAtrMultiplier = 1.0,
+            TrendTpAtrMultiplier = 1.5,
+            StrongTrendTpAtrMultiplier = 2.0,
+            Tp2MinDeltaAtr = 0.20,
+            StructureFallbackBars = 6,
+            ForceVolatilityTrailAfterBars = 6
         };
 
         public static TrailingProfile Index => new()
@@ -47,7 +65,16 @@ namespace GeminiV26.Core.TradeManagement
             AllowLiquidityTrailing = true,
             AllowTp2Extension = true,
             TrendTp2ExtensionMultiplier = 1.23,
-            StrongTrendTp2ExtensionMultiplier = 1.48
+            StrongTrendTp2ExtensionMultiplier = 1.48,
+            LowConfidenceSlAtrMultiplier = 1.0,
+            TrendSlAtrMultiplier = 1.5,
+            StrongTrendSlAtrMultiplier = 2.0,
+            LowConfidenceTpAtrMultiplier = 1.0,
+            TrendTpAtrMultiplier = 1.5,
+            StrongTrendTpAtrMultiplier = 2.0,
+            Tp2MinDeltaAtr = 0.20,
+            StructureFallbackBars = 6,
+            ForceVolatilityTrailAfterBars = 6
         };
 
         public static TrailingProfile Crypto => new()
@@ -62,7 +89,16 @@ namespace GeminiV26.Core.TradeManagement
             AllowLiquidityTrailing = true,
             AllowTp2Extension = true,
             TrendTp2ExtensionMultiplier = 1.25,
-            StrongTrendTp2ExtensionMultiplier = 1.50
+            StrongTrendTp2ExtensionMultiplier = 1.50,
+            LowConfidenceSlAtrMultiplier = 1.0,
+            TrendSlAtrMultiplier = 1.5,
+            StrongTrendSlAtrMultiplier = 2.0,
+            LowConfidenceTpAtrMultiplier = 1.0,
+            TrendTpAtrMultiplier = 1.5,
+            StrongTrendTpAtrMultiplier = 2.0,
+            Tp2MinDeltaAtr = 0.20,
+            StructureFallbackBars = 7,
+            ForceVolatilityTrailAfterBars = 6
         };
 
         public static TrailingProfile Metal => new()
@@ -77,7 +113,16 @@ namespace GeminiV26.Core.TradeManagement
             AllowLiquidityTrailing = true,
             AllowTp2Extension = true,
             TrendTp2ExtensionMultiplier = 1.24,
-            StrongTrendTp2ExtensionMultiplier = 1.46
+            StrongTrendTp2ExtensionMultiplier = 1.46,
+            LowConfidenceSlAtrMultiplier = 1.0,
+            TrendSlAtrMultiplier = 1.5,
+            StrongTrendSlAtrMultiplier = 2.0,
+            LowConfidenceTpAtrMultiplier = 1.0,
+            TrendTpAtrMultiplier = 1.5,
+            StrongTrendTpAtrMultiplier = 2.0,
+            Tp2MinDeltaAtr = 0.20,
+            StructureFallbackBars = 6,
+            ForceVolatilityTrailAfterBars = 6
         };
 
         public static TrailingProfile ResolveBySymbol(string symbolName)

--- a/Core/TradeManagement/TrendTradeManager.cs
+++ b/Core/TradeManagement/TrendTradeManager.cs
@@ -27,6 +27,9 @@ namespace GeminiV26.Core.TradeManagement
         public AdaptiveTrailingMode TrailingMode { get; init; }
         public bool AllowTp2Extension { get; init; }
         public double Tp2ExtensionMultiplier { get; init; }
+        public bool IsRunner { get; init; }
+        public double SlAtrMultiplier { get; init; }
+        public double TpAtrMultiplier { get; init; }
     }
 
     public sealed class TrendTradeManager
@@ -54,7 +57,24 @@ namespace GeminiV26.Core.TradeManagement
             if (ctx?.FinalDirection == TradeDirection.None)
             {
                 _bot.Print($"[DIR][EXIT_ILLEGAL_SOURCE] source=TradeType posId={position?.Id} reason=missing_final_direction");
-                return new TrendDecision { State = TradeTrendState.Normal, Score = 0, TrailingMode = AdaptiveTrailingMode.Structure, AllowTp2Extension = false, Tp2ExtensionMultiplier = 1.0 };
+                return new TrendDecision
+                {
+                    State = TradeTrendState.Normal,
+                    Score = 0,
+                    TrailingMode = AdaptiveTrailingMode.Structure,
+                    AllowTp2Extension = false,
+                    Tp2ExtensionMultiplier = 1.0,
+                    IsRunner = false,
+                    SlAtrMultiplier = profile?.LowConfidenceSlAtrMultiplier ?? 1.0,
+                    TpAtrMultiplier = profile?.LowConfidenceTpAtrMultiplier ?? 1.0
+                };
+            }
+
+            bool isRunner = ctx.Tp1Hit;
+            if (isRunner)
+            {
+                _bot.Print($"[TTM] Runner mode activated.");
+                _bot.Print($"[TTM][RUNNER] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} pos={position.Id} sl={FormatPrice(position.StopLoss)} tp={FormatPrice(position.TakeProfit)} reason=tp1_hit");
             }
 
             double priceNow = isLong ? _bot.Symbol.Bid : _bot.Symbol.Ask;
@@ -102,21 +122,26 @@ namespace GeminiV26.Core.TradeManagement
                 _ => TradeTrendState.StrongTrend
             };
 
-            AdaptiveTrailingMode mode = state switch
+            AdaptiveTrailingMode mode = AdaptiveTrailingMode.Structure;
+
+            double slAtrMultiplier = state switch
             {
-                TradeTrendState.Normal => AdaptiveTrailingMode.Volatility,
-                TradeTrendState.Trend => AdaptiveTrailingMode.Structure,
-                TradeTrendState.StrongTrend when profile.AllowLiquidityTrailing => AdaptiveTrailingMode.Liquidity,
-                _ => AdaptiveTrailingMode.Structure
+                TradeTrendState.StrongTrend => profile.StrongTrendSlAtrMultiplier,
+                TradeTrendState.Trend => profile.TrendSlAtrMultiplier,
+                _ => profile.LowConfidenceSlAtrMultiplier
             };
 
-            bool allowTp2Extension = profile.AllowTp2Extension && state != TradeTrendState.Normal;
-            double tp2Multiplier = state switch
+            double tpAtrMultiplier = state switch
             {
-                TradeTrendState.Trend => profile.TrendTp2ExtensionMultiplier,
-                TradeTrendState.StrongTrend => profile.StrongTrendTp2ExtensionMultiplier,
-                _ => 1.0
+                TradeTrendState.StrongTrend => profile.StrongTrendTpAtrMultiplier,
+                TradeTrendState.Trend => profile.TrendTpAtrMultiplier,
+                _ => profile.LowConfidenceTpAtrMultiplier
             };
+
+            _bot.Print($"[TTM][PROFILE] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} state={state} score={score} slMult={slAtrMultiplier:0.00} tpMult={tpAtrMultiplier:0.00} reason=confidence_profile");
+
+            bool allowTp2Extension = isRunner && profile.AllowTp2Extension;
+            TryExtendTp2(position, ctx, isLong, atr, tpAtrMultiplier, profile, allowTp2Extension);
 
             bool stateChanged =
                 ctx.PostTp1TrendState != state.ToString() ||
@@ -126,9 +151,6 @@ namespace GeminiV26.Core.TradeManagement
             if (stateChanged)
             {
                 _bot.Print($"[TTM] state={state} score={score} mode={mode}");
-
-                if (allowTp2Extension)
-                    _bot.Print($"[TTM] TP2 extension allowed multiplier={tp2Multiplier:0.00}");
             }
 
             return new TrendDecision
@@ -136,9 +158,76 @@ namespace GeminiV26.Core.TradeManagement
                 State = state,
                 Score = score,
                 TrailingMode = mode,
-                AllowTp2Extension = allowTp2Extension,
-                Tp2ExtensionMultiplier = tp2Multiplier
+                AllowTp2Extension = false,
+                Tp2ExtensionMultiplier = tpAtrMultiplier,
+                IsRunner = isRunner,
+                SlAtrMultiplier = slAtrMultiplier,
+                TpAtrMultiplier = tpAtrMultiplier
             };
+        }
+
+        private void TryExtendTp2(Position pos, PositionContext ctx, bool isLong, double atr, double tpAtrMultiplier, TrailingProfile profile, bool allowTp2Extension)
+        {
+            string direction = isLong ? "LONG" : "SHORT";
+            double currentTp = pos.TakeProfit ?? ctx.Tp2Price ?? 0;
+
+            if (!ctx.Tp1Hit)
+            {
+                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp=NA delta=0.00000 result=SKIPPED reason=tp1_not_hit");
+                return;
+            }
+
+            if (!allowTp2Extension)
+            {
+                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp=NA delta=0.00000 result=SKIPPED reason=extension_disabled");
+                return;
+            }
+
+            if (currentTp <= 0 || atr <= 0)
+            {
+                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp=NA delta=0.00000 result=SKIPPED reason=missing_tp_or_atr");
+                return;
+            }
+
+            double livePrice = isLong ? _bot.Symbol.Ask : _bot.Symbol.Bid;
+            double candidateTp = isLong
+                ? _bot.Symbol.Ask + (atr * tpAtrMultiplier)
+                : _bot.Symbol.Bid - (atr * tpAtrMultiplier);
+
+            double minDelta = atr * profile.Tp2MinDeltaAtr;
+            bool outward = isLong
+                ? candidateTp > currentTp + minDelta
+                : candidateTp < currentTp - minDelta;
+            double delta = candidateTp - currentTp;
+
+            if (!outward)
+            {
+                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(candidateTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=SKIPPED reason=not_outward_enough minDelta={minDelta:0.00000}");
+                return;
+            }
+
+            double normalizedTp = Normalize(candidateTp);
+            if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - normalizedTp) < _bot.Symbol.PipSize)
+            {
+                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(normalizedTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=SKIPPED reason=already_extended minDelta={minDelta:0.00000}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(pos, pos.StopLoss, normalizedTp);
+            if (!result.IsSuccessful)
+            {
+                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(normalizedTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=SKIPPED reason=modify_failed error={result.Error}");
+                return;
+            }
+
+            ctx.LastExtendedTp2 = normalizedTp;
+            if (ctx.RiskPriceDistance > 0 && ctx.Tp2R > 0)
+            {
+                double desiredR = Math.Abs(normalizedTp - pos.EntryPrice) / ctx.RiskPriceDistance;
+                ctx.Tp2ExtensionMultiplierApplied = desiredR / ctx.Tp2R;
+            }
+
+            _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(normalizedTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=EXTENDED minDelta={minDelta:0.00000}");
         }
 
         private static double EstimatePullbackDepth(bool isLong, StructureSnapshot structure, double priceNow)
@@ -155,6 +244,18 @@ namespace GeminiV26.Core.TradeManagement
                 return 0;
 
             return Math.Max(0, priceNow - structure.LastSwingLow.Price);
+        }
+
+        private double Normalize(double price)
+        {
+            var s = _bot.Symbol;
+            double steps = Math.Round(price / s.TickSize);
+            return Math.Round(steps * s.TickSize, s.Digits);
+        }
+
+        private static string FormatPrice(double? price)
+        {
+            return price.HasValue ? price.Value.ToString("0.#####") : "NA";
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Fix post-TP1 behaviour so trades become true runners: allow TP2 to dynamically extend with the trend and ensure SL actively trails instead of remaining stuck at break-even.
- Make trailing robust in cases with stale/no structure anchors and adapt trailing aggressiveness to trend confidence/score.

### Description
- TrendTradeManager: enable a runner mode when `ctx.Tp1Hit == true`, emit `[TTM][RUNNER]` logs, compute confidence-based SL/TP ATR multipliers, and introduce `TryExtendTp2(...)` which performs TP2 extensions using ATR-based candidate TPs and the corrected outward check using `minDelta = ATR * profile.Tp2MinDeltaAtr` and full `[TTM][TP2]` debug output.
- AdaptiveTrailingEngine: convert to a structure-first / volatility-fallback hybrid that forces fallback when structure anchors are stale or no SL update occurred after the configured bars threshold, clamps volatility fallback so SL never worsens, and emits structured `[TTM][TRAIL]` logs for decisions and updates.
- TrailingProfiles: add configurable multipliers and thresholds used by the new logic (`LowConfidence*/Trend*/StrongTrend*` SL/TP ATR multipliers, `Tp2MinDeltaAtr`, `StructureFallbackBars`, `ForceVolatilityTrailAfterBars`) and populate them for FX/Index/Crypto/Metal profiles.
- Minor helpers: added `Normalize` / `FormatPrice` helpers and minor defensive checks to avoid duplicate/insignificant updates and to record `ctx.LastExtendedTp2` and `ctx.Tp2ExtensionMultiplierApplied` when TP2 is extended.
- Files changed: `Core/TradeManagement/TrendTradeManager.cs`, `Core/TradeManagement/AdaptiveTrailingEngine.cs`, `Core/TradeManagement/TrailingProfiles.cs`.

### Testing
- Ran a syntax/parenthesis sanity check across the modified C# files (custom Python script) and it reported all files OK.
- Verified only the intended TTM files were modified (local diff check) and no unauthorized files were changed.
- Attempted to run C# toolchain checks, but `dotnet`/`csc`/`mcs` are not available in this environment so a full build was not executed (toolchain missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa12010208328b7a0dba9808bd973)