### PR TITLE
Enforce setup-dominant entry scoring

### DIFF
--- a/EntryTypes/BR_RangeBreakoutEntry.cs
+++ b/EntryTypes/BR_RangeBreakoutEntry.cs
@@ -11,6 +11,7 @@
 // A score RELATÍV MINŐSÉG, nem belépési engedély.
 // =========================================================
 
+using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using System;
 
@@ -42,6 +43,7 @@ namespace GeminiV26.EntryTypes
             };
 
             int score = 0;
+            int setupScore = 0;
 
             // =========================================================
             // 1️⃣ RANGE KÖRNYEZET (HARD + SOFT MINŐSÉG)
@@ -78,6 +80,64 @@ namespace GeminiV26.EntryTypes
             {
                 eval.Reason += "WeakRangeQuality;";
                 return eval;
+            }
+
+            var instrumentClass = SymbolRouting.ResolveInstrumentClass(ctx.Symbol);
+
+            if (instrumentClass == InstrumentClass.METAL)
+            {
+                bool hasStructure =
+                    ctx.IsValidFlagStructure_M5
+                    || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5)
+                    || ctx.HasEarlyPullback_M5;
+
+                if (!hasStructure)
+                    setupScore -= 40;
+                else
+                    setupScore += 20;
+            }
+            else if (instrumentClass == InstrumentClass.INDEX)
+            {
+                bool hasImpulse = ctx.HasImpulse_M5;
+                if (!hasImpulse)
+                    setupScore -= 40;
+                else
+                    setupScore += 15;
+
+                bool hasStructure =
+                    ctx.HasPullbackLong_M5 || ctx.HasPullbackShort_M5;
+
+                if (hasStructure)
+                    setupScore += 10;
+            }
+            else if (instrumentClass == InstrumentClass.CRYPTO)
+            {
+                if (!ctx.IsAtrExpanding_M5)
+                    setupScore -= 30;
+
+                bool hasStructure =
+                    ctx.IsValidFlagStructure_M5 ||
+                    (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5);
+
+                if (!hasStructure)
+                    setupScore -= 30;
+                else
+                    setupScore += 15;
+            }
+            else
+            {
+                double pullbackDepthR =
+                    ctx.RangeBreakDirection == TradeDirection.Short
+                        ? ctx.PullbackDepthRShort_M5
+                        : ctx.PullbackDepthRLong_M5;
+
+                bool hasStructure =
+                    pullbackDepthR >= 0.15;
+
+                if (!hasStructure)
+                    setupScore -= 35;
+                else
+                    setupScore += 15;
             }
 
             // =========================================================
@@ -138,6 +198,41 @@ namespace GeminiV26.EntryTypes
             if (ctx.IsVolumeIncreasing_M5)
                 score += 5;
 
+            if (instrumentClass == InstrumentClass.METAL)
+            {
+                bool hasConfirmation =
+                    ctx.RangeBreakDirection != TradeDirection.None
+                    || ctx.M1TriggerInTrendDirection;
+
+                if (hasConfirmation)
+                    setupScore += 20;
+            }
+            else if (instrumentClass == InstrumentClass.INDEX)
+            {
+                bool continuationSignal =
+                    ctx.RangeBreakDirection != TradeDirection.None;
+                bool breakoutConfirmed = continuationSignal;
+
+                if (continuationSignal || breakoutConfirmed)
+                    setupScore += 20;
+            }
+            else if (instrumentClass == InstrumentClass.CRYPTO)
+            {
+                bool continuationSignal =
+                    ctx.RangeBreakDirection != TradeDirection.None;
+
+                if (continuationSignal)
+                    setupScore += 20;
+            }
+            else
+            {
+                bool continuationSignal =
+                    ctx.RangeBreakDirection != TradeDirection.None;
+
+                if (continuationSignal)
+                    setupScore += 20;
+            }
+
             // =========================================================
             // HARD RULE – irány nélkül nincs setup
             // =========================================================
@@ -150,6 +245,11 @@ namespace GeminiV26.EntryTypes
             // =========================================================
             // MIN SCORE – ENTRYTYPE SZINTEN
             // =========================================================
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, MIN_SCORE - 10);
+
             eval.Score = score;
             eval.IsValid = score >= MIN_SCORE;
 

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -14,6 +14,7 @@ namespace GeminiV26.EntryTypes.Crypto
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             int score = 36;
+            int setupScore = 0;
 
             void ScoreLog(string label, int delta, int current)
             {
@@ -794,6 +795,43 @@ namespace GeminiV26.EntryTypes.Crypto
                     $"[BTC ASIA] passed: drift={directionalDriftOk}, retrace={retracementRatio:0.00}, bars={ctx.PullbackBars_M5}, confidence={score}"
                 );
             }
+
+            bool hasVolatility =
+                ctx.IsAtrExpanding_M5;
+
+            if (!hasVolatility)
+                setupScore -= 30;
+
+            bool hasFlag =
+                dir == TradeDirection.Long
+                    ? ctx.HasFlagLong_M5
+                    : ctx.HasFlagShort_M5;
+
+            bool structuredPB =
+                ctx.PullbackBars_M5 >= 2 &&
+                ctx.IsPullbackDecelerating_M5;
+
+            bool hasStructure =
+                hasFlag || structuredPB;
+
+            if (!hasStructure)
+                setupScore -= 30;
+            else
+                setupScore += 15;
+
+            bool continuationSignal =
+                ctx.M1TriggerInTrendDirection || validPullbackReaction;
+
+            bool hasMomentum =
+                continuationSignal;
+
+            if (hasMomentum)
+                setupScore += 20;
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, dynamicMinScore - 10);
 
             // =========================
             // FINAL CHECK

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -17,6 +17,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 return Invalid(ctx, "CTX_NOT_READY");
 
             int score = 25;
+            int setupScore = 0;
 
             // =========================
             // VOL REGIME – SOFT
@@ -39,6 +40,38 @@ namespace GeminiV26.EntryTypes.Crypto
                 return Invalid(ctx, "NO_BREAK_DIR");
 
             var eval = NewEval(ctx, dir);
+
+            bool hasVolatility =
+                ctx.IsAtrExpanding_M5;
+
+            if (!hasVolatility)
+                setupScore -= 30;
+
+            bool hasFlag =
+                dir == TradeDirection.Long ? ctx.HasFlagLong_M5 :
+                dir == TradeDirection.Short ? ctx.HasFlagShort_M5 :
+                ctx.IsValidFlagStructure_M5;
+
+            bool structuredPB =
+                ctx.PullbackBars_M5 >= 2 &&
+                ctx.IsPullbackDecelerating_M5;
+
+            bool hasStructure =
+                hasFlag || structuredPB;
+
+            if (!hasStructure)
+                setupScore -= 30;
+            else
+                setupScore += 15;
+
+            bool continuationSignal =
+                ctx.RangeBreakDirection == dir;
+
+            bool hasMomentum =
+                continuationSignal;
+
+            if (hasMomentum)
+                setupScore += 20;
 
             // =========================
             // BREAK STRENGTH
@@ -67,6 +100,11 @@ namespace GeminiV26.EntryTypes.Crypto
             // =========================
             if (ctx.IsAtrExpanding_M5)
                 score += 10;
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = System.Math.Min(score, MIN_SCORE - 10);
 
             eval.Score = score;
             eval.IsValid = score >= MIN_SCORE;

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -21,6 +21,8 @@ namespace GeminiV26.EntryTypes.FX
     {
         public EntryType Type => EntryType.FX_Flag;
 
+        private const double MinPullbackAtr = 0.15;
+
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 30)
@@ -74,6 +76,7 @@ namespace GeminiV26.EntryTypes.FX
             TradeDirection flagDir)
         {
             int score = 0;
+            int setupScore = 0;
             int penaltyBudget = 0;
 
             const int maxPenalty = 15;   // FX-en ennyi össz negatív korrekció lehet max
@@ -338,6 +341,11 @@ namespace GeminiV26.EntryTypes.FX
                 if (!hasReaction)
                     ApplyPenalty(1);
             }
+
+            double pullbackDepthR =
+                flagDir == TradeDirection.Long
+                    ? ctx.PullbackDepthRLong_M5
+                    : ctx.PullbackDepthRShort_M5;
 
             // =====================================================
             // FLAG RANGE (SIMPLE)
@@ -878,6 +886,22 @@ namespace GeminiV26.EntryTypes.FX
             if (!hasTrigger && !ctx.IsAtrExpanding_M5 && score < tuning.MinScore + 2)
                 ApplyPenalty(3);
 
+            bool continuationSignal = breakoutConfirmed;
+
+            bool hasStructure =
+                pullbackDepthR >= MinPullbackAtr;
+
+            if (!hasStructure)
+                setupScore -= 35;
+            else
+                setupScore += 15;
+
+            bool hasContinuation =
+                continuationSignal;
+
+            if (hasContinuation)
+                setupScore += 20;
+
             bool missingImpulse =
                 string.Equals(ctx.Transition?.Reason, "MissingImpulse", StringComparison.Ordinal);
 
@@ -914,6 +938,11 @@ namespace GeminiV26.EntryTypes.FX
             }
 
             if (min < 0) min = 0;
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, min - 10);
 
             ctx.Log?.Invoke($"[FX_FLAG FINAL] candDir={flagDir} score={score} min={min}");
 

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -10,6 +10,8 @@ namespace GeminiV26.EntryTypes.FX
     {
         public EntryType Type => EntryType.FX_MicroStructure;
 
+        private const double MinPullbackAtr = 0.15;
+
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 30)
@@ -41,6 +43,7 @@ namespace GeminiV26.EntryTypes.FX
             TradeDirection dir)
         {
             int score = 54;   // base score aligned with FlagEntry universe
+            int setupScore = 0;
 
             ctx.Log?.Invoke(
                 $"[FX_MICRO START] sym={ctx.Symbol} dir={dir} " +
@@ -52,6 +55,11 @@ namespace GeminiV26.EntryTypes.FX
                 dir == TradeDirection.Long
                 ? ctx.BarsSinceHighBreak_M5
                 : ctx.BarsSinceLowBreak_M5;
+
+            double pullbackDepthR =
+                dir == TradeDirection.Long
+                    ? ctx.PullbackDepthRLong_M5
+                    : ctx.PullbackDepthRShort_M5;
 
             ctx.Log?.Invoke($"[FX_MICRO STRUCT] barsSinceBreak={barsSinceBreak}");
             
@@ -128,6 +136,22 @@ namespace GeminiV26.EntryTypes.FX
             if (!breakout)
                 return Invalid(ctx, dir, "WAIT_BREAKOUT", score);
 
+            bool continuationSignal = breakout;
+
+            bool hasStructure =
+                pullbackDepthR >= MinPullbackAtr;
+
+            if (!hasStructure)
+                setupScore -= 35;
+            else
+                setupScore += 15;
+
+            bool hasContinuation =
+                continuationSignal;
+
+            if (hasContinuation)
+                setupScore += 20;
+
             score += 6;
 
             // -----------------------------------------------------
@@ -174,6 +198,11 @@ namespace GeminiV26.EntryTypes.FX
             // -----------------------------------------------------
 
             int minScore = 68;
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, minScore - 10);
 
             ctx.Log?.Invoke($"[FX_MICRO FINAL] dir={dir} score={score} min={minScore}");
 

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -85,6 +85,7 @@ namespace GeminiV26.EntryTypes.FX
             TradeDirection dir)
         {
             int score = 60;
+            int setupScore = 0;
             int penalty = 0;
             int penaltyBudget = 14;
 
@@ -361,7 +362,27 @@ namespace GeminiV26.EntryTypes.FX
                 return Block(ctx, dir, "PB_TOO_WEAK", score);
             }
 
+            bool continuationSignal = hasDirectionalM1Trigger;
+
+            bool hasStructure =
+                pullbackDepth >= 0.5;
+
+            if (!hasStructure)
+                setupScore -= 35;
+            else
+                setupScore += 15;
+
+            bool hasContinuation =
+                continuationSignal;
+
+            if (hasContinuation)
+                setupScore += 20;
+
             score += (int)System.Math.Round(matrix.EntryScoreModifier);
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = System.Math.Min(score, MIN_SCORE - 10);
 
             if (score < MIN_SCORE)
                 return Block(ctx, dir, $"LOW_SCORE_{score}", score);

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -38,6 +38,7 @@ namespace GeminiV26.EntryTypes.FX
                 return Invalid(ctx, "WEAK_EVIDENCE");
 
             int score = 0;
+            int setupScore = 0;
 
             // evidence a mag
             score += ctx.ReversalEvidenceScore * 12;   // 2->24, 3->36, 4->48
@@ -81,6 +82,32 @@ namespace GeminiV26.EntryTypes.FX
                     score += htfBonus;
                 }
             }
+
+            double pullbackDepthR =
+                ctx.ReversalDirection == TradeDirection.Long
+                    ? ctx.PullbackDepthRLong_M5
+                    : ctx.PullbackDepthRShort_M5;
+
+            bool continuationSignal = ctx.M1ReversalTrigger;
+
+            bool hasStructure =
+                pullbackDepthR >= 0.15;
+
+            if (!hasStructure)
+                setupScore -= 35;
+            else
+                setupScore += 15;
+
+            bool hasContinuation =
+                continuationSignal;
+
+            if (hasContinuation)
+                setupScore += 20;
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = System.Math.Min(score, MIN_SCORE - 10);
 
             var eval = BaseEval(ctx);
             eval.Direction = ctx.ReversalDirection;

--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -16,6 +16,7 @@ namespace GeminiV26.EntryTypes.INDEX
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             int score = 0;
+            int setupScore = 0;
 
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowBreakout)
@@ -92,6 +93,32 @@ namespace GeminiV26.EntryTypes.INDEX
             if (!ctx.IsAtrExpanding_M5)
                 score -= 10;
 
+            bool hasImpulseSetup =
+                ctx.HasImpulse_M5;
+
+            if (!hasImpulseSetup)
+                setupScore -= 40;
+            else
+                setupScore += 15;
+
+            bool hasStructure =
+                (dir == TradeDirection.Long ? ctx.HasPullbackLong_M5 : ctx.HasPullbackShort_M5);
+
+            if (hasStructure)
+                setupScore += 10;
+
+            bool continuationSignal =
+                ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir;
+
+            bool breakoutConfirmed =
+                continuationSignal;
+
+            bool hasContinuation =
+                continuationSignal || breakoutConfirmed;
+
+            if (hasContinuation)
+                setupScore += 20;
+
             // =====================================================
             // Core breakout scoring
             // =====================================================
@@ -136,6 +163,10 @@ namespace GeminiV26.EntryTypes.INDEX
                 score -= 4;
 
             score += (int)Math.Round(matrix.EntryScoreModifier);
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, MinScore - 10);
 
             if (score < MinScore)
                 return Reject(ctx, $"LOW_SCORE({score})", score, dir);

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -135,6 +135,7 @@ namespace GeminiV26.EntryTypes.INDEX
             double scoreMultiplier)
         {
             int score = BaseScore;
+            int setupScore = 0;
             int penaltyBudget = 0;
             const int maxPenalty = 22;
 
@@ -171,6 +172,11 @@ namespace GeminiV26.EntryTypes.INDEX
             bool hasImpulse =
                 dir == TradeDirection.Long ? ctx.HasImpulseLong_M5 :
                 dir == TradeDirection.Short ? ctx.HasImpulseShort_M5 :
+                false;
+
+            bool hasPullback =
+                dir == TradeDirection.Long ? ctx.HasPullbackLong_M5 :
+                dir == TradeDirection.Short ? ctx.HasPullbackShort_M5 :
                 false;
 
             DateTime traceBarTime = bars.OpenTimes[lastClosed];
@@ -375,6 +381,28 @@ namespace GeminiV26.EntryTypes.INDEX
                 (dir == TradeDirection.Long && (bullBreak || breakoutSignal)) ||
                 (dir == TradeDirection.Short && (bearBreak || breakoutSignal));
 
+            bool continuationSignal = breakoutSignal;
+
+            bool hasImpulseSetup =
+                hasImpulse;
+
+            if (!hasImpulseSetup)
+                setupScore -= 40;
+            else
+                setupScore += 15;
+
+            bool hasStructure =
+                hasPullback || hasFlag;
+
+            if (hasStructure)
+                setupScore += 10;
+
+            bool hasContinuation =
+                continuationSignal || breakoutConfirmed;
+
+            if (hasContinuation)
+                setupScore += 20;
+
             if (!breakoutConfirmed)
                 return Reject(ctx, "NO_FLAG_BREAKOUT", score, dir);
 
@@ -480,6 +508,11 @@ namespace GeminiV26.EntryTypes.INDEX
                     "[FLAG][PENALTY] Missing impulse detected → score penalty applied " +
                     $"symbol={ctx.Symbol} entry={Type} penalty=6 score={score}");
             }
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, MinScore - 10);
 
             ctx.Log?.Invoke(
                 $"[IDX_FLAG][FINAL] dir={dir} score={score} flagATR={flagAtr:F2} slopeATR={flagSlopeAtr:F2} " +

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -33,6 +33,7 @@ namespace GeminiV26.EntryTypes.METAL
                 return Reject(ctx, "CTX_NOT_READY");
 
             int score = 60; // base impulse score
+            int setupScore = 0;
 
             // =====================================================
             // 1️⃣ IRÁNY
@@ -97,10 +98,50 @@ namespace GeminiV26.EntryTypes.METAL
 
             score += 5;
 
+            bool hasFlag =
+                dir == TradeDirection.Long
+                    ? ctx.HasFlagLong_M5
+                    : ctx.HasFlagShort_M5;
+
+            bool structuredPB =
+                ctx.IsPullbackDecelerating_M5 &&
+                ctx.PullbackBars_M5 >= 2;
+
+            bool earlyPB =
+                ctx.HasEarlyPullback_M5;
+
+            bool hasStructure =
+                hasFlag
+                || structuredPB
+                || earlyPB;
+
+            if (!hasStructure)
+                setupScore -= 40;
+            else
+                setupScore += 20;
+
+            bool breakoutConfirmed =
+                ctx.HasBreakout_M1 &&
+                ctx.BreakoutDirection == dir;
+
+            bool earlyBreakout =
+                ctx.M1TriggerInTrendDirection;
+
+            bool hasConfirmation =
+                breakoutConfirmed
+                || earlyBreakout;
+
+            if (hasConfirmation)
+                setupScore += 20;
+
             // =====================================================
             // FINAL DECISION
             // =====================================================
             score += (int)System.Math.Round(matrix.EntryScoreModifier);
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = System.Math.Min(score, MinScore - 10);
 
             if (score < MinScore)
                 return Reject(ctx, $"LOW_SCORE({score})");

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -58,6 +58,7 @@ namespace GeminiV26.EntryTypes.METAL
         {
             int score = 60;
             int minScore = 64;
+            int setupScore = 0;
 
             var reasons = new List<string>();
 
@@ -217,10 +218,49 @@ namespace GeminiV26.EntryTypes.METAL
                 reasons.Add("HTF_AGAINST");
             }
 
+            bool hasFlag =
+                dir == TradeDirection.Long
+                    ? ctx.HasFlagLong_M5
+                    : ctx.HasFlagShort_M5;
+
+            bool structuredPB =
+                ctx.IsPullbackDecelerating_M5 &&
+                pbBars >= 2;
+
+            bool earlyPB =
+                ctx.HasEarlyPullback_M5;
+
+            bool hasStructure =
+                hasFlag
+                || structuredPB
+                || earlyPB;
+
+            if (!hasStructure)
+                setupScore -= 40;
+            else
+                setupScore += 20;
+
+            bool breakoutConfirmed =
+                m1;
+
+            bool earlyBreakout =
+                earlyContinuation;
+
+            bool hasConfirmation =
+                breakoutConfirmed
+                || earlyBreakout;
+
+            if (hasConfirmation)
+                setupScore += 20;
+
             // =========================
             // FINAL
             // =========================
             score += (int)Math.Round(matrix.EntryScoreModifier);
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, minScore - 10);
 
             bool valid = score >= minScore;
 

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.EntryTypes.METAL
                 return Reject(ctx, "CTX_NOT_READY");
 
             var reasons = new List<string>(8);
+            int setupScore = 0;
 
             // =====================================================
             // 1️⃣ TREND IRÁNY (XAU saját)
@@ -66,6 +67,46 @@ namespace GeminiV26.EntryTypes.METAL
 
             score += 15;
             reasons.Add("+M1_REV(15)");
+
+            bool hasFlag =
+                dir == TradeDirection.Long
+                    ? ctx.HasFlagLong_M5
+                    : ctx.HasFlagShort_M5;
+
+            bool structuredPB =
+                ctx.IsPullbackDecelerating_M5 &&
+                ctx.PullbackBars_M5 >= 2;
+
+            bool earlyPB =
+                ctx.HasEarlyPullback_M5;
+
+            bool hasStructure =
+                hasFlag
+                || structuredPB
+                || earlyPB;
+
+            if (!hasStructure)
+                setupScore -= 40;
+            else
+                setupScore += 20;
+
+            bool breakoutConfirmed =
+                ctx.M1ReversalTrigger;
+
+            bool earlyBreakout =
+                ctx.LastClosedBarInTrendDirection;
+
+            bool hasConfirmation =
+                breakoutConfirmed
+                || earlyBreakout;
+
+            if (hasConfirmation)
+                setupScore += 20;
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, MinScore - 10);
 
             // =====================================================
             // 5️⃣ MIN SCORE GATE

--- a/EntryTypes/TC_FlagEntry.cs
+++ b/EntryTypes/TC_FlagEntry.cs
@@ -10,6 +10,7 @@
 // - Score = minőség, nem létezési feltétel
 // =========================================================
 
+using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using System;
 
@@ -37,6 +38,7 @@ namespace GeminiV26.EntryTypes
             };
 
             int score = 0;
+            int setupScore = 0;
 
             // =========================================================
             // 1️⃣ IMPULSE – HARD (M5)
@@ -115,6 +117,89 @@ namespace GeminiV26.EntryTypes
 
             score += 30;
 
+            var instrumentClass = SymbolRouting.ResolveInstrumentClass(ctx.Symbol);
+
+            if (instrumentClass == InstrumentClass.METAL)
+            {
+                bool hasStructure =
+                    ctx.IsValidFlagStructure_M5
+                    || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5)
+                    || ctx.HasEarlyPullback_M5;
+
+                if (!hasStructure)
+                    setupScore -= 40;
+                else
+                    setupScore += 20;
+
+                bool hasConfirmation =
+                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
+
+                if (hasConfirmation)
+                    setupScore += 20;
+            }
+            else if (instrumentClass == InstrumentClass.INDEX)
+            {
+                bool hasImpulse = ctx.HasImpulse_M5;
+                if (!hasImpulse)
+                    setupScore -= 40;
+                else
+                    setupScore += 15;
+
+                bool hasStructure =
+                    ctx.HasPullbackLong_M5 || ctx.HasPullbackShort_M5 || ctx.IsValidFlagStructure_M5;
+
+                if (hasStructure)
+                    setupScore += 10;
+
+                bool continuationSignal =
+                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
+                bool breakoutConfirmed = continuationSignal;
+
+                if (continuationSignal || breakoutConfirmed)
+                    setupScore += 20;
+            }
+            else if (instrumentClass == InstrumentClass.CRYPTO)
+            {
+                if (!ctx.IsAtrExpanding_M5)
+                    setupScore -= 30;
+
+                bool hasStructure =
+                    ctx.IsValidFlagStructure_M5 ||
+                    (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5);
+
+                if (!hasStructure)
+                    setupScore -= 30;
+                else
+                    setupScore += 15;
+
+                bool continuationSignal =
+                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
+
+                if (continuationSignal)
+                    setupScore += 20;
+            }
+            else
+            {
+                double pullbackDepthR =
+                    eval.Direction == TradeDirection.Short
+                        ? ctx.PullbackDepthRShort_M5
+                        : ctx.PullbackDepthRLong_M5;
+
+                bool hasStructure =
+                    pullbackDepthR >= 0.15;
+
+                if (!hasStructure)
+                    setupScore -= 35;
+                else
+                    setupScore += 15;
+
+                bool continuationSignal =
+                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
+
+                if (continuationSignal)
+                    setupScore += 20;
+            }
+
             // =========================================================
             // 5️⃣ MINŐSÉGI BOOSTOK – SOFT
             // =========================================================
@@ -127,6 +212,11 @@ namespace GeminiV26.EntryTypes
             // =========================================================
             // 6️⃣ MIN SCORE – ENTRYTYPE SZINT
             // =========================================================
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, MIN_SCORE - 10);
+
             eval.Score = score;
             eval.IsValid = score >= MIN_SCORE;
 

--- a/EntryTypes/TC_PullbackEntry.cs
+++ b/EntryTypes/TC_PullbackEntry.cs
@@ -39,6 +39,7 @@ namespace GeminiV26.EntryTypes
             };
 
             int score = 0;
+            int setupScore = 0;
 
             var instrumentClass = SymbolRouting.ResolveInstrumentClass(ctx.Symbol);
             string symbolCanonical = SymbolRouting.NormalizeSymbol(ctx.Symbol);
@@ -310,6 +311,84 @@ namespace GeminiV26.EntryTypes
             if (ctx.HasImpulse_M5) score += 5;
             if (ctx.IsAtrExpanding_M5) score += 5;
 
+            if (instrumentClass == InstrumentClass.METAL)
+            {
+                bool hasStructure =
+                    (eval.Direction == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5)
+                    || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5)
+                    || ctx.HasEarlyPullback_M5;
+
+                if (!hasStructure)
+                    setupScore -= 40;
+                else
+                    setupScore += 20;
+
+                bool hasConfirmation =
+                    (!noM1Trigger) || ctx.LastClosedBarInTrendDirection;
+
+                if (hasConfirmation)
+                    setupScore += 20;
+            }
+            else if (instrumentClass == InstrumentClass.INDEX)
+            {
+                bool hasImpulse = ctx.HasImpulse_M5;
+                if (!hasImpulse)
+                    setupScore -= 40;
+                else
+                    setupScore += 15;
+
+                bool hasStructure =
+                    ctx.HasPullbackLong_M5 || ctx.HasPullbackShort_M5;
+
+                if (hasStructure)
+                    setupScore += 10;
+
+                bool continuationSignal = !noM1Trigger;
+                bool breakoutConfirmed = continuationSignal;
+
+                if (continuationSignal || breakoutConfirmed)
+                    setupScore += 20;
+            }
+            else if (instrumentClass == InstrumentClass.CRYPTO)
+            {
+                if (!ctx.IsAtrExpanding_M5)
+                    setupScore -= 30;
+
+                bool hasStructure =
+                    (eval.Direction == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5)
+                    || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5);
+
+                if (!hasStructure)
+                    setupScore -= 30;
+                else
+                    setupScore += 15;
+
+                bool continuationSignal = !noM1Trigger;
+
+                if (continuationSignal)
+                    setupScore += 20;
+            }
+            else
+            {
+                double pullbackDepthR =
+                    eval.Direction == TradeDirection.Short
+                        ? ctx.PullbackDepthRShort_M5
+                        : ctx.PullbackDepthRLong_M5;
+
+                bool hasStructure =
+                    pullbackDepthR >= 0.15;
+
+                if (!hasStructure)
+                    setupScore -= 35;
+                else
+                    setupScore += 15;
+
+                bool continuationSignal = !noM1Trigger;
+
+                if (continuationSignal)
+                    setupScore += 20;
+            }
+
             // =========================================================
             // FINAL RULES
             // =========================================================
@@ -318,6 +397,11 @@ namespace GeminiV26.EntryTypes
                 eval.Reason += "NoDirection;";
                 return eval;
             }
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, MIN_SCORE - 10);
 
             eval.Score = score;
             eval.IsValid = score >= MIN_SCORE;

--- a/EntryTypes/TR_ReversalEntry.cs
+++ b/EntryTypes/TR_ReversalEntry.cs
@@ -14,6 +14,7 @@
 //   IsRange_M5, IsAtrExpanding_M5
 // =========================================================
 
+using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 
 namespace GeminiV26.EntryTypes
@@ -41,6 +42,7 @@ namespace GeminiV26.EntryTypes
             };
 
             int score = 0;
+            int setupScore = 0;
 
             // =========================================================
             // 1️⃣ REVERSAL EVIDENCE (HARD QUALITY GATE)
@@ -107,6 +109,91 @@ namespace GeminiV26.EntryTypes
             {
                 score += 5;
             }
+
+            var instrumentClass = SymbolRouting.ResolveInstrumentClass(ctx.Symbol);
+
+            if (instrumentClass == InstrumentClass.METAL)
+            {
+                bool hasStructure =
+                    (eval.Direction == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5)
+                    || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5)
+                    || ctx.HasEarlyPullback_M5;
+
+                if (!hasStructure)
+                    setupScore -= 40;
+                else
+                    setupScore += 20;
+
+                bool hasConfirmation =
+                    ctx.M1ReversalTrigger || ctx.LastClosedBarInTrendDirection;
+
+                if (hasConfirmation)
+                    setupScore += 20;
+            }
+            else if (instrumentClass == InstrumentClass.INDEX)
+            {
+                bool hasImpulse = ctx.HasImpulse_M5;
+                if (!hasImpulse)
+                    setupScore -= 40;
+                else
+                    setupScore += 15;
+
+                bool hasStructure =
+                    ctx.HasPullbackLong_M5 || ctx.HasPullbackShort_M5;
+
+                if (hasStructure)
+                    setupScore += 10;
+
+                bool continuationSignal = ctx.M1ReversalTrigger;
+                bool breakoutConfirmed = continuationSignal;
+
+                if (continuationSignal || breakoutConfirmed)
+                    setupScore += 20;
+            }
+            else if (instrumentClass == InstrumentClass.CRYPTO)
+            {
+                if (!ctx.IsAtrExpanding_M5)
+                    setupScore -= 30;
+
+                bool hasStructure =
+                    (eval.Direction == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5)
+                    || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5);
+
+                if (!hasStructure)
+                    setupScore -= 30;
+                else
+                    setupScore += 15;
+
+                bool continuationSignal = ctx.M1ReversalTrigger;
+
+                if (continuationSignal)
+                    setupScore += 20;
+            }
+            else
+            {
+                double pullbackDepthR =
+                    eval.Direction == TradeDirection.Short
+                        ? ctx.PullbackDepthRShort_M5
+                        : ctx.PullbackDepthRLong_M5;
+
+                bool hasStructure =
+                    pullbackDepthR >= 0.15;
+
+                if (!hasStructure)
+                    setupScore -= 35;
+                else
+                    setupScore += 15;
+
+                bool continuationSignal = ctx.M1ReversalTrigger;
+
+                if (continuationSignal)
+                    setupScore += 20;
+            }
+
+            score += setupScore;
+
+            if (setupScore <= 0)
+                score = Math.Min(score, MIN_SCORE - 10);
 
             // =========================================================
             // 5️⃣ MIN SCORE (EntryType szinten)


### PR DESCRIPTION
### Motivation

- Ensure entries across all instruments only become tradable when a real setup exists while preserving additive scoring and avoiding hard rework of existing logic. 
- Make setup presence dominate final score so quality points cannot alone produce a tradable signal.

### Description

- Added a `setupScore` accumulator at the start of directional/evaluation blocks and computed it using existing context signals (impulse, pullback/flag structure, ATR/volatility, breakout/M1 confirmations) following instrument-specific rules (XAU, FX, INDEX, CRYPTO, and generic cases) without introducing new signals. 
- Applied the dominance rule before each final validity decision: `score += setupScore; if (setupScore <= 0) score = Math.Min(score, minScore - 10);` (or equivalent using the entry's configured `min`), so low-setup paths cannot reach the minimum threshold. 
- Kept all previous additive scoring intact and only added the setup weighting and clamp; changes are additive-only and limited to entry scoring/evaluation code paths in the IEntryType implementations. 
- Files touched include key entry evaluators such as `EntryTypes/FX/*` (`FX_FlagEntry`, `FX_PullbackEntry`, `FX_MicroStructureEntry`, `FX_ReversalEntry`), `EntryTypes/METAL/*` (`XAU_PullbackEntry`, `XAU_ImpulseEntry`, `XAU_ReversalEntry`), `EntryTypes/INDEX/*` (`Index_FlagEntry`, `Index_BreakoutEntry`), `EntryTypes/CRYPTO/*` (`BTC_PullbackEntry`, `BTC_RangeBreakoutEntry`), `EntryTypes/BR_RangeBreakoutEntry.cs`, and several TC/TR entries, applying the same dominance pattern everywhere final `IsValid` is decided.

### Testing

- Ran `git diff --check` to validate whitespace and simple diff issues and it completed without errors. 
- Attempted `dotnet --info` to run build/tests but `dotnet` is not available in this environment, so no project build or unit tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbdc612f6c8328b943537c16fb6bd3)