### PR TITLE
Make HTF a score-only directional bias (remove HTF gating across FX/CRYPTO/XAU/INDEX)

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1081,13 +1081,10 @@ namespace GeminiV26.Core
             }
 
         // =====================================================
-        // HTF BIAS GATE (Asset-group level)
-        // Handles FX / Crypto / Metals / Index policies
+        // HTF BIAS = SCORE-ONLY CONTEXT (Asset-group level)
+        // Handles FX / Crypto / Metals / Index policies without filtering
         // =====================================================
 
-        // =========================
-        // FX
-        // =========================
         if (isFxSymbol && _fxBias != null)
         {
             var bias = _fxBias.Get(_bot.SymbolName);
@@ -1097,200 +1094,38 @@ namespace GeminiV26.Core
             _ctx.FxHtfReason = bias.Reason;
 
             _bot.Print($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}");
+            ApplyHtfBiasScoreOnly(symbolSignals, bias, "FX");
         }
-
-        // =========================
-        // CRYPTO
-        // =========================
         else if (isCryptoSymbol && _cryptoBias != null)
         {
             var bias = _cryptoBias.Get(_bot.SymbolName);
             _ctx.CryptoHtfAllowedDirection = bias.AllowedDirection;
             _ctx.CryptoHtfConfidence01 = bias.Confidence01;
             _ctx.CryptoHtfReason = bias.Reason;
+
             _bot.Print($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}");
-
-            bool allowPullback = false;
-            bool allowFlag = false;
-
-            // =====================================================
-            // 1) TRANSITION / NEUTRAL
-            //    -> Pullback only
-            //    -> No direction filter
-            // =====================================================
-            if (bias.State == HtfBiasState.Neutral ||
-                bias.State == HtfBiasState.Transition)
-            {
-                allowPullback = true;
-                allowFlag = bias.State == HtfBiasState.Transition;
-
-                if (bias.State == HtfBiasState.Transition)
-                {
-                    _bot.Print($"[CRYPTO HTF POLICY] state=Transition allowPullback={allowPullback} allowFlag={allowFlag}");
-                }
-
-                _bot.Print("[TC] CRYPTO HTF NOTE: Transition/Neutral -> pullback/flag policy, no direction filter");
-
-                symbolSignals = symbolSignals
-                    .Where(e =>
-                        e == null ||
-                        !e.IsValid ||
-                        (allowPullback && e.Type == EntryType.Crypto_Pullback) ||
-                        (allowFlag && e.Type == EntryType.Crypto_Flag))
-                    .ToList();
-
-                if (symbolSignals.All(e => e == null || !e.IsValid))
-                {
-                    foreach (var s in symbolSignals)
-                    {
-                        _bot.Print(
-                            $"[TC][CRYPTO HTF CAND] type={s?.Type} " +
-                            $"valid={s?.IsValid} dir={s?.Direction} " +
-                            $"score={s?.Score} reason={s?.Reason}");
-                    }
-
-                    _bot.Print("[TC] CRYPTO HTF BLOCK: no valid pullback/flag in Transition/Neutral");
-                    return;
-                }
-            }
-
-            // =====================================================
-            // 2) TREND (Bull / Bear)
-            // =====================================================
-            else
-            {
-                if (bias.AllowedDirection != TradeDirection.None)
-                {
-                    symbolSignals = symbolSignals
-                        .Where(e => e == null || !e.IsValid || e.Direction == bias.AllowedDirection)
-                        .ToList();
-
-                    if (symbolSignals.All(e => e == null || !e.IsValid))
-                    {
-                        _bot.Print("[TC] CRYPTO HTF BLOCK: all candidates filtered by allowed direction");
-                        return;
-                    }
-                }
-            }
+            ApplyHtfBiasScoreOnly(symbolSignals, bias, "CRYPTO");
         }
+        else if (isMetalSymbol && _metalBias != null)
+        {
+            var bias = _metalBias.Get(_bot.SymbolName);
+            _ctx.MetalHtfAllowedDirection = bias.AllowedDirection;
+            _ctx.MetalHtfConfidence01 = bias.Confidence01;
+            _ctx.MetalHtfReason = bias.Reason;
 
-                // =========================
-                // METALS (XAU)
-                // =========================
-                else if (isMetalSymbol && _metalBias != null)
-                {
-                    var bias = _metalBias.Get(_bot.SymbolName);
-                    _ctx.MetalHtfAllowedDirection = bias.AllowedDirection;
-                    _ctx.MetalHtfConfidence01 = bias.Confidence01;
-                    _ctx.MetalHtfReason = bias.Reason;
-                    _bot.Print($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}");
+            _bot.Print($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}");
+            ApplyHtfBiasScoreOnly(symbolSignals, bias, "XAU");
+        }
+        else if (isIndexSymbol && _indexBias != null)
+        {
+            var bias = _indexBias.Get(_bot.SymbolName);
+            _ctx.IndexHtfAllowedDirection = bias.AllowedDirection;
+            _ctx.IndexHtfConfidence01 = bias.Confidence01;
+            _ctx.IndexHtfReason = bias.Reason;
 
-                    if (bias.State == HtfBiasState.Neutral ||
-                        bias.State == HtfBiasState.Transition)
-                    {
-                        _bot.Print("[TC] XAU HTF POLICY: Transition/Neutral -> Pullback primary, strong flag fallback");
-
-                        var pullbackSignals = symbolSignals
-                            .Where(e => e != null && e.Type == EntryType.XAU_Pullback)
-                            .ToList();
-
-                        bool pullbackValid = pullbackSignals.Any(e => e.IsValid);
-                        if (pullbackValid)
-                        {
-                            symbolSignals = symbolSignals
-                                .Where(e => e == null || !e.IsValid || e.Type == EntryType.XAU_Pullback)
-                                .ToList();
-                        }
-                        else
-                        {
-                            var fallbackFlags = symbolSignals
-                                .Where(e => e != null && e.Type == EntryType.XAU_Flag && e.IsValid)
-                                .ToList();
-
-                            if (fallbackFlags.Any())
-                            {
-                                foreach (var entry in fallbackFlags)
-                                {
-                                    _bot.Print($"[TC][XAU HTF CAND] type=XAU_Flag valid={entry.IsValid} score={entry.Score}");
-                                }
-                            }
-
-                            symbolSignals = symbolSignals
-                                .Where(e =>
-                                    e == null ||
-                                    !e.IsValid ||
-                                    e.Type == EntryType.XAU_Pullback ||
-                                    e.Type == EntryType.XAU_Flag ||
-                                    e.Type == EntryType.XAU_Reversal ||
-                                    e.Type == EntryType.XAU_Impulse)
-                                .ToList();
-                        }
-
-                        if (symbolSignals.All(e => e == null || !e.IsValid))
-                        {
-                            foreach (var s in symbolSignals)
-                            {
-                                _bot.Print(
-                                    $"[TC][XAU HTF CAND] type={s?.Type} " +
-                                    $"valid={s?.IsValid} dir={s?.Direction} " +
-                                    $"score={s?.Score} reason={s?.Reason}");
-                            }
-
-                            _bot.Print("[TC] XAU HTF BLOCK: no valid pullback/flag fallback in Transition/Neutral");
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        symbolSignals = symbolSignals
-                            .Where(e => e == null || !e.IsValid || e.Direction == bias.AllowedDirection)
-                            .ToList();
-
-                        if (symbolSignals.All(e => e == null || !e.IsValid))
-                        {
-                            _bot.Print("[TC] XAU HTF BLOCK: all candidates filtered by bias");
-                            return;
-                        }
-                    }
-                }
-
-                // =========================
-                // INDEX
-                // =========================
-                else if (isIndexSymbol && _indexBias != null)
-                {
-                    var bias = _indexBias.Get(_bot.SymbolName);
-                    _ctx.IndexHtfAllowedDirection = bias.AllowedDirection;
-                    _ctx.IndexHtfConfidence01 = bias.Confidence01;
-                    _ctx.IndexHtfReason = bias.Reason;
-                    _bot.Print($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}");
-
-                    if (bias.State == HtfBiasState.Neutral ||
-                        bias.State == HtfBiasState.Transition)
-                    {
-                        _bot.Print("[TC] INDEX HTF BLOCK: state=Transition/Neutral");
-                        return;
-                    }
-
-                    const int HtfAlignedMinScore = 75;
-
-                    symbolSignals = symbolSignals
-                        .Where(e =>
-                            e == null ||
-                            !e.IsValid ||
-                            (
-                                e.Direction == bias.AllowedDirection &&
-                                e.Score >= HtfAlignedMinScore
-                            )
-                        )
-                        .ToList();
-
-                    if (symbolSignals.All(e => e == null || !e.IsValid))
-                    {
-                        _bot.Print("[TC] INDEX HTF BLOCK: all candidates filtered by bias");
-                        return;
-                    }
-                }
+            _bot.Print($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}");
+            ApplyHtfBiasScoreOnly(symbolSignals, bias, "INDEX");
+        }
 
                 // =====================================================
                 // ROUTER
@@ -2134,6 +1969,63 @@ namespace GeminiV26.Core
                 return "Transition";
 
             return setup;
+        }
+
+        private void ApplyHtfBiasScoreOnly(List<EntryEvaluation> symbolSignals, HtfBiasSnapshot bias, string assetTag)
+        {
+            if (symbolSignals == null || bias == null)
+                return;
+
+            const double MisalignedPenalty = 0.70;
+            const double TransitionPenalty = 0.85;
+            const double AlignedDirectionalBoost = 1.10;
+
+            _bot.Print($"[HTF][BIAS] asset={assetTag} direction={bias.AllowedDirection} state={bias.State} impact=ScoreOnly conf={bias.Confidence01:0.00}");
+
+            int alignedCandidates = 0;
+            int misalignedCandidates = 0;
+
+            foreach (var candidate in symbolSignals)
+            {
+                if (candidate == null || !candidate.IsValid || candidate.Direction == TradeDirection.None)
+                    continue;
+
+                bool hasDirectionalBias = bias.AllowedDirection != TradeDirection.None;
+                bool aligned = hasDirectionalBias && candidate.Direction == bias.AllowedDirection;
+                bool misaligned = hasDirectionalBias && candidate.Direction != bias.AllowedDirection;
+
+                if (aligned)
+                    alignedCandidates++;
+
+                if (misaligned)
+                    misalignedCandidates++;
+
+                double multiplier = 1.0;
+
+                if (misaligned)
+                    multiplier *= MisalignedPenalty;
+
+                if (bias.State == HtfBiasState.Transition)
+                    multiplier *= TransitionPenalty;
+                else if (aligned && (bias.State == HtfBiasState.Bull || bias.State == HtfBiasState.Bear))
+                    multiplier *= AlignedDirectionalBoost;
+
+                int originalScore = candidate.Score;
+                candidate.Score = Math.Max(1, (int)Math.Round(candidate.Score * multiplier));
+
+                _bot.Print(
+                    $"[HTF][CANDIDATE] asset={assetTag} type={candidate.Type} dir={candidate.Direction} " +
+                    $"aligned={aligned} multiplier={multiplier:0.00} score={originalScore}->{candidate.Score} state={bias.State}");
+            }
+
+            string statePenaltyText = bias.State == HtfBiasState.Transition
+                ? TransitionPenalty.ToString("0.00")
+                : "1.00";
+
+            _bot.Print(
+                $"[HTF][APPLIED] asset={assetTag} dir={bias.AllowedDirection} state={bias.State} " +
+                $"penalty={statePenaltyText} directionalPenalty={MisalignedPenalty:0.00} " +
+                $"alignedCandidates={alignedCandidates} misaligned={misalignedCandidates}");
         }
 
         private static string ResolveMarketRegime(EntryContext entryCtx)

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -6,7 +6,7 @@ using GeminiV26.EntryTypes.Crypto;
 namespace GeminiV26.EntryTypes.Crypto
 {
     public class BTC_PullbackEntry : IEntryType
-    {        
+    {
         public EntryType Type => EntryType.Crypto_Pullback;
         private const int MIN_SCORE = 34;
         private const int BiasAgainstPenalty = 8;
@@ -33,74 +33,33 @@ namespace GeminiV26.EntryTypes.Crypto
             int lastClosed = bars.Count - 2;
 
             var bar = bars[lastClosed];
-            
+
             if (bars == null || bars.Count < 20)
                 return Block(ctx, "M5_NOT_READY", score);
-                       
+
             TradeDirection dir = ctx.TrendDirection;
             var originalTrendDir = ctx.TrendDirection;
 
             // =========================
-            // HTF DIRECTION OVERRIDE / PRACTICAL GATE
+            // HTF DIRECTIONAL BIAS (score-only)
             // =========================
             var allow = ctx.CryptoHtfAllowedDirection;
             var htfConf = ctx.CryptoHtfConfidence01;
 
-            // --- practical knobs ---
-            const double HTF_STRONG = 0.70;
-            const double HTF_SOFT_MIN = 0.40;          // ez alatt HTF-t ignoráljuk
-            const int SOFT_CONFLICT_EXTRA_SCORE = 8;   // ennyivel legyen erősebb a setup soft ellentétben
-            const int SOFT_CONFLICT_PENALTY = 4;       // opcionális: ha mégis engedjük, picit büntetjük
-
-            // 0) Ha nincs trend dir, próbáljuk HTF-ből pótolni (csak ha strong)
             if (dir != TradeDirection.Long && dir != TradeDirection.Short)
-            {
-                if (allow != TradeDirection.None && htfConf >= HTF_STRONG)
-                {
-                    dir = allow;
-                    Console.WriteLine($"[BTC_PULLBACK][HTF_DIR_FALLBACK] conf={htfConf:0.00} dir-> {dir}");
-                }
-                else
-                {
-                    return Block(ctx, "NO_TREND_DIR", score);
-                }
-            }
+                return Block(ctx, "NO_TREND_DIR", score);
 
-            // 1) Ha van HTF allow és mismatch
             if (allow != TradeDirection.None && dir != allow)
             {
-                // 1a) STRONG HTF -> override
-                if (htfConf >= HTF_STRONG)
-                {
-                    dir = allow;
-                    Console.WriteLine($"[BTC_PULLBACK][HTF_DIR_OVERRIDE] conf={htfConf:0.00} dir-> {dir}");
-                }
-                // 1b) SOFT HTF -> practical gate (csak erős setup átmehet)
-                else if (htfConf >= HTF_SOFT_MIN)
-                {
-                    // itt kell egy fix MIN_SCORE a file-odban (pl. 40)
-                    // feltétel: score >= MIN_SCORE + EXTRA
-                    if (score >= MIN_SCORE + SOFT_CONFLICT_EXTRA_SCORE)
-                    {
-                        score -= SOFT_CONFLICT_PENALTY; // opcionális, hogy a conflict “fájjon” kicsit
-                        Console.WriteLine(
-                            $"[BTC_PULLBACK][HTF_SOFT_CONFLICT_ALLOW] conf={htfConf:0.00} allow={allow} keepDir={dir} " +
-                            $"scoreOk (>= {MIN_SCORE + SOFT_CONFLICT_EXTRA_SCORE}) scoreAdj=-{SOFT_CONFLICT_PENALTY}"
-                        );
-                    }
-                    else
-                    {
-                        return Block(ctx,
-                            $"HTF_SOFT_CONFLICT_NEED_STRONGER_SETUP conf={htfConf:0.00} allow={allow} needScore>={MIN_SCORE + SOFT_CONFLICT_EXTRA_SCORE}",
-                            score,
-                            dir);
-                    }
-                }
-                // 1c) very weak HTF -> ignore, no action
-                else
-                {
-                    Console.WriteLine($"[BTC_PULLBACK][HTF_WEAK_IGNORED] conf={htfConf:0.00} allow={allow} keepDir={dir}");
-                }
+                const int SoftConflictPenalty = 4;
+                score -= SoftConflictPenalty;
+                Console.WriteLine(
+                    $"[BTC_PULLBACK][HTF_SOFT_CONFLICT] conf={htfConf:0.00} allow={allow} keepDir={dir} scoreAdj=-{SoftConflictPenalty}"
+                );
+            }
+            else if (allow == TradeDirection.None)
+            {
+                Console.WriteLine($"[BTC_PULLBACK][HTF_NEUTRAL] conf={htfConf:0.00} keepDir={dir}");
             }
 
             // =========================
@@ -366,7 +325,7 @@ namespace GeminiV26.EntryTypes.Crypto
             {
                 return Block(ctx, "CRYPTO_PULLBACK_VOL_BLOCK_NO_IMPULSE", score, dir);
             }
-            
+
             // =========================
             // LOW VOL + NO CLEAN REACTION HARD
             // =========================
@@ -404,7 +363,7 @@ namespace GeminiV26.EntryTypes.Crypto
 
             if (diCompression)
                 score -= 6;
-                
+
             // =========================
             // ULTRA SOFT LATE TREND MICRO PENALTY
             // =========================
@@ -417,7 +376,7 @@ namespace GeminiV26.EntryTypes.Crypto
             {
                 score -= 2;   // extrém finom korrekció
             }
-            
+
             // =========================
             // LATE IMPULSE / EXPANSION EXHAUSTION BLOCK
             // =========================
@@ -454,7 +413,7 @@ namespace GeminiV26.EntryTypes.Crypto
                     score,
                     dir);
             }
-            
+
             // =========================
             // ADX ROLL OVER CONTINUATION BLOCK
             // =========================
@@ -496,7 +455,7 @@ namespace GeminiV26.EntryTypes.Crypto
             {
                 int raw = ctx.BarsSinceImpulse_M5 - 5;
                 int agePenalty = Math.Max(0, Math.Min(3, raw));
-                
+
                 score -= agePenalty;
 
                 Console.WriteLine($"[BTC_PULLBACK][SOFT] IMPULSE_AGE penalty={agePenalty} bars={ctx.BarsSinceImpulse_M5}");
@@ -506,7 +465,7 @@ namespace GeminiV26.EntryTypes.Crypto
             // REAL PULLBACK REQUIREMENT (INSTITUTIONAL GUARD)
             // =========================
 
-            if (!ctx.IsPullbackDecelerating_M5 && 
+            if (!ctx.IsPullbackDecelerating_M5 &&
                 !ctx.HasReactionCandle_M5 &&
                 ctx.BarsSinceImpulse_M5 <= 2)
             {
@@ -565,26 +524,18 @@ namespace GeminiV26.EntryTypes.Crypto
 
             if (htfConflict && htfConf > 0)
             {
-                // lineáris büntetés
                 int htfPenalty = (int)Math.Round(3 + 10 * htfConf);
                 score -= htfPenalty;
 
-                Console.WriteLine($"[BTC_PULLBACK][HTF_PENALTY] conf={htfConf:0.00} penalty={htfPenalty}");
-
-                // domináns HTF + gyenge M5 → hard block
-                bool strongHtf = htfConf >= 0.7;
                 bool weakLocal =
                     ctx.Adx_M5 < 28 ||
                     !validPullbackReaction ||
                     fuelScore < 4;
 
-                if (strongHtf && weakLocal)
-                {
-                    return Block(ctx,
-                        $"HTF_DOMINANT_BLOCK conf={htfConf:0.00}",
-                        score,
-                        dir);
-                }
+                if (htfConf >= 0.7 && weakLocal)
+                    score -= 3;
+
+                Console.WriteLine($"[BTC_PULLBACK][HTF_PENALTY] conf={htfConf:0.00} penalty={htfPenalty} weakLocal={weakLocal}");
             }
 
             // =========================

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -236,7 +236,11 @@ namespace GeminiV26.EntryTypes.FX
                 }
 
                 if (ctx.FxHtfAllowedDirection == TradeDirection.None && ctx.FxHtfConfidence01 >= 0.50)
-                    return Invalid(ctx, flagDir, $"ASIA_HTF_TRANSITION_BLOCK conf={ctx.FxHtfConfidence01:F2}", score);
+                {
+                    ApplyPenalty(2);
+                    minBoost += 1;
+                    ctx.Log?.Invoke($"[FX_FLAG][HTF][BIAS] candDir={flagDir} state=Transition impact=ScoreOnly penalty=2 conf={ctx.FxHtfConfidence01:F2}");
+                }
             }
 
             // =====================================================
@@ -634,20 +638,12 @@ namespace GeminiV26.EntryTypes.FX
                 ctx.Log?.Invoke($"[FX_FLAG ADX] candDir={flagDir} slope={adxSlopeNow:F2} atrExp={ctx.IsAtrExpanding_M5}");
             }
 
-            // NY + HTF TRANSITION GUARD
+            // NY + HTF TRANSITION BIAS
             if (ctx.Session == FxSession.NewYork && htfTransitionZone && !breakout && !hasM1Confirmation)
             {
-                int strictMin = tuning.MinScore + 6;
-
-                if (score < strictMin)
-                {
-                    return Invalid(ctx, flagDir,
-                        $"NY_HTF_TRANSITION_NEEDS_CONFIRM conf={ctx.FxHtfConfidence01:F2}",
-                        score);
-                }
-
                 ApplyPenalty(3);
                 minBoost += 2;
+                ctx.Log?.Invoke($"[FX_FLAG][HTF][BIAS] candDir={flagDir} state=Transition impact=ScoreOnly penalty=3 conf={ctx.FxHtfConfidence01:F2}");
             }
 
             bool softM1 =

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -328,26 +328,20 @@ namespace GeminiV26.EntryTypes.FX
                 ctx.FxHtfAllowedDirection != TradeDirection.None &&
                 ctx.FxHtfAllowedDirection != dir;
 
-            // HARD GATE
-            if (htfMismatch)
-            {
-                return Block(ctx, dir, "NO_DIRECTION_ALIGNMENT", score);
-            }
-
             // =========================
             // HTF SOFT
             // =========================
-            if (ctx.FxHtfAllowedDirection != TradeDirection.None &&
-                ctx.FxHtfAllowedDirection != dir)
+            if (htfMismatch)
             {
                 double conf = ctx.FxHtfConfidence01;
                 int htfPenalty = (int)(conf * 10);
 
                 ApplyPenalty(ref score, ref penalty, htfPenalty, penaltyBudget, ctx, "HTF_MISMATCH");
 
-                // If HTF is strong and local fuel weak -> block (same intent as original)
                 if (conf >= 0.75 && fuel < 3)
-                    return Block(ctx, dir, "HTF_DOMINANT_BLOCK", score);
+                {
+                    ApplyPenalty(ref score, ref penalty, 3, penaltyBudget, ctx, "HTF_STRONG_WEAK_LOCAL");
+                }
             }
 
             // =========================


### PR DESCRIPTION
### Motivation
- HTF was being used as a hard gate that filtered and rejected candidate entries (e.g. “HTF BLOCK” logs and candidate filtering), which prevented trades in Transition/Neutral and made HTF act as a blocker instead of a soft bias.
- The goal is to make HTF influence only adjust candidate scores (soft bias) while ensuring candidates are never removed or invalidated solely by HTF.
- Changes must be applied consistently across FX, CRYPTO, XAU (metals) and INDEX instrument groups without changing core entry logic or validation rules.

### Description
- Replaced the HTF router-stage gating and candidate filtering in `Core/TradeCore.cs` with a centralized `ApplyHtfBiasScoreOnly` function that adjusts candidate `Score` values and emits transparent logs (`[HTF][BIAS]`, `[HTF][CANDIDATE]`, `[HTF][APPLIED]`) but does not remove or block candidates, and now this is invoked for FX/CRYPTO/XAU/INDEX.
- Converted previously blocking or filtering HTF behaviors into score-only impacts in entry implementations, including turning FX Flag/FX Pullback hard blocks into soft penalties and logging, and removing FX-level direction filters so HTF no longer short-circuits routing.
- Refactored BTC pullback HTF handling to remove direction overrides/fallbacks and hard HTF blocks, replacing them with score penalties and diagnostic logs while preserving other non-HTF validation gates and safety checks.
- Kept other entry validation and gating (impulse gates, session gates, ADX exhaustion blocks, etc.) intact and preserved the requirement not to alter entry generation, signal validation, or PositionContext/FinalConfidence computation logic.

### Testing
- Ran `git diff --check` to find and fix whitespace issues and it passed after trimming trailing whitespace.
- Ran a brace-balance Python sanity check over the modified C# files and all files reported `brace-balance-ok`.
- Scanned the codebase with `rg` to confirm removal of HTF filtering/block strings and to verify presence of the new HTF score-only logs, and the expected patterns were found/removed as intended.
- Note: full compile/run tests were not performed because `dotnet`/MSBuild tooling was not available in the environment (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac092dfbc8328983d6e05e61ee7a4)