### PR TITLE
Make entry decisions score-driven and reserve `IsValid` for hard safety

### DIFF
--- a/Core/Entry/EntryEvaluation.cs
+++ b/Core/Entry/EntryEvaluation.cs
@@ -11,6 +11,9 @@
         // 0–100
         public int Score;
 
+        // Router-level score gate for this candidate.
+        public int MinScoreThreshold;
+
         // instrument bias
         public int LogicConfidence;
 

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -5,12 +5,12 @@
 //    Korábban létezett olyan logika, ami MINDEN nem-null evalt
 //    beengedett (IsValid || IsValid == false). EZ MEGSZŰNT.
 //
-// ✅ Nincs több instrument-specifikus threshold / score gate:
-//    A TradeRouter SOHA nem tilt score alapján.
+// ✅ Score-alapú döntés:
+//    A TradeRouter csak akkor enged jelöltet tovább, ha
+//    IsValid == true ÉS Score >= MinScoreThreshold.
 //
-// ✅ A router CSAK rangsorol:
-//    Kizárólag IsValid == true setupok között választ,
-//    a Score kizárólag prioritás, nem belépési engedély.
+// ✅ A router ezután rangsorol:
+//    A Score egyszerre gate és prioritás a megmaradt setupok között.
 //
 // ✅ Logolás átlátható:
 //    jelöltek → valid setupok → nyertes kiválasztás
@@ -26,8 +26,8 @@ namespace GeminiV26.Core
 {
     /// <summary>
     /// TradeRouter (Szabálykönyv 1.0)
-    /// - CSAK IsValid == true setupokkal dolgozik
-    /// - Score csak rangsorol (nem gate)
+    /// - CSAK hard-safe (IsValid == true) setupokkal dolgozik
+    /// - Score gate = Score >= MinScoreThreshold
     /// - Winner = max Score (tie-break: determinisztikus priority)
     /// </summary>
     public class TradeRouter
@@ -61,36 +61,29 @@ namespace GeminiV26.Core
             _bot.Print($"[TR] evals={signals.Count} nonNull={nonNullCount} valid={validCount}");
             LogCandidates("CAND", signals);
 
-            // RULEBOOK: only IsValid == true is eligible
             var valid = signals
-                .Where(e => e != null && e.IsValid)
-                // ENTRY QUALITY GATE (Rulebook-safe)
-                .Where(e => e.Score >= MIN_ENTRY_SCORE_GLOBAL)
+                .Where(e => e != null && e.IsValid && e.Score >= ResolveMinScoreThreshold(e))
                 .ToList();
 
-            var rejectedByScore = signals
-                .Where(e => e != null && e.IsValid && e.Score < MIN_ENTRY_SCORE_GLOBAL)
-                .ToList();
-
-            foreach (var r in rejectedByScore)
+            foreach (var candidate in signals.Where(e => e != null))
             {
-                _bot.Print($"[TR] REJECTED_LOW_SCORE {r.Type} score={r.Score} reason={r.Reason}");
+                int threshold = ResolveMinScoreThreshold(candidate);
+                bool accepted = candidate.IsValid && candidate.Score >= threshold;
+                _bot.Print($"[ENTRY DECISION] type={candidate.Type} dir={candidate.Direction} score={candidate.Score} threshold={threshold} valid={candidate.IsValid} => {(accepted ? "ACCEPT" : "REJECT")}");
             }
 
             if (valid.Count == 0)
             {
-                _bot.Print("[TR] NO VALID SETUP AFTER QUALITY GATE");
-                return null; // ⛔ NINCS ENTRY, PONT
+                _bot.Print("[TR] NO VALID SETUP AFTER SCORE GATE");
+                return null;
             }
 
-            // RULEBOOK: Score ranks, doesn't gate.
-            // Winner = max score. Tie-breaker keeps deterministic behavior.
             var winner = valid
                 .OrderByDescending(e => e.Score)
                 .ThenBy(e => GetTypePriority(_bot.SymbolName, e.Type))
                 .First();
 
-            _bot.Print($"[TR] WINNER: {winner.Type} dir={winner.Direction} score={winner.Score} valid={winner.IsValid} reason={winner.Reason}");
+            _bot.Print($"[TR] WINNER: {winner.Type} dir={winner.Direction} score={winner.Score} threshold={ResolveMinScoreThreshold(winner)} valid={winner.IsValid} reason={winner.Reason}");
             return winner;
         }
 
@@ -104,8 +97,19 @@ namespace GeminiV26.Core
             foreach (var e in list)
             {
                 if (e == null) continue;
-                _bot.Print($"[TR] {scope} {e.Type} dir={e.Direction} valid={e.IsValid} score={e.Score} reason={e.Reason}");
+                _bot.Print($"[TR] {scope} {e.Type} dir={e.Direction} valid={e.IsValid} score={e.Score} threshold={ResolveMinScoreThreshold(e)} reason={e.Reason}");
             }
+        }
+
+
+        private static int ResolveMinScoreThreshold(EntryEvaluation evaluation)
+        {
+            if (evaluation == null)
+                return MIN_ENTRY_SCORE_GLOBAL;
+
+            return evaluation.MinScoreThreshold > 0
+                ? evaluation.MinScoreThreshold
+                : MIN_ENTRY_SCORE_GLOBAL;
         }
 
         // Deterministic tie-break (only used when scores are equal)

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -55,11 +55,8 @@ namespace GeminiV26.EntryTypes.METAL
             bool hasValidRange = hi > lo && hi > 0 && lo > 0;
             ctx.Log?.Invoke($"[FLAG RANGE CHECK] hi={hi} lo={lo} valid={hasValidRange}");
 
-            if (!hasValidRange)
-                return Invalid(ctx, "NO_FLAG_RANGE");
-
-            if (!ctx.HasFlagLong_M5 && !ctx.HasFlagShort_M5)
-                return Invalid(ctx, "NO_FLAG_STRUCTURE");
+            if (double.IsNaN(hi) || double.IsNaN(lo) || double.IsInfinity(hi) || double.IsInfinity(lo))
+                return Invalid(ctx, "DATA_INTEGRITY", 0);
                 
             double rangeAtr = hasValidRange && ctx.AtrM5 > 0
                 ? (hi - lo) / ctx.AtrM5
@@ -68,21 +65,17 @@ namespace GeminiV26.EntryTypes.METAL
             if (hasValidRange && rangeAtr > tuning.MaxFlagAtrMult * 1.3)
                 ctx.Log?.Invoke($"[FLAG WARN] Wide range kept as soft signal rangeAtr={rangeAtr:F2} maxHard={tuning.MaxFlagAtrMult * 1.3:F2}");
 
+            bool ambiguousSpike = false;
             if (hasValidRange)
             {
                 bool wickBoth = bar.High >= hi && bar.Low <= lo;
                 bool closeUp = bar.Close > hi;
                 bool closeDn = bar.Close < lo;
-
-                if (wickBoth && !closeUp && !closeDn)
-                    return Invalid(ctx, "AMBIGUOUS_SPIKE");
+                ambiguousSpike = wickBoth && !closeUp && !closeDn;
             }
 
-            var buy = EvaluateSide(TradeDirection.Long, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
-            var sell = EvaluateSide(TradeDirection.Short, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
-
-            if (!buy.IsValid && !sell.IsValid)
-                return Reject(ctx, tag, session, tuning, buy, sell);
+            var buy = EvaluateSide(TradeDirection.Long, ctx, tuning, hi, lo, hasValidRange, rangeAtr, ambiguousSpike, bar, last);
+            var sell = EvaluateSide(TradeDirection.Short, ctx, tuning, hi, lo, hasValidRange, rangeAtr, ambiguousSpike, bar, last);
 
             if (buy.IsValid && !sell.IsValid) return buy;
             if (!buy.IsValid && sell.IsValid) return sell;
@@ -109,6 +102,7 @@ namespace GeminiV26.EntryTypes.METAL
             double lo,
             bool hasValidRange,
             double rangeAtr,
+            bool ambiguousSpike,
             Bar bar,
             int index)
         {
@@ -117,6 +111,9 @@ namespace GeminiV26.EntryTypes.METAL
             int setupScore = 0;
 
             var reasons = new List<string>();
+
+            if (XauEntryDecisionPolicy.IsTrendSafetyBlock(ctx, dir, out string hardReason))
+                return InvalidDir(ctx, dir, hardReason, score, minScore);
 
             if (rangeAtr > 0)
             {
@@ -148,7 +145,10 @@ namespace GeminiV26.EntryTypes.METAL
                     : ctx.HasImpulseShort_M5;
 
             if (!hasImpulse)
-                return InvalidDir(ctx, dir, "NO_IMPULSE", score);
+            {
+                score -= 18;
+                reasons.Add("NO_IMPULSE(-18)");
+            }
 
             int barsSinceImpulse =
                 dir == TradeDirection.Long
@@ -189,9 +189,14 @@ namespace GeminiV26.EntryTypes.METAL
                 ctx.IsPullbackDecelerating_M5;
 
             if (!(ctx.HasFlagLong_M5 || ctx.HasFlagShort_M5))
-                return InvalidDir(ctx, dir, "NO_FLAG", score);
-
-            score += 5;
+            {
+                score -= 12;
+                reasons.Add("NO_FLAG_RANGE(-12)");
+            }
+            else
+            {
+                score += 5;
+            }
 
             if (ctx.PullbackBars_M5 > 0)
                 score += 4;
@@ -208,12 +213,30 @@ namespace GeminiV26.EntryTypes.METAL
                 || earlyPB;
 
             if (!hasStructure)
-                setupScore -= 40;
+            {
+                setupScore -= 20;
+                reasons.Add("WEAK_STRUCTURE(-20)");
+            }
             else
+            {
                 setupScore += 20;
+                reasons.Add("STRUCTURE_OK(+20)");
+            }
 
             if (!hasSomeStructure)
-                reasons.Add("NO_STRUCTURE");
+                reasons.Add("IMPERFECT_FLAG(-0)");
+
+            if (!hasValidRange)
+            {
+                score -= 12;
+                reasons.Add("NO_FLAG_RANGE(-12)");
+            }
+
+            if (ambiguousSpike)
+            {
+                score -= 10;
+                reasons.Add("AMBIGUOUS_SPIKE(-10)");
+            }
 
             ctx.Log?.Invoke($"[XAU FLAG] flag={hasFlag} earlyPB={earlyPB} structPB={structuredPB} score={score}");
 
@@ -257,6 +280,11 @@ namespace GeminiV26.EntryTypes.METAL
 
             if (hasConfirmation)
                 setupScore += 20;
+            else
+            {
+                setupScore -= 10;
+                reasons.Add("PARTIAL_CONFIRMATION(-10)");
+            }
 
             if (breakoutInstant && !breakoutConfirmed)
             {
@@ -315,31 +343,30 @@ namespace GeminiV26.EntryTypes.METAL
             }
 
             if (dir == TradeDirection.Long && IsLowerHigh(ctx.M5, index))
-                return InvalidDir(ctx, dir, "LOWER_HIGH", score);
+            {
+                score -= 8;
+                reasons.Add("LOWER_HIGH(-8)");
+            }
 
             if (dir == TradeDirection.Short && IsHigherLow(ctx.M5, index))
-                return InvalidDir(ctx, dir, "HIGHER_LOW", score);
+            {
+                score -= 8;
+                reasons.Add("HIGHER_LOW(-8)");
+            }
 
             score += setupScore;
-
-            if (setupScore <= 0)
-                score = Math.Min(score, minScore - 10);
-
-            int effectiveMinScore = earlyBreakout ? minScore - 2 : minScore;
-
-            bool valid = score >= effectiveMinScore;
-
-            if (!valid)
-                return InvalidDir(ctx, dir, "LOW_SCORE", score);
+            XauEntryDecisionPolicy.ApplyLogicBiasScore(ctx, dir, ref score, reasons);
 
             return new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = EntryType.XAU_Flag,
                 Direction = dir,
-                Score = score,
+                Score = Math.Max(0, score),
+                MinScoreThreshold = earlyBreakout ? minScore - 2 : minScore,
+                LogicConfidence = ctx.LogicBiasConfidence,
                 IsValid = true,
-                Reason = $"ACCEPT {dir} score={score} breakoutConfirmed={breakoutConfirmed} earlyBreakout={earlyBreakout} breakAtr={breakAtr:F2} bodyRatio={bodyRatio:F2} rangeAtr={rangeAtr:F2}"
+                Reason = $"[XAU_FLAG][ENTRY DECISION] score={Math.Max(0, score)} threshold={(earlyBreakout ? minScore - 2 : minScore)} valid=true dir={dir} breakoutConfirmed={breakoutConfirmed} earlyBreakout={earlyBreakout} breakAtr={breakAtr:F2} bodyRatio={bodyRatio:F2} rangeAtr={rangeAtr:F2} :: {string.Join(" | ", reasons)}"
             };
         }
 
@@ -376,18 +403,10 @@ namespace GeminiV26.EntryTypes.METAL
             EntryEvaluation buy,
             EntryEvaluation sell)
         {
-            return new EntryEvaluation
-            {
-                Symbol = ctx.Symbol,
-                Type = EntryType.XAU_Flag,
-                Direction = TradeDirection.None,
-                Score = (int)tuning.BaseScore,
-                IsValid = false,
-                Reason = $"REJECT BOTH buy={buy.Score}/{buy.IsValid} sell={sell.Score}/{sell.IsValid}"
-            };
+            return buy.Score >= sell.Score ? buy : sell;
         }
 
-        private static EntryEvaluation InvalidDir(EntryContext ctx, TradeDirection dir, string reason, int score)
+        private static EntryEvaluation InvalidDir(EntryContext ctx, TradeDirection dir, string reason, int score, int minScore)
         {
             return new EntryEvaluation
             {
@@ -395,20 +414,23 @@ namespace GeminiV26.EntryTypes.METAL
                 Type = EntryType.XAU_Flag,
                 Direction = dir,
                 Score = Math.Max(0, score),
+                MinScoreThreshold = minScore,
                 IsValid = false,
-                Reason = reason
+                Reason = $"[XAU_FLAG][ENTRY DECISION] score={Math.Max(0, score)} threshold={minScore} valid=false dir={dir} state={reason}"
             };
         }
 
-        private static EntryEvaluation Invalid(EntryContext ctx, string reason)
+        private static EntryEvaluation Invalid(EntryContext ctx, string reason, int score = 0)
         {
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = EntryType.XAU_Flag,
                 Direction = TradeDirection.None,
+                Score = Math.Max(0, score),
+                MinScoreThreshold = 0,
                 IsValid = false,
-                Reason = reason
+                Reason = $"[XAU_FLAG][ENTRY DECISION] score={Math.Max(0, score)} threshold=0 valid=false state={reason}"
             };
         }
     }

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -1,27 +1,17 @@
-﻿using GeminiV26.Core.Entry;
+﻿using System;
+using System.Collections.Generic;
+using GeminiV26.Core.Entry;
 using GeminiV26.Core;
 using GeminiV26.Core.Matrix;
 
 namespace GeminiV26.EntryTypes.METAL
 {
-    /// <summary>
-    /// XAU Impulse Continuation Entry – LIVE VERSION
-    /// Phase 3.9 – Momentum continuation for metals
-    ///
-    /// Belép, ha:
-    /// - M5 ATR expanzió
-    /// - M5 impulse
-    /// - ADX minimum szint
-    /// - EMA alignment irányba
-    /// - M1 trigger megerősítés
-    /// </summary>
     public class XAU_ImpulseEntry : IEntryType
     {
         public EntryType Type => EntryType.XAU_Impulse;
 
         private const double SlopeEps = 0.0;
-        private const int MinScore = 65;
-        private const double MinAdx = 18.0;
+        private const int MinScoreThreshold = 65;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
@@ -32,152 +22,153 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null)
                 return Reject(ctx, "CTX_NOT_READY");
 
-            int score = 60; // base impulse score
-            int setupScore = 0;
-
-            // =====================================================
-            // 1️⃣ IRÁNY
-            // =====================================================
             TradeDirection dir = ResolveXauDirection(ctx);
             if (dir == TradeDirection.None)
-                return Reject(ctx, "NO_CLEAR_DIRECTION");
+                return Reject(ctx, "NO_TREND_CONTEXT");
 
-            // =====================================================
-            // 2️⃣ ATR EXPANSION
-            // =====================================================
+            int score = 60;
+            int setupScore = 0;
+            var reasons = new List<string>();
+
+            if (XauEntryDecisionPolicy.IsTrendSafetyBlock(ctx, dir, out string hardReason))
+                return Build(ctx, dir, score, false, hardReason, reasons);
+
             if (!ctx.IsAtrExpanding_M5)
-                return Reject(ctx, "ATR_NOT_EXPANDING");
+            {
+                score -= 10;
+                reasons.Add("ATR_NOT_EXPANDING(-10)");
+            }
+            else
+            {
+                score += 5;
+                reasons.Add("ATR_EXPANDING(+5)");
+            }
 
-            score += 5;
-
-            // =====================================================
-            // 3️⃣ IMPULSE M5
-            // =====================================================
             if (!ctx.HasImpulse_M5)
-                return Reject(ctx, "NO_M5_IMPULSE");
+            {
+                score -= 14;
+                reasons.Add("NO_M5_IMPULSE(-14)");
+            }
+            else
+            {
+                score += 5;
+                reasons.Add("M5_IMPULSE(+5)");
+            }
 
-            score += 5;
-
-            // =====================================================
-            // 4️⃣ ADX FILTER (XAU stricter momentum control)
-            // =====================================================
-
-            double minAdxRequired = 18.0;
-
-            // XAU impulse continuationhez erősebb trend kell
-            if (SymbolRouting.ResolveInstrumentClass(ctx.Symbol) == InstrumentClass.METAL)
-                minAdxRequired = 28.0;
-
-            minAdxRequired = System.Math.Max(minAdxRequired, matrix.MinAdx);
+            double minAdxRequired = SymbolRouting.ResolveInstrumentClass(ctx.Symbol) == InstrumentClass.METAL
+                ? 28.0
+                : 18.0;
+            minAdxRequired = Math.Max(minAdxRequired, matrix.MinAdx);
 
             if (ctx.Adx_M5 < minAdxRequired)
-                return Reject(ctx, $"ADX_TOO_LOW({ctx.Adx_M5:F1})");
-
-            if (ctx.Adx_M5 >= 30)
+            {
+                score -= 10;
+                reasons.Add($"ADX_TOO_LOW(-10:{ctx.Adx_M5:F1}<{minAdxRequired:F1})");
+            }
+            else if (ctx.Adx_M5 >= 30)
+            {
                 score += 5;
+                reasons.Add("ADX_STRONG(+5)");
+            }
 
-            // =====================================================
-            // 5️⃣ EMA ALIGNMENT
-            // =====================================================
             if (dir == TradeDirection.Long)
             {
                 if (ctx.Ema8_M5 > ctx.Ema21_M5)
+                {
                     score += 5;
+                    reasons.Add("EMA_ALIGN(+5)");
+                }
+                else
+                {
+                    score -= 5;
+                    reasons.Add("EMA_MISALIGN(-5)");
+                }
             }
             else
             {
                 if (ctx.Ema8_M5 < ctx.Ema21_M5)
+                {
                     score += 5;
+                    reasons.Add("EMA_ALIGN(+5)");
+                }
+                else
+                {
+                    score -= 5;
+                    reasons.Add("EMA_MISALIGN(-5)");
+                }
             }
 
-            // =====================================================
-            // 6️⃣ M1 TRIGGER (Continuation confirmation)
-            // =====================================================
             if (!ctx.M1TriggerInTrendDirection)
-                return Reject(ctx, "NO_M1_TRIGGER");
+            {
+                score -= 8;
+                reasons.Add("NO_M1_TRIGGER(-8)");
+            }
+            else
+            {
+                score += 5;
+                reasons.Add("M1_TRIGGER_OK(+5)");
+            }
 
-            score += 5;
-
-            bool hasFlag =
-                dir == TradeDirection.Long
-                    ? ctx.HasFlagLong_M5
-                    : ctx.HasFlagShort_M5;
-
-            bool structuredPB =
-                ctx.IsPullbackDecelerating_M5 &&
-                ctx.PullbackBars_M5 >= 2;
-
-            bool earlyPB =
-                ctx.HasEarlyPullback_M5;
-
-            bool hasStructure =
-                hasFlag
-                || structuredPB
-                || earlyPB;
+            bool hasFlag = dir == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5;
+            bool structuredPB = ctx.IsPullbackDecelerating_M5 && ctx.PullbackBars_M5 >= 2;
+            bool earlyPB = ctx.HasEarlyPullback_M5;
+            bool hasStructure = hasFlag || structuredPB || earlyPB;
 
             if (!hasStructure)
-                setupScore -= 40;
-            else
-                setupScore += 20;
-
-            bool breakoutConfirmed =
-                ctx.HasBreakout_M1 &&
-                ctx.BreakoutDirection == dir;
-
-            bool earlyBreakout =
-                ctx.M1TriggerInTrendDirection;
-
-            bool hasConfirmation =
-                breakoutConfirmed
-                || earlyBreakout;
-
-            if (hasConfirmation)
-                setupScore += 20;
-
-            // =====================================================
-            // FINAL DECISION
-            // =====================================================
-            score += (int)System.Math.Round(matrix.EntryScoreModifier);
-            score += setupScore;
-
-            if (setupScore <= 0)
-                score = System.Math.Min(score, MinScore - 10);
-
-            if (score < MinScore)
-                return Reject(ctx, $"LOW_SCORE({score})");
-
-            string note =
-                $"[XAU_IMPULSE_CONT] {ctx.Symbol} dir={dir} " +
-                $"Score={score} ADX={ctx.Adx_M5:F1} ATR_EXP=True IMPULSE=True";
-
-            return new EntryEvaluation
             {
-                Symbol = ctx.Symbol,
-                Type = Type,
-                Direction = dir,
-                Score = score,
-                IsValid = true,
-                Reason = note
-            };
+                setupScore -= 20;
+                reasons.Add("WEAK_STRUCTURE(-20)");
+            }
+            else
+            {
+                setupScore += 20;
+                reasons.Add("STRUCTURE_OK(+20)");
+            }
+
+            bool breakoutConfirmed = ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir;
+            bool earlyBreakout = ctx.M1TriggerInTrendDirection;
+            if (breakoutConfirmed || earlyBreakout)
+            {
+                setupScore += 20;
+                reasons.Add("CONFIRMATION_OK(+20)");
+            }
+            else
+            {
+                setupScore -= 10;
+                reasons.Add("PARTIAL_CONFIRMATION(-10)");
+            }
+
+            if (ctx.IsTransition_M5)
+            {
+                score -= 6;
+                reasons.Add("TRANSITION_PENALTY(-6)");
+            }
+
+            if (ctx.MetalHtfAllowedDirection != TradeDirection.None && ctx.MetalHtfAllowedDirection != dir)
+            {
+                score -= 5;
+                reasons.Add("HTF_AGAINST(-5)");
+            }
+
+            score += (int)Math.Round(matrix.EntryScoreModifier);
+            score += setupScore;
+            XauEntryDecisionPolicy.ApplyLogicBiasScore(ctx, dir, ref score, reasons);
+
+            return Build(ctx, dir, score, true, "SCORE_DRIVEN", reasons);
         }
 
-        // =====================================================
-        // IRÁNY MEGHATÁROZÁS – változatlan
-        // =====================================================
         private TradeDirection ResolveXauDirection(EntryContext ctx)
         {
             bool up5 = ctx.Ema21Slope_M5 > SlopeEps;
             bool dn5 = ctx.Ema21Slope_M5 < -SlopeEps;
-
             bool up15 = ctx.Ema21Slope_M15 > SlopeEps;
             bool dn15 = ctx.Ema21Slope_M15 < -SlopeEps;
 
             if (up5 && up15) return TradeDirection.Long;
             if (dn5 && dn15) return TradeDirection.Short;
 
-            double a5 = System.Math.Abs(ctx.Ema21Slope_M5);
-            double a15 = System.Math.Abs(ctx.Ema21Slope_M15);
-
+            double a5 = Math.Abs(ctx.Ema21Slope_M5);
+            double a15 = Math.Abs(ctx.Ema21Slope_M15);
             if (a5 <= 0 && a15 <= 0) return TradeDirection.None;
 
             if (a15 >= a5 * 0.9)
@@ -188,7 +179,6 @@ namespace GeminiV26.EntryTypes.METAL
 
             if (up5) return TradeDirection.Long;
             if (dn5) return TradeDirection.Short;
-
             return TradeDirection.None;
         }
 
@@ -198,8 +188,26 @@ namespace GeminiV26.EntryTypes.METAL
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
+                Direction = TradeDirection.None,
+                Score = 0,
+                MinScoreThreshold = MinScoreThreshold,
                 IsValid = false,
-                Reason = $"[XAU_IMPULSE_REJECT] {reason}"
+                Reason = $"[XAU_IMPULSE][ENTRY DECISION] score=0 threshold={MinScoreThreshold} valid=false state={reason}"
+            };
+        }
+
+        private EntryEvaluation Build(EntryContext ctx, TradeDirection dir, int score, bool isValid, string state, List<string> reasons)
+        {
+            return new EntryEvaluation
+            {
+                Symbol = ctx?.Symbol,
+                Type = Type,
+                Direction = dir,
+                Score = Math.Max(0, score),
+                MinScoreThreshold = MinScoreThreshold,
+                IsValid = isValid,
+                LogicConfidence = ctx?.LogicBiasConfidence ?? 0,
+                Reason = $"[XAU_IMPULSE][ENTRY DECISION] score={Math.Max(0, score)} threshold={MinScoreThreshold} valid={isValid} state={state} dir={dir} :: {string.Join(" | ", reasons ?? new List<string>())}"
             };
         }
     }

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -11,128 +11,99 @@ namespace GeminiV26.EntryTypes.METAL
 
         private const int BarsNotReadyMin = 20;
         private const int ScoreDeadband = 2;
-
-        private const int FreshImpulsePenalty = 6;
+        private const int MinScoreThreshold = 64;
         private const int NoM1Penalty = 6;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowPullback)
-                return Reject(ctx, "SESSION_DISABLED");
+                return Reject(ctx, "SESSION_DISABLED", MinScoreThreshold);
 
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < BarsNotReadyMin)
-                return Reject(ctx, "CTX_NOT_READY");
-
-            if (ctx.MarketState?.IsTrend != true)
-                return Reject(ctx, "NO_TREND_STATE");
+                return Reject(ctx, "CTX_NOT_READY", MinScoreThreshold);
 
             var buy = EvaluateSide(TradeDirection.Long, ctx, matrix);
             var sell = EvaluateSide(TradeDirection.Short, ctx, matrix);
-
-            if (!buy.IsValid && !sell.IsValid)
-                return RejectBoth(ctx, buy, sell);
-
-            if (buy.IsValid && !sell.IsValid) return buy;
-            if (!buy.IsValid && sell.IsValid) return sell;
-
-            int diff = buy.Score - sell.Score;
-
-            if (Math.Abs(diff) <= ScoreDeadband)
-            {
-                // döntés: melyik oldal reagált előbb
-                if (ctx.BarsSinceImpulseLong_M5 < ctx.BarsSinceImpulseShort_M5)
-                    return buy;
-
-                if (ctx.BarsSinceImpulseShort_M5 < ctx.BarsSinceImpulseLong_M5)
-                    return sell;
-            }
-
-            return diff >= 0 ? buy : sell;
+            return SelectBest(ctx, buy, sell);
         }
 
-        private EntryEvaluation EvaluateSide(
-            TradeDirection dir,
-            EntryContext ctx,
-            SessionMatrixConfig matrix)
+        private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx, SessionMatrixConfig matrix)
         {
             int score = 60;
-            int minScore = 64;
             int setupScore = 0;
-
             var reasons = new List<string>();
 
-            // =========================
-            // IMPULSE (2-sided)
-            // =========================
-            bool hasImpulse =
-                dir == TradeDirection.Long
-                    ? ctx.HasImpulseLong_M5
-                    : ctx.HasImpulseShort_M5;
+            if (XauEntryDecisionPolicy.IsTrendSafetyBlock(ctx, dir, out string hardReason))
+                return Build(dir, Math.Max(0, score), false, hardReason, ctx, reasons, MinScoreThreshold);
 
-            if (!hasImpulse)
-                return InvalidDir(ctx, dir, "NO_IMPULSE", score);
-
-            int barsSinceImpulse =
-                dir == TradeDirection.Long
-                    ? ctx.BarsSinceImpulseLong_M5
-                    : ctx.BarsSinceImpulseShort_M5;
-
-            if (barsSinceImpulse > 6)
-                return InvalidDir(ctx, dir, "STALE_IMPULSE", score);
-
-            if (barsSinceImpulse == 0)
+            bool hasImpulse = dir == TradeDirection.Long ? ctx.HasImpulseLong_M5 : ctx.HasImpulseShort_M5;
+            if (hasImpulse)
             {
-                return InvalidDir(ctx, dir, "IMPULSE_TOO_FRESH", score);
+                score += 8;
+                reasons.Add("IMPULSE_OK");
+            }
+            else
+            {
+                score -= 18;
+                reasons.Add("NO_IMPULSE(-18)");
             }
 
-            // =========================
-            // PULLBACK
-            // =========================
-            int pbBars =
-                dir == TradeDirection.Long
-                    ? ctx.PullbackBarsLong_M5
-                    : ctx.PullbackBarsShort_M5;
-            
-            double pbDepth =
-                dir == TradeDirection.Long
-                    ? ctx.PullbackDepthRLong_M5
-                    : ctx.PullbackDepthRShort_M5;
+            int barsSinceImpulse = dir == TradeDirection.Long ? ctx.BarsSinceImpulseLong_M5 : ctx.BarsSinceImpulseShort_M5;
+            if (barsSinceImpulse > 6)
+            {
+                score -= 12;
+                reasons.Add("STALE_IMPULSE(-12)");
+            }
+            else if (barsSinceImpulse == 0)
+            {
+                score -= 6;
+                reasons.Add("IMPULSE_TOO_FRESH(-6)");
+            }
+            else if (barsSinceImpulse <= 2)
+            {
+                score += 4;
+                reasons.Add("IMPULSE_FRESH(+4)");
+            }
 
-           bool noPullback = pbBars == 0;
+            int pbBars = dir == TradeDirection.Long ? ctx.PullbackBarsLong_M5 : ctx.PullbackBarsShort_M5;
+            double pbDepth = dir == TradeDirection.Long ? ctx.PullbackDepthRLong_M5 : ctx.PullbackDepthRShort_M5;
+            bool noPullback = pbBars == 0;
 
-            // EARLY CONTINUATION DETECTION
             bool earlyContinuation =
-                pbBars > 0 &&          // ← EZ A KULCS FIX
+                pbBars > 0 &&
                 hasImpulse &&
                 barsSinceImpulse <= 2 &&
                 ctx.LastClosedBarInTrendDirection;
 
-            // ha early continuation → NEM büntetjük
             if (noPullback)
             {
-            return InvalidDir(ctx, dir, "NO_PULLBACK", score);
+                score -= 14;
+                reasons.Add("NO_PULLBACK(-14)");
             }
             else if (earlyContinuation)
             {
                 score += 8;
-                reasons.Add("EARLY_CONTINUATION");
+                reasons.Add("EARLY_CONTINUATION(+8)");
             }
 
             if (pbBars > 3)
-                return InvalidDir(ctx, dir, "PULLBACK_TOO_LONG", score);
-
-            double max = 1.0;
-            double deepLimit = 1.4;
-
-            // HARD REJECT csak extrém eset
-            if (pbDepth > deepLimit)
             {
-                return InvalidDir(ctx, dir, "PB_TOO_DEEP_HARD", score);
+                score -= 10;
+                reasons.Add("PULLBACK_TOO_LONG(-10)");
+            }
+            else if (pbBars >= 2)
+            {
+                score += 5;
+                reasons.Add("PB_LENGTH_OK(+5)");
             }
 
-            // DEEP PULLBACK (nem automatikus halál!)
-            if (pbDepth > max)
+            if (pbDepth > 1.4)
+            {
+                score -= 16;
+                reasons.Add("PB_TOO_DEEP(-16)");
+            }
+            else if (pbDepth > 1.0)
             {
                 bool compression =
                     ctx.HasReactionCandle_M5 ||
@@ -142,23 +113,20 @@ namespace GeminiV26.EntryTypes.METAL
                 if (compression)
                 {
                     score += 4;
-                    reasons.Add("DEEP_PB_ALLOWED");
+                    reasons.Add("DEEP_PB_ALLOWED(+4)");
                 }
                 else
                 {
                     score -= 4;
-                    reasons.Add("DEEP_PB_NO_CONFIRM");
+                    reasons.Add("DEEP_PB_NO_CONFIRM(-4)");
                 }
             }
-            else
+            else if (pbDepth > 0)
             {
                 score += 8;
-                reasons.Add("PB_OK");
+                reasons.Add("PB_OK(+8)");
             }
 
-            // =========================
-            // REACTION (core edge)
-            // =========================
             bool reaction =
                 ctx.HasReactionCandle_M5 ||
                 ctx.HasRejectionWick_M5 ||
@@ -167,161 +135,123 @@ namespace GeminiV26.EntryTypes.METAL
             if (reaction)
             {
                 score += 10;
-                reasons.Add("REACTION_OK");
+                reasons.Add("REACTION_OK(+10)");
             }
             else
             {
                 score -= 6;
-                reasons.Add("NO_REACTION");
+                reasons.Add("NO_REACTION(-6)");
             }
 
             if (ctx.HasEarlyPullback_M5)
             {
                 score += 1;
-                reasons.Add("EARLY_PULLBACK");
+                reasons.Add("EARLY_PULLBACK(+1)");
             }
 
             if (ctx.IsTransition_M5)
             {
                 score -= 6;
-                reasons.Add("TRANSITION_PENALTY");
+                reasons.Add("TRANSITION_PENALTY(-6)");
             }
 
-            // =========================
-            // M1 trigger
-            // =========================
-            bool m1 =
-                ctx.M1TriggerInTrendDirection ||
-                ctx.M1ReversalTrigger;
-
+            bool m1 = ctx.M1TriggerInTrendDirection || ctx.M1ReversalTrigger;
             if (m1)
             {
                 score += 10;
-                reasons.Add("M1_OK");
+                reasons.Add("M1_OK(+10)");
             }
             else
             {
                 score -= NoM1Penalty;
-                reasons.Add("NO_M1");
+                reasons.Add("NO_M1_TRIGGER(-6)");
             }
 
-            // =========================
-            // HTF (soft only)
-            // =========================
-            bool against =
-                ctx.MetalHtfAllowedDirection != TradeDirection.None &&
-                ctx.MetalHtfAllowedDirection != dir;
-
+            bool against = ctx.MetalHtfAllowedDirection != TradeDirection.None && ctx.MetalHtfAllowedDirection != dir;
             if (against)
             {
                 score -= 5;
-                reasons.Add("HTF_AGAINST");
+                reasons.Add("HTF_AGAINST(-5)");
             }
 
-            bool hasFlag =
-                dir == TradeDirection.Long
-                    ? ctx.HasFlagLong_M5
-                    : ctx.HasFlagShort_M5;
-
-            bool structuredPB =
-                ctx.IsPullbackDecelerating_M5 &&
-                pbBars >= 2;
-
-            bool earlyPB =
-                ctx.HasEarlyPullback_M5;
-
-            bool hasStructure =
-                hasFlag
-                || structuredPB
-                || earlyPB;
+            bool hasFlag = dir == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5;
+            bool structuredPB = ctx.IsPullbackDecelerating_M5 && pbBars >= 2;
+            bool earlyPB = ctx.HasEarlyPullback_M5;
+            bool hasStructure = hasFlag || structuredPB || earlyPB;
 
             if (!hasStructure)
-                setupScore -= 40;
+            {
+                setupScore -= 20;
+                reasons.Add("WEAK_STRUCTURE(-20)");
+            }
             else
+            {
                 setupScore += 20;
+                reasons.Add("STRUCTURE_OK(+20)");
+            }
 
-            bool breakoutConfirmed =
-                m1;
-
-            bool earlyBreakout =
-                earlyContinuation;
-
-            bool hasConfirmation =
-                breakoutConfirmed
-                || earlyBreakout;
+            bool breakoutConfirmed = m1;
+            bool earlyBreakout = earlyContinuation;
+            bool hasConfirmation = breakoutConfirmed || earlyBreakout;
 
             if (hasConfirmation)
+            {
                 setupScore += 20;
+                reasons.Add("CONFIRMATION_OK(+20)");
+            }
+            else
+            {
+                setupScore -= 10;
+                reasons.Add("PARTIAL_CONFIRMATION(-10)");
+            }
 
-            // =========================
-            // FINAL
-            // =========================
             score += (int)Math.Round(matrix.EntryScoreModifier);
             score += setupScore;
 
-            if (setupScore <= 0)
-                score = Math.Min(score, minScore - 10);
-
-            bool valid = score >= minScore;
-
-            if (!valid)
-                return InvalidDir(ctx, dir, "LOW_SCORE", score);
-
-            return new EntryEvaluation
-            {
-                Symbol = ctx.Symbol,
-                Type = Type,
-                Direction = dir,
-                Score = score,
-                IsValid = true,
-                Reason = $"ACCEPT {dir} score={score} pbBars={pbBars} depth={pbDepth:F2} early={earlyContinuation}"
-            };
+            XauEntryDecisionPolicy.ApplyLogicBiasScore(ctx, dir, ref score, reasons);
+            return Build(dir, score, true, "SCORE_DRIVEN", ctx, reasons, MinScoreThreshold);
         }
 
-        // =========================
+        private EntryEvaluation SelectBest(EntryContext ctx, EntryEvaluation buy, EntryEvaluation sell)
+        {
+            int diff = buy.Score - sell.Score;
+            if (Math.Abs(diff) <= ScoreDeadband)
+            {
+                if (ctx.BarsSinceImpulseLong_M5 < ctx.BarsSinceImpulseShort_M5)
+                    return buy;
+                if (ctx.BarsSinceImpulseShort_M5 < ctx.BarsSinceImpulseLong_M5)
+                    return sell;
+            }
 
-        private EntryEvaluation Reject(EntryContext ctx, string reason)
+            return diff >= 0 ? buy : sell;
+        }
+
+        private EntryEvaluation Reject(EntryContext ctx, string reason, int threshold)
         {
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
                 Direction = TradeDirection.None,
+                Score = 0,
+                MinScoreThreshold = threshold,
                 IsValid = false,
                 Reason = reason
             };
         }
 
-        private EntryEvaluation RejectBoth(
-            EntryContext ctx,
-            EntryEvaluation buy,
-            EntryEvaluation sell)
+        private EntryEvaluation Build(TradeDirection dir, int score, bool isValid, string state, EntryContext ctx, List<string> reasons, int threshold)
         {
             return new EntryEvaluation
             {
-                Symbol = ctx.Symbol,
-                Type = Type,
-                Direction = TradeDirection.None,
-                IsValid = false,
-                Score = Math.Max(buy.Score, sell.Score),
-                Reason = $"REJECT BOTH buy={buy.Score}/{buy.IsValid} sell={sell.Score}/{sell.IsValid}"
-            };
-        }
-
-        private EntryEvaluation InvalidDir(
-            EntryContext ctx,
-            TradeDirection dir,
-            string reason,
-            int score)
-        {
-            return new EntryEvaluation
-            {
-                Symbol = ctx.Symbol,
+                Symbol = ctx?.Symbol,
                 Type = Type,
                 Direction = dir,
                 Score = Math.Max(0, score),
-                IsValid = false,
-                Reason = reason
+                MinScoreThreshold = threshold,
+                IsValid = isValid,
+                LogicConfidence = ctx?.LogicBiasConfidence ?? 0,
+                Reason = $"[XAU_PULLBACK][ENTRY DECISION] score={Math.Max(0, score)} threshold={threshold} valid={isValid} state={state} dir={dir} :: {string.Join(" | ", reasons ?? new List<string>())}"
             };
         }
     }

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -9,138 +9,100 @@ namespace GeminiV26.EntryTypes.METAL
         public EntryType Type => EntryType.XAU_Reversal;
 
         private const int MinEvidence = 4;
-        private const int MinScore = 50;
+        private const int MinScoreThreshold = 50;
         private const double SlopeEps = 0.0;
-
-        private const int NoM1Penalty = 12;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             if (ctx == null || !ctx.IsReady || ctx.M5 == null)
                 return Reject(ctx, "CTX_NOT_READY");
 
-            var reasons = new List<string>(8);
-            int setupScore = 0;
-
-            // =====================================================
-            // 1️⃣ TREND IRÁNY (XAU saját)
-            // =====================================================
             TradeDirection trendDir = ResolveXauDirection(ctx);
             if (trendDir == TradeDirection.None)
-                return Reject(ctx, "NO_TREND_DIR");
+                return Reject(ctx, "NO_TREND_CONTEXT");
 
-            // Reversal irány = trend ellen
-            TradeDirection dir = trendDir == TradeDirection.Long
-                ? TradeDirection.Short
-                : TradeDirection.Long;
+            TradeDirection dir = trendDir == TradeDirection.Long ? TradeDirection.Short : TradeDirection.Long;
+            var reasons = new List<string> { $"Trend={trendDir}" };
+            int score = 20;
+            int setupScore = 0;
 
-            reasons.Add($"Trend={trendDir}");
-
-            // =====================================================
-            // 2️⃣ RANGE KÖTELEZŐ
-            // =====================================================
-            if (!ctx.IsRange_M5)
-                return RejectDecision(ctx, dir, 0, "NOT_RANGE", reasons);
+            if (XauEntryDecisionPolicy.IsReversalSafetyBlock(ctx, dir, out string hardReason))
+                return Build(ctx, dir, score, false, hardReason, reasons);
 
             reasons.Add("RANGE_OK");
 
-            // extra kontroll XAU-ra – ne kontrázzunk még élő trendet
-            if (ctx.Adx_M5 > 22)
-                return RejectDecision(ctx, dir, 0, $"RANGE_BUT_ADX_STRONG({ctx.Adx_M5:F1})", reasons);
-
-            // =====================================================
-            // 3️⃣ REVERSAL EVIDENCE
-            // =====================================================
             int evidence = ctx.ReversalEvidenceScore;
             if (evidence < MinEvidence)
-                return RejectDecision(ctx, dir, 0, $"WEAK_EVIDENCE({evidence})", reasons);
-
-            int score = evidence * 12 + 20;
-            reasons.Add($"Evidence={evidence}");
-
-            // =====================================================
-            // 4️⃣ M1 REVERSAL TRIGGER
-            // =====================================================
-            // XAU reversalhez kötelező az M1 trigger
-            if (!ctx.M1ReversalTrigger)
-                return RejectDecision(ctx, dir, score, "NO_M1_REV", reasons);
-
-            score += 15;
-            reasons.Add("+M1_REV(15)");
-
-            bool hasFlag =
-                dir == TradeDirection.Long
-                    ? ctx.HasFlagLong_M5
-                    : ctx.HasFlagShort_M5;
-
-            bool structuredPB =
-                ctx.IsPullbackDecelerating_M5 &&
-                ctx.PullbackBars_M5 >= 2;
-
-            bool earlyPB =
-                ctx.HasEarlyPullback_M5;
-
-            bool hasStructure =
-                hasFlag
-                || structuredPB
-                || earlyPB;
-
-            if (!hasStructure)
-                setupScore -= 40;
+            {
+                score -= 12;
+                reasons.Add($"WEAK_EVIDENCE(-12:{evidence})");
+            }
             else
+            {
+                score += evidence * 12;
+                reasons.Add($"EVIDENCE_OK(+{evidence * 12})");
+            }
+
+            if (!ctx.M1ReversalTrigger)
+            {
+                score -= 12;
+                reasons.Add("NO_M1_TRIGGER(-12)");
+            }
+            else
+            {
+                score += 15;
+                reasons.Add("M1_REV_OK(+15)");
+            }
+
+            bool hasFlag = dir == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5;
+            bool structuredPB = ctx.IsPullbackDecelerating_M5 && ctx.PullbackBars_M5 >= 2;
+            bool earlyPB = ctx.HasEarlyPullback_M5;
+            bool hasStructure = hasFlag || structuredPB || earlyPB;
+            if (!hasStructure)
+            {
+                setupScore -= 20;
+                reasons.Add("WEAK_STRUCTURE(-20)");
+            }
+            else
+            {
                 setupScore += 20;
+                reasons.Add("STRUCTURE_OK(+20)");
+            }
 
-            bool breakoutConfirmed =
-                ctx.M1ReversalTrigger;
-
-            bool earlyBreakout =
-                ctx.LastClosedBarInTrendDirection;
-
-            bool hasConfirmation =
-                breakoutConfirmed
-                || earlyBreakout;
-
-            if (hasConfirmation)
+            bool breakoutConfirmed = ctx.M1ReversalTrigger;
+            bool earlyBreakout = ctx.LastClosedBarInTrendDirection;
+            if (breakoutConfirmed || earlyBreakout)
+            {
                 setupScore += 20;
+                reasons.Add("CONFIRMATION_OK(+20)");
+            }
+            else
+            {
+                setupScore -= 10;
+                reasons.Add("PARTIAL_CONFIRMATION(-10)");
+            }
+
+            if (ctx.IsTransition_M5)
+            {
+                score -= 5;
+                reasons.Add("TRANSITION_PENALTY(-5)");
+            }
+
+            if (ctx.MetalHtfAllowedDirection != TradeDirection.None && ctx.MetalHtfAllowedDirection != dir)
+            {
+                score -= 5;
+                reasons.Add("HTF_AGAINST(-5)");
+            }
 
             score += setupScore;
-
-            if (setupScore <= 0)
-                score = Math.Min(score, MinScore - 10);
-
-            // =====================================================
-            // 5️⃣ MIN SCORE GATE
-            // =====================================================
-            if (score < MinScore)
-                return RejectDecision(ctx, dir, score, $"LOW_SCORE({score})", reasons);
-
-            // =====================================================
-            // ACCEPT
-            // =====================================================
-            string note =
-                $"[XAU_REV] {ctx.Symbol} dir={dir} " +
-                $"Score={score} Min={MinScore} Decision=ACCEPT | " +
-                string.Join(" | ", reasons);
-
-            return new EntryEvaluation
-            {
-                Symbol = ctx.Symbol,
-                Type = Type,
-                Direction = dir,
-                Score = score,
-                IsValid = true,
-                Reason = note
-            };
+            XauEntryDecisionPolicy.ApplyLogicBiasScore(ctx, dir, ref score, reasons);
+            return Build(ctx, dir, score, true, "SCORE_DRIVEN", reasons);
         }
 
-        // =====================================================
-        // HELPERS
-        // =====================================================
         private TradeDirection ResolveXauDirection(EntryContext ctx)
         {
             bool up5 = ctx.Ema21Slope_M5 > SlopeEps;
             bool dn5 = ctx.Ema21Slope_M5 < -SlopeEps;
-
             bool up15 = ctx.Ema21Slope_M15 > SlopeEps;
             bool dn15 = ctx.Ema21Slope_M15 < -SlopeEps;
 
@@ -149,7 +111,6 @@ namespace GeminiV26.EntryTypes.METAL
 
             double a5 = Math.Abs(ctx.Ema21Slope_M5);
             double a15 = Math.Abs(ctx.Ema21Slope_M15);
-
             if (a5 <= 0 && a15 <= 0) return TradeDirection.None;
 
             if (a15 >= a5 * 0.9)
@@ -160,7 +121,6 @@ namespace GeminiV26.EntryTypes.METAL
 
             if (up5) return TradeDirection.Long;
             if (dn5) return TradeDirection.Short;
-
             return TradeDirection.None;
         }
 
@@ -170,31 +130,26 @@ namespace GeminiV26.EntryTypes.METAL
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
+                Direction = TradeDirection.None,
+                Score = 0,
+                MinScoreThreshold = MinScoreThreshold,
                 IsValid = false,
-                Reason = reason
+                Reason = $"[XAU_REV][ENTRY DECISION] score=0 threshold={MinScoreThreshold} valid=false state={reason}"
             };
         }
 
-        private EntryEvaluation RejectDecision(
-            EntryContext ctx,
-            TradeDirection dir,
-            int score,
-            string reason,
-            List<string> reasons)
+        private EntryEvaluation Build(EntryContext ctx, TradeDirection dir, int score, bool isValid, string state, List<string> reasons)
         {
-            string note =
-                $"[XAU_REV] {ctx?.Symbol} dir={dir} " +
-                $"Score={score} Decision=REJECT Reason={reason} | " +
-                (reasons != null ? string.Join(" | ", reasons) : "");
-
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
                 Direction = dir,
                 Score = Math.Max(0, score),
-                IsValid = false,
-                Reason = note
+                MinScoreThreshold = MinScoreThreshold,
+                IsValid = isValid,
+                LogicConfidence = ctx?.LogicBiasConfidence ?? 0,
+                Reason = $"[XAU_REV][ENTRY DECISION] score={Math.Max(0, score)} threshold={MinScoreThreshold} valid={isValid} state={state} dir={dir} :: {string.Join(" | ", reasons ?? new List<string>())}"
             };
         }
     }

--- a/EntryTypes/METAL/XauEntryDecisionPolicy.cs
+++ b/EntryTypes/METAL/XauEntryDecisionPolicy.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using GeminiV26.Core;
+using GeminiV26.Core.Entry;
+
+namespace GeminiV26.EntryTypes.METAL
+{
+    internal static class XauEntryDecisionPolicy
+    {
+        public static bool HasDataIntegrityIssue(EntryContext ctx)
+        {
+            if (ctx == null)
+                return true;
+
+            return double.IsNaN(ctx.AtrM5)
+                   || double.IsInfinity(ctx.AtrM5)
+                   || double.IsNaN(ctx.Adx_M5)
+                   || double.IsInfinity(ctx.Adx_M5)
+                   || double.IsNaN(ctx.Ema21Slope_M5)
+                   || double.IsInfinity(ctx.Ema21Slope_M5)
+                   || double.IsNaN(ctx.Ema21Slope_M15)
+                   || double.IsInfinity(ctx.Ema21Slope_M15);
+        }
+
+        public static bool IsTrendSafetyBlock(EntryContext ctx, TradeDirection dir, out string reason)
+        {
+            if (ctx == null || !ctx.IsReady || ctx.M5 == null)
+            {
+                reason = "CTX_NOT_READY";
+                return true;
+            }
+
+            if (HasDataIntegrityIssue(ctx))
+            {
+                reason = "DATA_INTEGRITY";
+                return true;
+            }
+
+            if (ctx.MarketState?.IsTrend != true)
+            {
+                reason = "NO_TREND_CONTEXT";
+                return true;
+            }
+
+            if (ctx.MarketState?.IsRange == true)
+            {
+                reason = "WRONG_REGIME_RANGE";
+                return true;
+            }
+
+            if (IsExplicitHtfHardBlock(ctx, dir))
+            {
+                reason = "HTF_HARD_BLOCK";
+                return true;
+            }
+
+            reason = null;
+            return false;
+        }
+
+        public static bool IsReversalSafetyBlock(EntryContext ctx, TradeDirection dir, out string reason)
+        {
+            if (ctx == null || !ctx.IsReady || ctx.M5 == null)
+            {
+                reason = "CTX_NOT_READY";
+                return true;
+            }
+
+            if (HasDataIntegrityIssue(ctx))
+            {
+                reason = "DATA_INTEGRITY";
+                return true;
+            }
+
+            if (!ctx.IsRange_M5)
+            {
+                reason = "WRONG_REGIME_NOT_RANGE";
+                return true;
+            }
+
+            if (ctx.Adx_M5 > 22)
+            {
+                reason = $"WRONG_REGIME_TRENDING_ADX({ctx.Adx_M5:F1})";
+                return true;
+            }
+
+            if (IsExplicitHtfHardBlock(ctx, dir))
+            {
+                reason = "HTF_HARD_BLOCK";
+                return true;
+            }
+
+            reason = null;
+            return false;
+        }
+
+        public static void ApplyLogicBiasScore(EntryContext ctx, TradeDirection dir, ref int score, List<string> reasons)
+        {
+            if (ctx == null || dir == TradeDirection.None)
+                return;
+
+            if (ctx.LogicBiasDirection == TradeDirection.None || ctx.LogicBiasConfidence <= 0)
+                return;
+
+            int delta = ResolveBiasDelta(ctx.LogicBiasConfidence);
+            if (ctx.LogicBiasDirection == dir)
+            {
+                score += delta;
+                reasons?.Add($"LOGIC_BIAS_ALIGN(+{delta})");
+            }
+            else
+            {
+                score -= delta;
+                reasons?.Add($"LOGIC_BIAS_AGAINST(-{delta})");
+            }
+        }
+
+        public static bool IsExplicitHtfHardBlock(EntryContext ctx, TradeDirection dir)
+        {
+            if (ctx == null || dir == TradeDirection.None)
+                return false;
+
+            string reason = ctx.MetalHtfReason ?? string.Empty;
+            if (reason.IndexOf("HARD_BLOCK", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                reason.IndexOf("STRONG_BLOCK", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return ctx.MetalHtfAllowedDirection == TradeDirection.None || ctx.MetalHtfAllowedDirection != dir;
+            }
+
+            return false;
+        }
+
+        private static int ResolveBiasDelta(int logicBiasConfidence)
+        {
+            if (logicBiasConfidence >= 75)
+                return 9;
+            if (logicBiasConfidence >= 50)
+                return 7;
+            return 5;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Make `Score` the primary decision driver and keep `MinScoreThreshold` as the sole quality gate so high-scoring setups are not incorrectly blocked by soft checks.
- Restrict `IsValid` to represent HARD safety conditions (bad regime, missing trend context, data integrity, explicit HTF hard block) and prevent pattern-perfection checks from turning `IsValid` false.
- Centralize HTF / logic-bias handling so directional bonuses/penalties affect score only and explicit HTF hard blocks remain strict safety gates.

### Description
- Added a per-candidate `MinScoreThreshold` to `EntryEvaluation` and updated `TradeRouter` to accept candidates only when `IsValid == true && Score >= MinScoreThreshold`, with expanded `[ENTRY DECISION]` logging showing `score`, `threshold`, `valid` and `ACCEPT|REJECT` outcomes (file: `Core/Entry/EntryEvaluation.cs`, `Core/TradeRouter.cs`).
- Introduced `XauEntryDecisionPolicy` to centralize HARD safety checks (`DATA_INTEGRITY`, `WRONG_REGIME_*`, missing trend/range context, explicit HTF hard block) and to apply `LogicBias` score adjustments without invalidating candidates (file: `EntryTypes/METAL/XauEntryDecisionPolicy.cs`).
- Refactored XAU entry types (`XAU_Flag`, `XAU_Pullback`, `XAU_Impulse`, `XAU_Reversal`) to stop using soft pattern failures to set `IsValid=false`; instead these conditions subtract/add score penalties or bonuses, apply logic-bias via the shared policy, and choose direction by higher side score (files: `EntryTypes/METAL/XAU_FlagEntry.cs`, `XAU_PullbackEntry.cs`, `XAU_ImpulseEntry.cs`, `XAU_ReversalEntry.cs`).
- Removed legacy `REJECT BOTH` behavior for XAU by returning the side with the higher score and propagated candidate-level `MinScoreThreshold` into entry evaluation results so router-level gating honors instrument tuning.

### Testing
- Ran `git diff --check` to ensure no whitespace/index issues and the scan produced no blocking warnings (success).
- Performed repository pattern checks with `rg -n "REJECT BOTH|NO_M1_TRIGGER|NO_FLAG_RANGE|PARTIAL_CONFIRMATION|ENTRY DECISION|MinScoreThreshold"` to validate the new decision/logging markers and that soft-fail strings are now handled as score penalties (matches found as expected).
- Attempted to run `dotnet build GeminiV26.sln` but the environment does not have `dotnet` installed, so no full compile was performed (warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc021278a4832888cc2e00c7b9d153)