### PR TITLE
Add setup-dominant entry scoring gates across METAL/FX/INDEX/CRYPTO

### DIFF
--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -122,6 +122,7 @@ namespace GeminiV26.EntryTypes.Crypto
             var bar = bars[lastIndex];
 
             int score = 0;
+            int setupScore = 0;
 
             if (!ctx.HasImpulse_M5)
             {
@@ -165,6 +166,10 @@ namespace GeminiV26.EntryTypes.Crypto
                 dir == TradeDirection.Long ? ctx.HasFlagLong_M5 :
                 dir == TradeDirection.Short ? ctx.HasFlagShort_M5 :
                 ctx.IsValidFlagStructure_M5;
+
+            bool structuredPB =
+                ctx.PullbackBars_M5 >= 2 &&
+                ctx.IsPullbackDecelerating_M5;
 
             string flagState = hasFlag ? "OK" : "FLAG_WEAK_OR_FORMING";
 
@@ -223,6 +228,28 @@ namespace GeminiV26.EntryTypes.Crypto
                     ? (ctx.FlagBreakoutUp || ctx.FlagBreakoutUpConfirmed)
                     : (ctx.FlagBreakoutDown || ctx.FlagBreakoutDownConfirmed));
 
+            bool hasVolatility =
+                ctx.IsAtrExpanding_M5;
+
+            if (!hasVolatility)
+                setupScore -= 30;
+
+            bool hasStructure =
+                hasFlag || structuredPB;
+
+            if (!hasStructure)
+                setupScore -= 30;
+            else
+                setupScore += 15;
+
+            bool continuationSignal = breakoutSignal;
+
+            bool hasMomentum =
+                continuationSignal;
+
+            if (hasMomentum)
+                setupScore += 20;
+
             bool longValid = bullBreak || bullReclaim || (dir == TradeDirection.Long && breakoutSignal);
             bool shortValid = bearBreak || bearReclaim || (dir == TradeDirection.Short && breakoutSignal);
 
@@ -250,6 +277,11 @@ namespace GeminiV26.EntryTypes.Crypto
                     "[FLAG] Missing impulse context" +
                     $"symbol={ctx.Symbol} entry={EntryType.Crypto_Flag} penalty=6 score={score}");
             }
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, MinScore - 10);
 
             if (score < MinScore)
                 return Invalid(ctx, $"LOW_SCORE({score})");

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -33,6 +33,8 @@ namespace GeminiV26.EntryTypes.FX
 
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)
         {
+            int setupScore = 0;
+
             bool hasImpulse =
                 dir == TradeDirection.Long ? ctx.HasImpulseLong_M5 : ctx.HasImpulseShort_M5;
 
@@ -82,12 +84,33 @@ namespace GeminiV26.EntryTypes.FX
             if (!m1Confirm)
                 return Invalid(ctx, "NO_M1_CONFIRM");
 
+            bool continuationSignal = m1Confirm;
+
+            bool hasStructure =
+                pullbackDepthAtr >= MinPullbackAtr;
+
+            if (!hasStructure)
+                setupScore -= 35;
+            else
+                setupScore += 15;
+
+            bool hasContinuation =
+                continuationSignal;
+
+            if (hasContinuation)
+                setupScore += 20;
+
             // ✅ FIX: side-aware score boost
             if (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir)
                 score += 10;
 
             if (ctx.IsRange_M5)
                 score -= 10;
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = System.Math.Min(score, MinScore - 10);
 
             if (score < MinScore)
                 return Invalid(ctx, "LOW_SCORE");

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -40,6 +40,8 @@ namespace GeminiV26.EntryTypes.FX
 
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)
         {
+            int setupScore = 0;
+
             bool hasImpulse =
                 dir == TradeDirection.Long ? ctx.HasImpulseLong_M5 : ctx.HasImpulseShort_M5;
 
@@ -95,13 +97,35 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx.IsAtrExpanding_M5)
                 return Invalid(ctx, "VolExpanding");
 
+            bool continuationSignal =
+                ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir;
+
+            bool hasStructure =
+                pullbackDepthR >= MinPullbackAtr;
+
+            if (!hasStructure)
+                setupScore -= 35;
+            else
+                setupScore += 15;
+
+            bool hasContinuation =
+                continuationSignal;
+
+            if (hasContinuation)
+                setupScore += 20;
+
             int score = 30;
 
-            if (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir)
+            if (continuationSignal)
                 score += 15;
 
             if (ctx.IsRange_M5)
                 score -= 10;
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = System.Math.Min(score, MinScore - 10);
 
             // =====================================================
             // SCORE → DIRECTION

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -48,6 +48,7 @@ namespace GeminiV26.EntryTypes.FX
             FxTuning tuning)
         {
             int minScore = Math.Max(40, tuning.MinScore - 5);
+            int setupScore = 0;
 
             double pullbackDepthR =
                 dir == TradeDirection.Long ? ctx.PullbackDepthRLong_M5 : ctx.PullbackDepthRShort_M5;
@@ -82,6 +83,20 @@ namespace GeminiV26.EntryTypes.FX
             if (!continuationSignal)
                 return Invalid(ctx, "NO_CONTINUATION_SIGNAL");
 
+            bool hasStructure =
+                pullbackDepthR >= MinPullbackAtr;
+
+            if (!hasStructure)
+                setupScore -= 35;
+            else
+                setupScore += 15;
+
+            bool hasContinuation =
+                continuationSignal;
+
+            if (hasContinuation)
+                setupScore += 20;
+
             int score = 50;
 
             if (!ctx.PullbackTouchedEma21_M5)
@@ -105,6 +120,11 @@ namespace GeminiV26.EntryTypes.FX
 
             if (ctx.Session == FxSession.NewYork)
                 score += 2;
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, minScore - 10);
 
             TradeDirection finalDir =
                 score >= minScore ? dir : TradeDirection.None;

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -52,6 +52,7 @@ namespace GeminiV26.EntryTypes.INDEX
             // =============================
             // MATRIX DRIVEN THRESHOLDS
             // =============================
+            int setupScore = 0;
             double minAdxTrend = p.MinAdxTrend > 0 ? p.MinAdxTrend : 20;
             minAdxTrend = Math.Max(minAdxTrend, matrix.MinAdx);
             int maxBarsSinceImpulse = p.MaxBarsSinceImpulse_M5 > 0 ? p.MaxBarsSinceImpulse_M5 : 4;
@@ -92,6 +93,28 @@ namespace GeminiV26.EntryTypes.INDEX
                 (dir == TradeDirection.Short && bars[lastClosed].Close < bars[lastClosed].Open);
 
             bool m1TriggerInDir = HasDirectionalM1Trigger(ctx, dir);
+            bool continuationSignal = m1TriggerInDir;
+            bool breakoutConfirmed = m1TriggerInDir;
+
+            bool hasImpulseSetup = ctx.HasImpulse_M5;
+
+            if (!hasImpulseSetup)
+                setupScore -= 40;
+            else
+                setupScore += 15;
+
+            bool hasStructure =
+                (dir == TradeDirection.Long ? ctx.HasPullbackLong_M5 : ctx.HasPullbackShort_M5) ||
+                hasFlag;
+
+            if (hasStructure)
+                setupScore += 10;
+
+            bool hasContinuation =
+                continuationSignal || breakoutConfirmed;
+
+            if (hasContinuation)
+                setupScore += 20;
 
             // =====================================================
             // CHOP SOFT (matrix ADX)
@@ -244,6 +267,11 @@ namespace GeminiV26.EntryTypes.INDEX
             // =====================================================
             // FINAL SCORE GATE
             // =====================================================
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, MinScore - 10);
+
             score += (int)Math.Round(matrix.EntryScoreModifier);
 
             if (score < MinScore)

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -114,6 +114,7 @@ namespace GeminiV26.EntryTypes.METAL
         {
             int score = (int)tuning.BaseScore;
             int minScore = (int)tuning.MinScore;
+            int setupScore = 0;
 
             var reasons = new List<string>();
 
@@ -201,6 +202,16 @@ namespace GeminiV26.EntryTypes.METAL
             bool hasSomeStructure =
                 hasFlag || structuredPB || earlyPB;
 
+            bool hasStructure =
+                hasFlag
+                || structuredPB
+                || earlyPB;
+
+            if (!hasStructure)
+                setupScore -= 40;
+            else
+                setupScore += 20;
+
             if (!hasSomeStructure)
                 reasons.Add("NO_STRUCTURE");
 
@@ -239,6 +250,13 @@ namespace GeminiV26.EntryTypes.METAL
                 (!hasValidRange || breakAtr >= 0.03) &&
                 bodyRatio >= 0.45 &&
                 ctx.LastClosedBarInTrendDirection;
+
+            bool hasConfirmation =
+                breakoutConfirmed
+                || earlyBreakout;
+
+            if (hasConfirmation)
+                setupScore += 20;
 
             if (breakoutInstant && !breakoutConfirmed)
             {
@@ -301,6 +319,11 @@ namespace GeminiV26.EntryTypes.METAL
 
             if (dir == TradeDirection.Short && IsHigherLow(ctx.M5, index))
                 return InvalidDir(ctx, dir, "HIGHER_LOW", score);
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, minScore - 10);
 
             int effectiveMinScore = earlyBreakout ? minScore - 2 : minScore;
 


### PR DESCRIPTION
### Motivation
- Ensure that a trade cannot occur without an explicit setup and make setup quality dominate the final entry score across instruments, preventing fallback/random trades.
- Implement this as an additive gate inside existing entry evaluators without refactoring or changing routing/execution logic.

### Description
- Added an additive `setupScore` integer at the top of each targeted `EvaluateSide()` / `Evaluate()` and computed instrument-specific setup signals using existing context variables only (no new classes or refactors).
- METAL (XAU): compute `hasStructure` from existing `hasFlag`, `structuredPB`, `earlyPB` and `hasConfirmation` from breakout flags; adjust `setupScore` and then `score += setupScore` and cap when `setupScore <= 0` before the final min-score check (`EntryTypes/METAL/XAU_FlagEntry.cs`).
- FX: applied setup gating to `FX_MicroContinuation`, `FX_ImpulseContinuation`, and `FX_FlagContinuation` by using pullback maturity (`pullbackDepthR`/`pullbackDepthAtr`) and continuation signals (`m1`/breakout) to build `setupScore`, then `score += setupScore` and cap when `setupScore <= 0` before final score decision (`EntryTypes/FX/*`).
- INDEX: added `setupScore` in the index pullback evaluator using `ctx.HasImpulse_M5`, pullback/flag structure (`ctx.HasPullbackLong_M5`/`ctx.HasPullbackShort_M5` and `hasFlag`) and M1 continuation to weight setup; applied `score += setupScore` and the non-positive cap before the existing final gate (`EntryTypes/INDEX/Index_PullbackEntry.cs`).
- CRYPTO: added `setupScore` to BTC flag evaluator using volatility (`ctx.IsAtrExpanding_M5`), structure (`hasFlag || structuredPB`) and breakout/momentum signals; applied `score += setupScore` and the non-positive cap before the existing final threshold (`EntryTypes/CRYPTO/BTC_FlagEntry.cs`).
- All changes are constrained to `Evaluate()`/`EvaluateSide()` code paths, are additive, preserve existing logs/returns and do not introduce new types or refactors.
- Files modified: `EntryTypes/METAL/XAU_FlagEntry.cs`, `EntryTypes/FX/FX_MicroContinuationEntry.cs`, `EntryTypes/FX/FX_ImpulseContinuationEntry.cs`, `EntryTypes/FX/FX_FlagContinuationEntry.cs`, `EntryTypes/INDEX/Index_PullbackEntry.cs`, `EntryTypes/CRYPTO/BTC_FlagEntry.cs`.

### Testing
- Ran `git diff --check` with no whitespace/errors reported.
- Ran a repository sanity script to verify `setupScore` is present in all targeted files (script succeeded).
- Attempted a compile check with `dotnet build` but `dotnet` CLI is not available in the environment so a full build/test could not be run (reported in PR validation).
- Changes were committed on the branch (`Add setup-dominant entry scoring gates`, commit `0b0cd24`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd7f836288328ab853abfdc583a2d)