### PR TITLE
Respect builder flag SSOT in detectors

### DIFF
--- a/Core/Entry/FlagBreakoutDetector.cs
+++ b/Core/Entry/FlagBreakoutDetector.cs
@@ -58,8 +58,6 @@ namespace GeminiV26.Core.Entry
             ExpireState(ctx, state);
 
             // defaults
-            ctx.FlagHigh = 0.0;
-            ctx.FlagLow = 0.0;
             ctx.FlagBreakoutUp = false;
             ctx.FlagBreakoutDown = false;
 
@@ -86,45 +84,36 @@ namespace GeminiV26.Core.Entry
                 return;
             }
 
-            int flagBars = Math.Max(
-                ctx.FlagBarsLong_M5,
-                ctx.FlagBarsShort_M5);
+            int longFlagBars = ctx.FlagBarsLong_M5;
+            int shortFlagBars = ctx.FlagBarsShort_M5;
+            bool hasLongFlag = ctx.HasFlagLong_M5;
+            bool hasShortFlag = ctx.HasFlagShort_M5;
             int lastClosed = ctx.M5.Count - 2;
-            if (flagBars <= 0)
+
+            if (!hasLongFlag && !hasShortFlag)
             {
-                _log?.Invoke("[FLAG_BREAKOUT][WAIT] no flag yet");
+                _log?.Invoke(
+                    $"[FLAG_BREAKOUT][WAIT] builder flag missing long={hasLongFlag} short={hasShortFlag} longFlagBars={longFlagBars} shortFlagBars={shortFlagBars}");
+                SyncStateBack(ctx, state);
+                return;
+            }
+
+            double flagHigh = ctx.FlagHigh;
+            double flagLow = ctx.FlagLow;
+            double flagAtr = ctx.FlagAtr_M5;
+
+            if (flagHigh <= flagLow || flagAtr <= 0)
+            {
+                _log?.Invoke(
+                    $"[FLAG_BREAKOUT][WAIT] builder flag range not ready high={flagHigh:0.#####} low={flagLow:0.#####} flagAtr={flagAtr:0.#####} long={hasLongFlag} short={hasShortFlag}");
                 SyncStateBack(ctx, state);
                 return;
             }
 
             // =========================
-            // Compute flag range
+            // Direction-agnostic breakout checks using builder SSOT
             // =========================
-            int flagEnd = lastClosed - 1;
-            int start = Math.Max(0, flagEnd - flagBars + 1);
-            if (start > flagEnd)
-            {
-                _log?.Invoke("[FLAG_BREAKOUT][WAIT] range not ready");
-                SyncStateBack(ctx, state);
-                return;
-            }
-
-            double flagHigh = double.MinValue;
-            double flagLow = double.MaxValue;
-
-            for (int i = start; i <= flagEnd; i++)
-            {
-                flagHigh = Math.Max(flagHigh, ctx.M5.HighPrices[i]);
-                flagLow = Math.Min(flagLow, ctx.M5.LowPrices[i]);
-            }
-
-            ctx.FlagHigh = flagHigh;
-            ctx.FlagLow = flagLow;
-
-            // =========================
-            // Direction-agnostic breakout checks
-            // =========================
-            double breakoutBuffer = ctx.AtrM5 * 0.10;
+            double breakoutBuffer = flagAtr * 0.10;
 
             double lastHigh = ctx.M5.HighPrices[lastClosed];
             double lastLow = ctx.M5.LowPrices[lastClosed];
@@ -136,8 +125,8 @@ namespace GeminiV26.Core.Entry
             bool closeUp = lastClose > flagHigh;
             bool closeDown = lastClose < flagLow;
 
-            bool breakoutUp = highBreak && closeUp;
-            bool breakoutDown = lowBreak && closeDown;
+            bool breakoutUp = hasLongFlag && highBreak && closeUp;
+            bool breakoutDown = hasShortFlag && lowBreak && closeDown;
 
             ctx.FlagBreakoutUp = breakoutUp;
             ctx.FlagBreakoutDown = breakoutDown;
@@ -167,10 +156,11 @@ namespace GeminiV26.Core.Entry
             // Logs
             // =========================
             _log?.Invoke(
-                $"[FLAG_BREAKOUT][RANGE] high={flagHigh:0.#####} low={flagLow:0.#####} bars={flagBars} lastClosedIndex={lastClosed}");
+                $"[FLAG_BREAKOUT][RANGE] high={flagHigh:0.#####} low={flagLow:0.#####} flagAtr={flagAtr:0.#####} builderLong={hasLongFlag} builderShort={hasShortFlag} longFlagBars={longFlagBars} shortFlagBars={shortFlagBars} lastClosedIndex={lastClosed}");
 
             _log?.Invoke(
                 $"[FLAG_BREAKOUT][CHECK] " +
+                $"builderLong={hasLongFlag} builderShort={hasShortFlag} " +
                 $"highBreak={highBreak} lowBreak={lowBreak} " +
                 $"closeUp={closeUp} closeDown={closeDown} " +
                 $"breakoutUp={breakoutUp} breakoutDown={breakoutDown} " +

--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -59,10 +59,6 @@ namespace GeminiV26.Core.Entry
 
             ctx.PullbackDepthRLong_M5 = longSide.PullbackDepthR;
             ctx.PullbackDepthRShort_M5 = shortSide.PullbackDepthR;
-
-            ctx.HasFlagLong_M5 = longSide.HasFlag;
-            ctx.HasFlagShort_M5 = shortSide.HasFlag;
-
             ctx.FlagBarsLong_M5 = longSide.FlagBars;
             ctx.FlagBarsShort_M5 = shortSide.FlagBars;
 
@@ -127,14 +123,14 @@ namespace GeminiV26.Core.Entry
                 $"[TRANSITION][LONG] phase={longSide.Phase} " +
                 $"impulse={longSide.HasImpulse.ToString().ToLowerInvariant()} barsSince={longSide.BarsSinceImpulse} " +
                 $"pullback={longSide.HasPullback.ToString().ToLowerInvariant()} pbBars={longSide.PullbackBars} pbDepthR={longSide.PullbackDepthR:0.00} " +
-                $"flag={longSide.HasFlag.ToString().ToLowerInvariant()} flagBars={longSide.FlagBars} comp={longSide.CompressionScore:0.00} " +
+                $"flagState={longSide.HasFlag.ToString().ToLowerInvariant()} flagBars={longSide.FlagBars} comp={longSide.CompressionScore:0.00} " +
                 $"tradable={longSide.IsTradable.ToString().ToLowerInvariant()} score={longSide.QualityScore:0.00} bonus={longSide.BonusScore} reason={longSide.Reason}");
 
             ctx.Log?.Invoke(
                 $"[TRANSITION][SHORT] phase={shortSide.Phase} " +
                 $"impulse={shortSide.HasImpulse.ToString().ToLowerInvariant()} barsSince={shortSide.BarsSinceImpulse} " +
                 $"pullback={shortSide.HasPullback.ToString().ToLowerInvariant()} pbBars={shortSide.PullbackBars} pbDepthR={shortSide.PullbackDepthR:0.00} " +
-                $"flag={shortSide.HasFlag.ToString().ToLowerInvariant()} flagBars={shortSide.FlagBars} comp={shortSide.CompressionScore:0.00} " +
+                $"flagState={shortSide.HasFlag.ToString().ToLowerInvariant()} flagBars={shortSide.FlagBars} comp={shortSide.CompressionScore:0.00} " +
                 $"tradable={shortSide.IsTradable.ToString().ToLowerInvariant()} score={shortSide.QualityScore:0.00} bonus={shortSide.BonusScore} reason={shortSide.Reason}");
 
             ctx.Log?.Invoke(
@@ -561,10 +557,6 @@ namespace GeminiV26.Core.Entry
 
             ctx.PullbackDepthRLong_M5 = 0.0;
             ctx.PullbackDepthRShort_M5 = 0.0;
-
-            ctx.HasFlagLong_M5 = false;
-            ctx.HasFlagShort_M5 = false;
-
             ctx.FlagBarsLong_M5 = 0;
             ctx.FlagBarsShort_M5 = 0;
 


### PR DESCRIPTION
### Motivation
- Ensure `EntryContextBuilder` remains the single source of truth (SSOT) for flags and related range values to avoid downstream contradictions. 
- Prevent `TransitionDetector` from overwriting builder-owned flag truth fields while preserving its transition/state computations. 
- Make `FlagBreakoutDetector` explicitly rely on builder-provided flag truth and range fields when deciding directional breakouts.

### Description
- Removed all writes to builder-owned flag truth fields in `TransitionDetector.cs` so it no longer sets `ctx.HasFlagLong_M5`, `ctx.HasFlagShort_M5`, or clears them in the reset path while preserving `FlagBars*`, compression, phase, impulse/pullback state and runtime counters. 
- Adjusted `TransitionDetector` logging to label transition-local flag information as `flagState` to clarify it is not the builder SSOT. 
- Updated `FlagBreakoutDetector.cs` to require builder flags (`ctx.HasFlagLong_M5` / `ctx.HasFlagShort_M5`) and builder range fields (`ctx.FlagHigh`, `ctx.FlagLow`, `ctx.FlagAtr_M5`) before treating a move as a valid directional breakout, and to early-return (with debug log) when builder flag or range data is missing/invalid. 
- Kept existing breakout runtime/confirm/expiry state and minimal log entries, and avoided changes to any files outside the two scoped detectors.

### Testing
- Attempted an automated build with `dotnet build`, but the command failed in the environment (`dotnet` not installed), so compilation could not be verified in-container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc2cf55e88328b6dac5c6067bfcec)