### PR TITLE
Unify entry gating: global MinScoreThreshold (55) and score-first decision policy

### DIFF
--- a/Core/Entry/EntryDecisionPolicy.cs
+++ b/Core/Entry/EntryDecisionPolicy.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+
+namespace GeminiV26.Core.Entry
+{
+    public static class EntryDecisionPolicy
+    {
+        public const int MinScoreThreshold = 55;
+
+        private static readonly string[] HardSafetyReasonTokens =
+        {
+            "CTX_NOT_READY",
+            "ATR_NOT_READY",
+            "ATR_ZERO",
+            "NO_PROFILE",
+            "NO_FX_PROFILE",
+            "NO_INDEX_PROFILE",
+            "NO_CRYPTO_PROFILE",
+            "NO_TUNING",
+            "NO_FLAG_TUNING",
+            "NO_SESSION",
+            "NO_SESSION_TUNING",
+            "NO_MARKETSTATE",
+            "NO_TREND_STATE",
+            "NO_TREND_DIR",
+            "NO_CLEAR_DIRECTION",
+            "NO_DIRECTION",
+            "FLAG_DIRECTION_INVALID",
+            "SESSION_DISABLED",
+            "SESSION_MATRIX_ALLOW",
+            "SESSION_MATRIX_BREAKOUT_DISABLED",
+            "SESSION_MATRIX_PULLBACK_DISABLED",
+            "SESSION_MATRIX_ATR_AVG_UNAVAILABLE",
+            "SESSION_MATRIX_EMA_DISTANCE_TOO_LOW",
+            "NO_RANGE",
+            "NOT_RANGE",
+            "AMBIGUOUS_SPIKE",
+            "PB_TOO_DEEP_HARD",
+            "PB_TOO_DEEP_EXTREME",
+            "PULLBACK_TOO_DEEP_EXTREME",
+            "DATA",
+            "INVALID_STATE",
+            "INSUFFICIENT",
+            "NO_VALID_SIDE"
+        };
+
+        private static readonly Dictionary<string, int> SoftReasonScores = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["LOW_SCORE"] = 50,
+            ["SCORE_TOO_LOW"] = 50,
+            ["NO_M1"] = 51,
+            ["NO_M1_TRIGGER"] = 51,
+            ["NO_M1_CONFIRM"] = 51,
+            ["NO_M1_CONFIRMATION"] = 51,
+            ["NO_REACTION"] = 50,
+            ["WEAK"] = 50,
+            ["EARLY_PULLBACK"] = 53,
+            ["PULLBACK_TOO_LONG"] = 49,
+            ["PB_TOO_LONG"] = 49,
+            ["PB_TOO_SHALLOW"] = 50,
+            ["PB_TOO_DEEP"] = 49,
+            ["STALE_IMPULSE"] = 50,
+            ["IMPULSE_TOO_OLD"] = 50,
+            ["NO_PULLBACK"] = 50,
+            ["NO_DECELERATION"] = 51,
+            ["NO_CONTINUATION_SIGNAL"] = 50,
+            ["WAIT_BREAKOUT"] = 52,
+            ["NO_FLAG"] = 50,
+            ["NO_FLAG_RANGE"] = 49,
+            ["NO_FLAG_STRUCTURE"] = 50,
+            ["NO_IMPULSE"] = 50,
+            ["NO_BREAK"] = 51,
+            ["NO_BREAKOUT"] = 51,
+            ["TRANSITION"] = 52,
+            ["HTF"] = 52,
+            ["IN_RANGE"] = 0,
+            ["NO_TREND"] = 0,
+            ["RANGE_BUT_ADX_STRONG"] = 0,
+            ["FX_REV_ASIA_BLOCKED"] = 0,
+            ["DISABLED"] = 0
+        };
+
+        public static EntryEvaluation Normalize(EntryEvaluation eval)
+        {
+            if (eval == null)
+                return null;
+
+            eval.Score = Math.Max(0, Math.Min(100, eval.Score));
+
+            bool hardInvalid = IsHardInvalid(eval);
+            if (!hardInvalid && eval.Direction != TradeDirection.None)
+            {
+                if (!eval.IsValid)
+                {
+                    eval.Score = Math.Max(eval.Score, ResolveSoftScore(eval.Reason));
+                    eval.IsValid = true;
+                }
+            }
+            else if (hardInvalid)
+            {
+                eval.IsValid = false;
+            }
+
+            return eval;
+        }
+
+        public static bool IsHardInvalid(EntryEvaluation eval)
+        {
+            if (eval == null)
+                return true;
+
+            if (eval.IsValid)
+                return false;
+
+            return IsHardInvalidReason(eval.Reason) || eval.Direction == TradeDirection.None;
+        }
+
+        public static bool IsHardInvalidReason(string reason)
+        {
+            if (string.IsNullOrWhiteSpace(reason))
+                return false;
+
+            foreach (var token in HardSafetyReasonTokens)
+            {
+                if (reason.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static bool Accepts(EntryEvaluation eval)
+        {
+            return eval != null && eval.IsValid && eval.Score >= MinScoreThreshold;
+        }
+
+        public static int ResolveSoftScore(string reason)
+        {
+            if (string.IsNullOrWhiteSpace(reason))
+                return MinScoreThreshold - 5;
+
+            foreach (var kvp in SoftReasonScores)
+            {
+                if (reason.IndexOf(kvp.Key, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return kvp.Value;
+            }
+
+            return MinScoreThreshold - 5;
+        }
+    }
+}

--- a/Core/Entry/EntryRouter.cs
+++ b/Core/Entry/EntryRouter.cs
@@ -41,7 +41,10 @@ namespace GeminiV26.Core.Entry
                     var eval = entryType.Evaluate(ctx);
 
                     if (eval != null)
+                    {
+                        eval = EntryDecisionPolicy.Normalize(eval);
                         eval.Reason = "[ROUTER] " + (eval.Reason ?? "");
+                    }
 
                     // DEBUG – marad
                     System.Diagnostics.Debug.WriteLine(

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1538,7 +1538,7 @@ namespace GeminiV26.Core
 
             foreach (var entry in symbolSignals)
             {
-                if (entry == null || !entry.IsValid)
+                if (entry == null || entry.Direction == TradeDirection.None || EntryDecisionPolicy.IsHardInvalid(entry))
                     continue;
 
                 int boost = 0;
@@ -1987,7 +1987,7 @@ namespace GeminiV26.Core
 
             foreach (var candidate in symbolSignals)
             {
-                if (candidate == null || !candidate.IsValid || candidate.Direction == TradeDirection.None)
+                if (candidate == null || candidate.Direction == TradeDirection.None || EntryDecisionPolicy.IsHardInvalid(candidate))
                     continue;
 
                 bool hasDirectionalBias = bias.AllowedDirection != TradeDirection.None;

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -34,11 +34,6 @@ namespace GeminiV26.Core
     {
         private readonly Robot _bot;
 
-        // =========================================================
-        // ENTRY QUALITY GATES (NOT SCORE GATES)
-        // =========================================================
-        private const int MIN_ENTRY_SCORE_GLOBAL = 20;
-
         public TradeRouter(Robot bot)
         {
             _bot = bot;
@@ -54,41 +49,47 @@ namespace GeminiV26.Core
             if (signals == null || signals.Count == 0)
                 return null;
 
-            // Candidate logging (raw)
             int nonNullCount = signals.Count(e => e != null);
             int validCount = signals.Count(e => e != null && e.IsValid);
 
-            _bot.Print($"[TR] evals={signals.Count} nonNull={nonNullCount} valid={validCount}");
+            _bot.Print($"[TR] evals={signals.Count} nonNull={nonNullCount} valid={validCount} threshold={EntryDecisionPolicy.MinScoreThreshold}");
             LogCandidates("CAND", signals);
 
-            // RULEBOOK: only IsValid == true is eligible
-            var valid = signals
-                .Where(e => e != null && e.IsValid)
-                // ENTRY QUALITY GATE (Rulebook-safe)
-                .Where(e => e.Score >= MIN_ENTRY_SCORE_GLOBAL)
-                .ToList();
+            EntryEvaluation winner = null;
 
-            var rejectedByScore = signals
-                .Where(e => e != null && e.IsValid && e.Score < MIN_ENTRY_SCORE_GLOBAL)
-                .ToList();
-
-            foreach (var r in rejectedByScore)
+            foreach (var candidate in signals.Where(e => e != null))
             {
-                _bot.Print($"[TR] REJECTED_LOW_SCORE {r.Type} score={r.Score} reason={r.Reason}");
+                string decision;
+
+                if (!candidate.IsValid)
+                {
+                    decision = "REJECT";
+                }
+                else if (candidate.Score < EntryDecisionPolicy.MinScoreThreshold)
+                {
+                    decision = "REJECT";
+                }
+                else
+                {
+                    decision = "ACCEPT";
+
+                    if (winner == null
+                        || candidate.Score > winner.Score
+                        || (candidate.Score == winner.Score
+                            && GetTypePriority(_bot.SymbolName, candidate.Type) < GetTypePriority(_bot.SymbolName, winner.Type)))
+                    {
+                        winner = candidate;
+                    }
+                }
+
+                _bot.Print($"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} score={candidate.Score} threshold={EntryDecisionPolicy.MinScoreThreshold} valid={candidate.IsValid.ToString().ToLowerInvariant()} → {decision}");
             }
 
-            if (valid.Count == 0)
+            if (winner == null)
             {
-                _bot.Print("[TR] NO VALID SETUP AFTER QUALITY GATE");
-                return null; // ⛔ NINCS ENTRY, PONT
+                _bot.Print("[TR] NO CANDIDATE PASSED GLOBAL ENTRY DECISION");
+                return null;
             }
-
-            // RULEBOOK: Score ranks, doesn't gate.
-            // Winner = max score. Tie-breaker keeps deterministic behavior.
-            var winner = valid
-                .OrderByDescending(e => e.Score)
-                .ThenBy(e => GetTypePriority(_bot.SymbolName, e.Type))
-                .First();
 
             _bot.Print($"[TR] WINNER: {winner.Type} dir={winner.Direction} score={winner.Score} valid={winner.IsValid} reason={winner.Reason}");
             return winner;

--- a/EntryTypes/BR_RangeBreakoutEntry.cs
+++ b/EntryTypes/BR_RangeBreakoutEntry.cs
@@ -28,7 +28,7 @@ namespace GeminiV26.EntryTypes
         private const double MaxSlopeForRange = 0.0005;
 
         // --- Szabálykönyv ---
-        private const int MIN_SCORE = 50;
+        private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
@@ -251,7 +251,7 @@ namespace GeminiV26.EntryTypes
                 score = Math.Min(score, MIN_SCORE - 10);
 
             eval.Score = score;
-            eval.IsValid = score >= MIN_SCORE;
+            eval.IsValid = true;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -15,7 +15,7 @@ namespace GeminiV26.EntryTypes.Crypto
         private const double BreakBufferAtr = 0.03;
         private const double MaxDistFromEmaAtr = 1.2;
 
-        private const int MinScore = 16;
+        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
         private const int HtfAgainstPenalty = 8;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
@@ -93,17 +93,11 @@ namespace GeminiV26.EntryTypes.Crypto
             var longEval = EvaluateSide(ctx, TradeDirection.Long, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
             var shortEval = EvaluateSide(ctx, TradeDirection.Short, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
 
-            bool buyValid = longEval.IsValid;
-            bool sellValid = shortEval.IsValid;
-
-            if (!buyValid && !sellValid)
+            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {
-                ctx.Log?.Invoke($"[FLAG][REJECT] No valid direction buyValid={buyValid} sellValid={sellValid}");
+                ctx.Log?.Invoke($"[FLAG][REJECT] No hard-tradable direction long={longEval.Score}/{longEval.IsValid} short={shortEval.Score}/{shortEval.IsValid}");
                 return Invalid(ctx, "FLAG_DIRECTION_INVALID");
             }
-
-            if (buyValid && !sellValid) return longEval;
-            if (!buyValid && sellValid) return shortEval;
 
             return longEval.Score >= shortEval.Score ? longEval : shortEval;
         }
@@ -254,10 +248,10 @@ namespace GeminiV26.EntryTypes.Crypto
             bool shortValid = bearBreak || bearReclaim || (dir == TradeDirection.Short && breakoutSignal);
 
             if (dir == TradeDirection.Long && !longValid)
-                return Invalid(ctx, "NO_BREAK_LONG");
+                return Invalid(ctx, dir, "NO_BREAK_LONG", 51);
 
             if (dir == TradeDirection.Short && !shortValid)
-                return Invalid(ctx, "NO_BREAK_SHORT");
+                return Invalid(ctx, dir, "NO_BREAK_SHORT", 51);
 
             if (dir == TradeDirection.Long && close > open) score += 6;
             if (dir == TradeDirection.Short && close < open) score += 6;
@@ -284,7 +278,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 score = Math.Min(score, MinScore - 10);
 
             if (score < MinScore)
-                return Invalid(ctx, $"LOW_SCORE({score})");
+                return Invalid(ctx, dir, $"LOW_SCORE({score})", score);
 
             return new EntryEvaluation
             {
@@ -303,6 +297,17 @@ namespace GeminiV26.EntryTypes.Crypto
                 Symbol = ctx?.Symbol,
                 Type = EntryType.Crypto_Flag,
                 Direction = TradeDirection.None,
+                IsValid = false,
+                Reason = reason
+            };
+
+        private static EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason, int score) =>
+            new EntryEvaluation
+            {
+                Symbol = ctx?.Symbol,
+                Type = EntryType.Crypto_Flag,
+                Direction = dir,
+                Score = score,
                 IsValid = false,
                 Reason = reason
             };

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -8,7 +8,7 @@ namespace GeminiV26.EntryTypes.Crypto
     public class BTC_PullbackEntry : IEntryType
     {
         public EntryType Type => EntryType.Crypto_Pullback;
-        private const int MIN_SCORE = 34;
+        private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
         private const int BiasAgainstPenalty = 8;
 
         public EntryEvaluation Evaluate(EntryContext ctx)

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -5,7 +5,7 @@ namespace GeminiV26.EntryTypes.Crypto
     public class BTC_RangeBreakoutEntry : IEntryType
     {
         public EntryType Type => EntryType.Crypto_RangeBreakout;
-        private const int MIN_SCORE = 35;
+        private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
         private const int MIN_RANGE_BARS = 15;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
@@ -107,7 +107,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 score = System.Math.Min(score, MIN_SCORE - 10);
 
             eval.Score = score;
-            eval.IsValid = score >= MIN_SCORE;
+            eval.IsValid = true;
 
             if (!eval.IsValid)
                 eval.Reason += $"LowScore({score});";

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -7,7 +7,7 @@ namespace GeminiV26.EntryTypes.FX
     {
         public EntryType Type => EntryType.FX_FlagContinuation;
 
-        private const int MinScore = 55;
+        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
         private const double MinPullbackAtr = 0.15;
         private const double MaxPullbackAtr = 0.60;
 
@@ -19,16 +19,10 @@ namespace GeminiV26.EntryTypes.FX
             var longEval = EvaluateSide(TradeDirection.Long, ctx);
             var shortEval = EvaluateSide(TradeDirection.Short, ctx);
 
-            if (longEval.IsValid && !shortEval.IsValid)
-                return longEval;
+            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
+                return Invalid(ctx, "NO_VALID_SIDE");
 
-            if (!longEval.IsValid && shortEval.IsValid)
-                return shortEval;
-
-            if (longEval.IsValid && shortEval.IsValid)
-                return longEval.Score >= shortEval.Score ? longEval : shortEval;
-
-            return Invalid(ctx, "NO_VALID_SIDE");
+            return longEval.Score >= shortEval.Score ? longEval : shortEval;
         }
 
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)
@@ -49,13 +43,13 @@ namespace GeminiV26.EntryTypes.FX
                 (ctx.IsAtrExpanding_M5 && !ctx.IsRange_M5);
 
             if (!hasValidImpulse)
-                return Invalid(ctx, "NO_IMPULSE");
+                return Invalid(ctx, dir, "NO_IMPULSE", 49);
 
             if (!isValidFlagStructure)
-                return Invalid(ctx, "INVALID_FLAG");
+                return Invalid(ctx, dir, "INVALID_FLAG", 50);
 
             if (pullbackDepthAtr < MinPullbackAtr)
-                return Invalid(ctx, "PB_TOO_SHALLOW");
+                return Invalid(ctx, dir, "PB_TOO_SHALLOW", 50);
 
             // =========================
             // SESSION-AWARE PULLBACK DEPTH
@@ -68,13 +62,13 @@ namespace GeminiV26.EntryTypes.FX
             int score = 48;
 
             if (pullbackDepthAtr > maxPb)
-                return Invalid(ctx, "PB_TOO_DEEP");
+                return Invalid(ctx, dir, "PB_TOO_DEEP", 49);
 
             if (!ctx.IsPullbackDecelerating_M5)
-                return Invalid(ctx, "NO_DECELERATION");
+                return Invalid(ctx, dir, "NO_DECELERATION", 51);
 
             if (!ctx.HasReactionCandle_M5)
-                return Invalid(ctx, "NO_REACTION");
+                return Invalid(ctx, dir, "NO_REACTION", 50);
 
             // ✅ FIX: side-aware M1 confirmation
             bool m1Confirm =
@@ -82,7 +76,7 @@ namespace GeminiV26.EntryTypes.FX
                 (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
 
             if (!m1Confirm)
-                return Invalid(ctx, "NO_M1_CONFIRM");
+                return Invalid(ctx, dir, "NO_M1_CONFIRM", 51);
 
             bool continuationSignal = m1Confirm;
 
@@ -113,7 +107,7 @@ namespace GeminiV26.EntryTypes.FX
                 score = System.Math.Min(score, MinScore - 10);
 
             if (score < MinScore)
-                return Invalid(ctx, "LOW_SCORE");
+                return Invalid(ctx, dir, "LOW_SCORE", score);
 
             return new EntryEvaluation
             {
@@ -131,6 +125,17 @@ namespace GeminiV26.EntryTypes.FX
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
+                IsValid = false,
+                Reason = reason
+            };
+
+        private EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason, int score)
+            => new()
+            {
+                Symbol = ctx?.Symbol,
+                Type = Type,
+                Direction = dir,
+                Score = score,
                 IsValid = false,
                 Reason = reason
             };

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -145,7 +145,7 @@ namespace GeminiV26.EntryTypes.FX
                 double hardFloor = dynamicMinAdx - 6.0;
 
                 bool strongContextForAdx =
-                    score >= (tuning.MinScore + 6) &&
+                    score >= (EntryDecisionPolicy.MinScoreThreshold + 6) &&
                     !ctx.IsRange_M5;
 
                 if (adxNow < hardFloor - 2)
@@ -550,7 +550,7 @@ namespace GeminiV26.EntryTypes.FX
             if (tuning.RequireM1Trigger && !breakout && !hasM1Confirmation)
             {
                 bool strongContext =
-                    score >= tuning.MinScore + 2 &&
+                    score >= EntryDecisionPolicy.MinScoreThreshold + 2 &&
                     !ctx.IsRange_M5;
 
                 if (!strongContext)
@@ -656,7 +656,7 @@ namespace GeminiV26.EntryTypes.FX
 
             bool softM1 =
                 ctx.Session == FxSession.London &&
-                score >= tuning.MinScore + 2 &&
+                score >= EntryDecisionPolicy.MinScoreThreshold + 2 &&
                 !ctx.IsRange_M5;
 
             // EARLY ENTRY RETEST GUARD (use flagDir + hi/lo)
@@ -883,7 +883,7 @@ namespace GeminiV26.EntryTypes.FX
             }
 
             // A+ gate: keep
-            if (!hasTrigger && !ctx.IsAtrExpanding_M5 && score < tuning.MinScore + 2)
+            if (!hasTrigger && !ctx.IsAtrExpanding_M5 && score < EntryDecisionPolicy.MinScoreThreshold + 2)
                 ApplyPenalty(3);
 
             bool continuationSignal = breakoutConfirmed;
@@ -915,7 +915,7 @@ namespace GeminiV26.EntryTypes.FX
             }
 
             // FINAL MIN SCORE
-            int min = tuning.MinScore;
+            int min = EntryDecisionPolicy.MinScoreThreshold;
 
             int sessionStrictness =
                 ctx.Session == FxSession.NewYork ? 2 :

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -14,7 +14,7 @@ namespace GeminiV26.EntryTypes.FX
         private const double MinSlope = 0.00015;
 
         // ===== Patch knobs (FX-safe) =====
-        private const int MinScore = 55;                 // was 45
+        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;                 // was 45
         private const double MinPullbackAtr = 0.15;      // avoid top-tick entries
         private const double MaxPullbackAtr = 1.0;       // already present logic
 
@@ -26,16 +26,10 @@ namespace GeminiV26.EntryTypes.FX
             var longEval = EvaluateSide(TradeDirection.Long, ctx);
             var shortEval = EvaluateSide(TradeDirection.Short, ctx);
 
-            if (longEval.IsValid && !shortEval.IsValid)
-                return longEval;
+            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
+                return Invalid(ctx, "NO_VALID_SIDE");
 
-            if (!longEval.IsValid && shortEval.IsValid)
-                return shortEval;
-
-            if (longEval.IsValid && shortEval.IsValid)
-                return longEval.Score >= shortEval.Score ? longEval : shortEval;
-
-            return Invalid(ctx, "NO_VALID_SIDE");
+            return longEval.Score >= shortEval.Score ? longEval : shortEval;
         }
 
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)
@@ -73,29 +67,29 @@ namespace GeminiV26.EntryTypes.FX
             }
 
             if (dir == TradeDirection.Long && !up)
-                return Invalid(ctx, "NoTrend");
+                return Invalid(ctx, dir, "NoTrend", 0);
 
             if (dir == TradeDirection.Short && !down)
-                return Invalid(ctx, "NoTrend");
+                return Invalid(ctx, dir, "NoTrend", 0);
 
             // =====================================================
             // IMPULSE CONDITIONS (REAL CONTEXT FIELDS)
             // =====================================================
             if (ctx.Adx_M5 < 22)
-                return Invalid(ctx, "WeakTrend");
+                return Invalid(ctx, dir, "WeakTrend", 50);
 
             if (!hasImpulse)
-                return Invalid(ctx, "NoImpulse");
+                return Invalid(ctx, dir, "NoImpulse", 50);
 
             if (pullbackDepthR > MaxPullbackAtr)
-                return Invalid(ctx, "TooDeepPullback");
+                return Invalid(ctx, dir, "TooDeepPullback", 49);
 
             if (pullbackDepthR < MinPullbackAtr)
-                return Invalid(ctx, "NoMeaningfulPullback");
+                return Invalid(ctx, dir, "NoMeaningfulPullback", 50);
 
             // ATR expanding = kifulladó impulse chase FX-en
             if (ctx.IsAtrExpanding_M5)
-                return Invalid(ctx, "VolExpanding");
+                return Invalid(ctx, dir, "VolExpanding", 51);
 
             bool continuationSignal =
                 ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir;
@@ -130,18 +124,13 @@ namespace GeminiV26.EntryTypes.FX
             // =====================================================
             // SCORE → DIRECTION
             // =====================================================
-            TradeDirection finalDir = TradeDirection.None;
-
-            if (score >= MinScore)
-                finalDir = dir;
-
             return new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
-                Direction = finalDir,
+                Direction = dir,
                 Score = score,
-                IsValid = finalDir != TradeDirection.None,
+                IsValid = true,
                 Reason =
                     $"FX_CONT score={score} " +
                     $"pbR={pullbackDepthR:F2} " +
@@ -154,6 +143,17 @@ namespace GeminiV26.EntryTypes.FX
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
+                IsValid = false,
+                Reason = reason
+            };
+
+        private EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason, int score)
+            => new()
+            {
+                Symbol = ctx?.Symbol,
+                Type = Type,
+                Direction = dir,
+                Score = score,
                 IsValid = false,
                 Reason = reason
             };

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -30,16 +30,10 @@ namespace GeminiV26.EntryTypes.FX
             var longEval = EvaluateSide(TradeDirection.Long, ctx, tuning);
             var shortEval = EvaluateSide(TradeDirection.Short, ctx, tuning);
 
-            if (longEval.IsValid && !shortEval.IsValid)
-                return longEval;
+            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
+                return Invalid(ctx, "NO_VALID_SIDE");
 
-            if (!longEval.IsValid && shortEval.IsValid)
-                return shortEval;
-
-            if (longEval.IsValid && shortEval.IsValid)
-                return longEval.Score >= shortEval.Score ? longEval : shortEval;
-
-            return Invalid(ctx, "NO_VALID_SIDE");
+            return longEval.Score >= shortEval.Score ? longEval : shortEval;
         }
 
         private EntryEvaluation EvaluateSide(
@@ -47,7 +41,7 @@ namespace GeminiV26.EntryTypes.FX
             EntryContext ctx,
             FxTuning tuning)
         {
-            int minScore = Math.Max(40, tuning.MinScore - 5);
+            int minScore = EntryDecisionPolicy.MinScoreThreshold;
             int setupScore = 0;
 
             double pullbackDepthR =
@@ -59,19 +53,19 @@ namespace GeminiV26.EntryTypes.FX
                     : (ctx.Ema21Slope_M5 < -MinSlope && ctx.Ema21Slope_M15 < 0);
 
             if (!trendOk)
-                return Invalid(ctx, "NO_TREND_SLOPE");
+                return Invalid(ctx, dir, "NO_TREND_SLOPE", 0);
 
             if (ctx.IsRange_M5)
-                return Invalid(ctx, "IN_RANGE");
+                return Invalid(ctx, dir, "IN_RANGE", 0);
 
             if (pullbackDepthR < MinPullbackAtr)
-                return Invalid(ctx, "PB_TOO_SHALLOW");
+                return Invalid(ctx, dir, "PB_TOO_SHALLOW", 50);
 
             if (pullbackDepthR > tuning.MaxPullbackAtr * 0.45)
-                return Invalid(ctx, "PB_TOO_DEEP");
+                return Invalid(ctx, dir, "PB_TOO_DEEP", 49);
 
             if (pullbackDepthR < 0.35)
-                return Invalid(ctx, "PB_NOT_MATURE");
+                return Invalid(ctx, dir, "PB_NOT_MATURE", 51);
 
             // ✅ FIX: side-aware M1
             bool m1Aligned = ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir;
@@ -81,7 +75,7 @@ namespace GeminiV26.EntryTypes.FX
                 m1Aligned;
 
             if (!continuationSignal)
-                return Invalid(ctx, "NO_CONTINUATION_SIGNAL");
+                return Invalid(ctx, dir, "NO_CONTINUATION_SIGNAL", 50);
 
             bool hasStructure =
                 pullbackDepthR >= MinPullbackAtr;
@@ -126,16 +120,13 @@ namespace GeminiV26.EntryTypes.FX
             if (setupScore <= 0)
                 score = Math.Min(score, minScore - 10);
 
-            TradeDirection finalDir =
-                score >= minScore ? dir : TradeDirection.None;
-
             return new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
-                Direction = finalDir,
+                Direction = dir,
                 Score = score,
-                IsValid = finalDir != TradeDirection.None,
+                IsValid = true,
                 Reason =
                     $"FX_MICRO_CONT score={score} " +
                     $"pbR={pullbackDepthR:F2} " +
@@ -148,6 +139,17 @@ namespace GeminiV26.EntryTypes.FX
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
+                IsValid = false,
+                Reason = reason
+            };
+
+        private EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason, int score)
+            => new()
+            {
+                Symbol = ctx?.Symbol,
+                Type = Type,
+                Direction = dir,
+                Score = score,
                 IsValid = false,
                 Reason = reason
             };

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -197,7 +197,7 @@ namespace GeminiV26.EntryTypes.FX
             // FINAL SCORE GATE
             // -----------------------------------------------------
 
-            int minScore = 68;
+            int minScore = EntryDecisionPolicy.MinScoreThreshold;
 
             score += setupScore;
 

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -15,7 +15,7 @@ namespace GeminiV26.EntryTypes.FX
     {
         public EntryType Type => EntryType.FX_Pullback;
 
-        private const int MIN_SCORE = 35;
+        private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
         private const int ATR_REL_LOOKBACK = 20;
         private const double ATR_REL_EXPANSION_FACTOR = 0.85;
 
@@ -41,16 +41,16 @@ namespace GeminiV26.EntryTypes.FX
             var longEval = EvaluateSide(ctx, fx, matrix, TradeDirection.Long);
             var shortEval = EvaluateSide(ctx, fx, matrix, TradeDirection.Short);
 
-            bool longValid = longEval.IsValid;
-            bool shortValid = shortEval.IsValid;
+            if (ctx.FxHtfAllowedDirection == TradeDirection.Long)
+                longEval.Score += 3;
 
-            // FIX #1:
-            // Ha mindkét oldal invalid, NEM gyártunk fallbackből tradelhető setupot.
-            // Diagnosztikai score marad, de no direction + invalid.
-            if (!longValid && !shortValid)
+            if (ctx.FxHtfAllowedDirection == TradeDirection.Short)
+                shortEval.Score += 3;
+
+            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {
                 int bestScore = Math.Max(longEval.Score, shortEval.Score);
-                ctx?.Log?.Invoke($"[FX_PullbackEntry] BOTH_INVALID long={longEval.Score} short={shortEval.Score}");
+                ctx?.Log?.Invoke($"[FX_PullbackEntry] BOTH_HARD_INVALID long={longEval.Score} short={shortEval.Score}");
 
                 return new EntryEvaluation
                 {
@@ -63,19 +63,7 @@ namespace GeminiV26.EntryTypes.FX
                 };
             }
 
-            if (longValid && shortValid)
-            {
-                if (ctx.FxHtfAllowedDirection == TradeDirection.Long)
-                    longEval.Score += 3;
-
-                if (ctx.FxHtfAllowedDirection == TradeDirection.Short)
-                    shortEval.Score += 3;
-
-                var winner = longEval.Score >= shortEval.Score ? longEval : shortEval;
-                return winner;
-            }
-
-            return longValid ? longEval : shortEval;
+            return longEval.Score >= shortEval.Score ? longEval : shortEval;
         }
 
         private EntryEvaluation EvaluateSide(

--- a/EntryTypes/FX/FX_RangeBreakoutEntry.cs
+++ b/EntryTypes/FX/FX_RangeBreakoutEntry.cs
@@ -13,7 +13,7 @@ namespace GeminiV26.EntryTypes.FX
         private const double MinBreakATR = 0.3;
         private const int MaxFakeoutBars = 1;
         private const double MaxSlopeForRange = 0.0005;
-        private const int MIN_SCORE = 50;
+        private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -10,7 +10,7 @@ namespace GeminiV26.EntryTypes.FX
 
         // FX RESET: egységesített küszöbök – nem session-tiltás, hanem score
         private const int MIN_EVIDENCE = 2;
-        private const int MIN_SCORE = 38;
+        private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
@@ -112,7 +112,7 @@ namespace GeminiV26.EntryTypes.FX
             var eval = BaseEval(ctx);
             eval.Direction = ctx.ReversalDirection;
             eval.Score = score;
-            eval.IsValid = score >= MIN_SCORE;
+            eval.IsValid = true;
 
             eval.Reason =
                 $"FX_REV dir={eval.Direction} score={score} " +

--- a/EntryTypes/FX/FxInstrumentMatrix.cs
+++ b/EntryTypes/FX/FxInstrumentMatrix.cs
@@ -40,7 +40,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 60,               // SZIGORÍTÁS: 55-ről 62-re, kiöljük a bizonytalan trade-eket
+                        MinScore = 55,               // SZIGORÍTÁS: 55-ről 62-re, kiöljük a bizonytalan trade-eket
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.2,        // SZIGORÍTÁS: 1.6-ról 1.2-re, ne engedjük a túlnyúlt zászlókat
                         MaxPullbackAtr = 0.80,       // SZIGORÍTÁS: 0.95-ről 0.80-ra, csak szoros visszateszt
@@ -54,7 +54,7 @@ namespace GeminiV26.Instruments.FX
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 52,               // SZIGORÍTÁS: 55-ről 58-ra
+                        MinScore = 55,               // SZIGORÍTÁS: 55-ről 58-ra
                         FlagBars = 3,                // STABILITÁS: 3-ról 4 bárra emelve, több idő a bázisépítésre
                         MaxFlagAtrMult = 3.2,      // ideiglenesen lazítjuk
                         MaxPullbackAtr = 1.35,     // vissza engedjük
@@ -68,7 +68,7 @@ namespace GeminiV26.Instruments.FX
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 54,               
+                        MinScore = 55,
                         FlagBars = 4,
                         MaxFlagAtrMult = 3.0,
                         MaxPullbackAtr = 1.30,
@@ -116,7 +116,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 60,
+                        MinScore = 55,
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.5,
                         MaxPullbackAtr = 0.08,
@@ -130,7 +130,7 @@ namespace GeminiV26.Instruments.FX
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 58,
+                        MinScore = 55,
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.9,
                         MaxPullbackAtr = 1.15,
@@ -192,7 +192,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 60,               // SZIGORÍTÁS: 55-ről 62-re (csak a betonbiztos setupok)
+                        MinScore = 55,               // SZIGORÍTÁS: 55-ről 62-re (csak a betonbiztos setupok)
                         FlagBars = 3,                // STABILITÁS: 2-ről 3 bárra
                         MaxFlagAtrMult = 1.5,        // SZIGORÍTÁS: 1.4-ről 1.1-re (csak szoros zászlók)
                         MaxPullbackAtr = 0.95,       // SZIGORÍTÁS: 0.95-ről 0.70-re (ne engedjünk mély visszatesztet)
@@ -208,7 +208,7 @@ namespace GeminiV26.Instruments.FX
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 57,               // SZIGORÍTÁS: 55-ről 58-ra
+                        MinScore = 55,               // SZIGORÍTÁS: 55-ről 58-ra
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.7,        // SZIGORÍTÁS: 2.0-ról 1.6-ra
                         MaxPullbackAtr = 1.05,       // SZIGORÍTÁS: 1.30-ról 0.90-re
@@ -222,7 +222,7 @@ namespace GeminiV26.Instruments.FX
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 59,
+                        MinScore = 55,
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.65,
                         MaxPullbackAtr = 1.05,
@@ -272,7 +272,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 60,               // SZIGORÍTÁS: 55 helyett 60, csak a legjobb setupok menjenek át
+                        MinScore = 55,               // SZIGORÍTÁS: 55 helyett 60, csak a legjobb setupok menjenek át
                         FlagBars = 3,                // STABILITÁS: 2 helyett 3 bár, hogy a zajt jobban szűrjük
                         MaxFlagAtrMult = 1.2,        // SZIGORÍTÁS: Kisebb zászló kiterjedés
                         MaxPullbackAtr = 1.20,       // LAZÍTÁS: 1.00-ról 1.20-ra - kell a tér a GBPJPY zajának
@@ -288,7 +288,7 @@ namespace GeminiV26.Instruments.FX
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 58,
+                        MinScore = 55,
                         FlagBars = 3,
                         MaxFlagAtrMult = 2.1,
                         MaxPullbackAtr = 1.40,
@@ -302,7 +302,7 @@ namespace GeminiV26.Instruments.FX
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 60,
+                        MinScore = 55,
                         FlagBars = 2,
                         MaxFlagAtrMult = 1.2,
                         MaxPullbackAtr = 0.95,
@@ -350,7 +350,7 @@ namespace GeminiV26.Instruments.FX
                 asia: new FxFlagSessionTuning
                 {
                     BaseScore = 52,
-                    MinScore = 60,               // SZIGORÍTÁS: 55-ről 60-ra (csak a legtisztább EMA21 bounce mehet)
+                    MinScore = 55,               // SZIGORÍTÁS: 55-ről 60-ra (csak a legtisztább EMA21 bounce mehet)
                     FlagBars = 3,                // STABILITÁS: Több megerősítő gyertya kell
                     MaxFlagAtrMult = 1.2,        // SZIGORÍTÁS: 1.3-ról 1.2-re (kisebb zászló = kisebb kockázat)
                     MaxPullbackAtr = 0.80,       // SZIGORÍTÁS: 0.85-ről 0.80-ra
@@ -366,7 +366,7 @@ namespace GeminiV26.Instruments.FX
                 london: new FxFlagSessionTuning
                 {
                     BaseScore = 54,
-                    MinScore = 60,               // SZIGORÍTÁS: Londonban is magasabb küszöb
+                    MinScore = 55,               // SZIGORÍTÁS: Londonban is magasabb küszöb
                     FlagBars = 3,
                     MaxFlagAtrMult = 1.8,        // SZIGORÍTÁS: 2.0-ról 1.8-ra (kevesebb zajt engedünk)
                     MaxPullbackAtr = 1.10,       // SZIGORÍTÁS: 1.30-ról 1.10-re (ne engedjünk túl mély korrekciót)
@@ -381,7 +381,7 @@ namespace GeminiV26.Instruments.FX
                 {
                     // New York marad a -20-as bias miatt eleve tiltáshoz közeli állapotban
                     BaseScore = 54,
-                    MinScore = 60,
+                    MinScore = 55,
                     FlagBars = 2,
                     MaxFlagAtrMult = 1.1,
                     MaxPullbackAtr = 0.75,
@@ -430,7 +430,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 60,               // SZIGORÍTÁS: 55-ről 60-ra
+                        MinScore = 55,               // SZIGORÍTÁS: 55-ről 60-ra
                         FlagBars = 3,                // STABILITÁS: 2 helyett 3 bár
                         MaxFlagAtrMult = 1.1,        // SZIGORÍTÁS: 1.4-ről 1.1-re (ne vegyünk túlnyúlt mozgást)
                         MaxPullbackAtr = 0.65,       // SZIGORÍTÁS: 0.75-ről 0.65-re
@@ -447,7 +447,7 @@ namespace GeminiV26.Instruments.FX
                     {
                         // London marad szigorú, de itt is bekapcsoljuk a biztonsági fékeket
                         BaseScore = 54,
-                        MinScore = 60,
+                        MinScore = 55,
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.2,
                         MaxPullbackAtr = 0.70,
@@ -463,7 +463,7 @@ namespace GeminiV26.Instruments.FX
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 60,               // NY-ban szinte elérhetetlen szigor
+                        MinScore = 55,               // NY-ban szinte elérhetetlen szigor
                         FlagBars = 1,
                         MaxFlagAtrMult = 0.9,
                         MaxPullbackAtr = 0.60,
@@ -513,7 +513,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 60
+                        MinScore = 55,               // SZIGORÍTÁS: 55 -> 60
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.1,        // SZIGORÍTÁS: 1.7 -> 1.1 (csak kompakt alakzatok)
                         MaxPullbackAtr = 0.70,       // SZIGORÍTÁS: 1.05 -> 0.70
@@ -529,7 +529,7 @@ namespace GeminiV26.Instruments.FX
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 60,
+                        MinScore = 55,
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.3,        // SZIGORÍTÁS: 1.8 -> 1.3
                         MaxPullbackAtr = 0.85,       // SZIGORÍTÁS: 1.35 -> 0.85
@@ -543,7 +543,7 @@ namespace GeminiV26.Instruments.FX
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 60,
+                        MinScore = 55,
                         FlagBars = 2,
                         MaxFlagAtrMult = 0.9,
                         MaxPullbackAtr = 0.85,
@@ -591,7 +591,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 62 (legyen nagyon válogatós)
+                        MinScore = 55,               // SZIGORÍTÁS: 55 -> 62 (legyen nagyon válogatós)
                         FlagBars = 3,                // STABILITÁS: 2 -> 4 bár (építsen komoly bázist)
                         MaxFlagAtrMult = 1.2,        // SZIGORÍTÁS: 1.8 -> 1.0 (csak kompakt, sűrű bázis)
                         MaxPullbackAtr = 0.75,       // SZIGORÍTÁS: 1.10 -> 0.60 (ne engedjünk mély visszatesztet)
@@ -607,7 +607,7 @@ namespace GeminiV26.Instruments.FX
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 60,               // Londonban szinte csak "véletlenül" lépjen be
+                        MinScore = 55,               // Londonban szinte csak "véletlenül" lépjen be
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.3,
                         MaxPullbackAtr = 0.85,
@@ -621,7 +621,7 @@ namespace GeminiV26.Instruments.FX
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 60,               // Gyakorlatilag kikapcsolva
+                        MinScore = 55,               // Gyakorlatilag kikapcsolva
                         FlagBars = 2,
                         MaxFlagAtrMult = 0.7,
                         MaxPullbackAtr = 0.50,
@@ -669,7 +669,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 60
+                        MinScore = 55,               // SZIGORÍTÁS: 55 -> 60
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.2,        // SZIGORÍTÁS: 1.4 -> 1.2
                         MaxPullbackAtr = 0.75,       // SZIGORÍTÁS: 0.85 -> 0.75
@@ -685,7 +685,7 @@ namespace GeminiV26.Instruments.FX
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 58
+                        MinScore = 55,               // SZIGORÍTÁS: 55 -> 58
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.6,        // SZIGORÍTÁS: 2.0 -> 1.6 (megfogja a csúcson vételt)
                         MaxPullbackAtr = 1.00,       // SZIGORÍTÁS: 1.30 -> 1.00
@@ -701,7 +701,7 @@ namespace GeminiV26.Instruments.FX
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 58,               // NY-ban maradhat a 55, mert a +5 bónusszal együtt is szűrve lesz
+                        MinScore = 55,               // NY-ban maradhat a 55, mert a +5 bónusszal együtt is szűrve lesz
                         FlagBars = 3,                // STABILITÁS: 2 -> 3 bár
                         MaxFlagAtrMult = 1.3,
                         MaxPullbackAtr = 0.90,
@@ -751,7 +751,7 @@ namespace GeminiV26.Instruments.FX
                     asia: new FxFlagSessionTuning
                     {
                         BaseScore = 52,
-                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 65 (Csak extrém jó jel mehet át)
+                        MinScore = 55,               // SZIGORÍTÁS: 55 -> 65 (Csak extrém jó jel mehet át)
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.0,        // SZIGORÍTÁS: 1.4 -> 1.0 (Csak nagyon szűk bázis)
                         MaxPullbackAtr = 0.60,       // SZIGORÍTÁS: 0.95 -> 0.60
@@ -767,7 +767,7 @@ namespace GeminiV26.Instruments.FX
                     london: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 60,               // SZIGORÍTÁS: 55 -> 58
+                        MinScore = 55,               // SZIGORÍTÁS: 55 -> 58
                         FlagBars = 3,
                         MaxFlagAtrMult = 1.4,        // SZIGORÍTÁS: 2.0 -> 1.4 (Kompaktabb setupok)
                         MaxPullbackAtr = 0.85,       // SZIGORÍTÁS: 1.30 -> 0.85
@@ -783,7 +783,7 @@ namespace GeminiV26.Instruments.FX
                     ny: new FxFlagSessionTuning
                     {
                         BaseScore = 54,
-                        MinScore = 60,
+                        MinScore = 55,
                         FlagBars = 2,
                         MaxFlagAtrMult = 1.1,
                         MaxPullbackAtr = 0.75,       // SZIGORÍTÁS: 0.90 -> 0.75

--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -11,7 +11,7 @@ namespace GeminiV26.EntryTypes.INDEX
         public EntryType Type => EntryType.Index_Breakout;
 
         private const int BaseScore = 50;
-        private const int MinScore = 60;
+        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -25,7 +25,7 @@ namespace GeminiV26.EntryTypes.INDEX
         private const double MaxSameDirSlopeAtr = 0.20;
 
         private const int BaseScore = 84;
-        private const int MinScore = 72;
+        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
 
         private static readonly Dictionary<string, int> _traceInvocationCountByBarDir = new Dictionary<string, int>();
 
@@ -102,20 +102,13 @@ namespace GeminiV26.EntryTypes.INDEX
             longEval.Score += (int)Math.Round(matrix.EntryScoreModifier);
             shortEval.Score += (int)Math.Round(matrix.EntryScoreModifier);
 
-            bool buyValid = longEval.IsValid;
-            bool sellValid = shortEval.IsValid;
-
-            if (!buyValid && !sellValid)
+            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {
-                ctx.Log?.Invoke($"[FLAG][REJECT] No valid direction buyValid={buyValid} sellValid={sellValid}");
+                ctx.Log?.Invoke($"[FLAG][REJECT] No hard-tradable direction long={longEval.Score}/{longEval.IsValid} short={shortEval.Score}/{shortEval.IsValid}");
                 return Reject(ctx, "FLAG_DIRECTION_INVALID", Math.Max(longEval.Score, shortEval.Score), TradeDirection.None);
             }
 
-            if (buyValid && sellValid)
-                return longEval.Score >= shortEval.Score ? longEval : shortEval;
-
-            if (buyValid) return longEval;
-            return shortEval;
+            return longEval.Score >= shortEval.Score ? longEval : shortEval;
         }
 
         private EntryEvaluation EvaluateDir(

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -10,7 +10,7 @@ namespace GeminiV26.EntryTypes.INDEX
         public EntryType Type => EntryType.Index_Pullback;
 
         private const int BaseScore = 60;
-        private const int MinScore = 55;
+        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
 
         private const double MaxPullbackDepthAtr = 0.9;
         private const int MaxPullbackBars = 5;
@@ -19,28 +19,22 @@ namespace GeminiV26.EntryTypes.INDEX
         {
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowPullback)
-                return null;
+                return Reject(ctx, TradeDirection.None, 0, "SESSION_MATRIX_ALLOWPULLBACK_DISABLED");
 
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 10)
-                return null;
+                return Reject(ctx, TradeDirection.None, 0, "CTX_NOT_READY");
 
             var p = IndexInstrumentMatrix.Get(ctx.Symbol);
             if (p == null)
-                return null;
+                return Reject(ctx, TradeDirection.None, 0, "NO_INDEX_PROFILE");
 
             var longEval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
             var shortEval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
 
-            bool longValid = longEval != null && longEval.IsValid;
-            bool shortValid = shortEval != null && shortEval.IsValid;
+            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
+                return Reject(ctx, TradeDirection.None, Math.Max(longEval?.Score ?? 0, shortEval?.Score ?? 0), "IDX_PULLBACK_NO_SIDE");
 
-            if (!longValid && !shortValid)
-                return null;
-
-            if (longValid && shortValid)
-                return longEval.Score >= shortEval.Score ? longEval : shortEval;
-
-            return longValid ? longEval : shortEval;
+            return longEval.Score >= shortEval.Score ? longEval : shortEval;
         }
 
         private EntryEvaluation EvaluateSide(
@@ -193,7 +187,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 if (!compressionDetected)
                 {
                     ctx.Log?.Invoke($"[PB] dir={dir} rejected: deep pullback without compression");
-                    return null;
+                    return Reject(ctx, dir, score, "DEEP_PULLBACK_NO_COMPRESSION");
                 }
 
                 TradeDirection impulseDirection =
@@ -206,7 +200,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 if (!breakoutAligned)
                 {
                     ctx.Log?.Invoke($"[PB] dir={dir} rejected: breakout against impulse");
-                    return null;
+                    return Reject(ctx, dir, score, "BREAKOUT_AGAINST_IMPULSE");
                 }
 
                 ctx.Log?.Invoke($"[PB] dir={dir} DeepPullbackContinuation accepted");
@@ -214,13 +208,13 @@ namespace GeminiV26.EntryTypes.INDEX
 
             if (pullbackDepthAtr <= 0 ||
                 pullbackDepthAtr > maxPullbackDepthAtr)
-                return null;
+                return Reject(ctx, dir, score, "PULLBACK_DEPTH_INVALID");
 
             if (ctx.PullbackBars_M5 > maxPullbackBars)
-                return null;
+                return Reject(ctx, dir, score, "PULLBACK_BARS_TOO_LONG");
 
             if (!ctx.HasReactionCandle_M5)
-                return null;
+                return Reject(ctx, dir, score, "NO_REACTION");
 
             if (!lastBarInDir)
                 score -= 10;
@@ -282,7 +276,7 @@ namespace GeminiV26.EntryTypes.INDEX
                     $"pbBars={ctx.PullbackBars_M5} | fatigue={trendFatigue} | " +
                     $"ADX={ctx.Adx_M5:F1}"
                 );
-                return null;
+                return Reject(ctx, dir, score, "LOW_SCORE");
             }
 
             Console.WriteLine(
@@ -301,6 +295,20 @@ namespace GeminiV26.EntryTypes.INDEX
                 Reason =
                     $"IDX_PULLBACK_4.1 dir={dir} score={score} " +
                     $"pbATR={pullbackDepthAtr:F2} pbBars={ctx.PullbackBars_M5} fatigue={trendFatigue}"
+            };
+        }
+
+
+        private static EntryEvaluation Reject(EntryContext ctx, TradeDirection dir, int score, string reason)
+        {
+            return new EntryEvaluation
+            {
+                Symbol = ctx?.Symbol,
+                Type = EntryType.Index_Pullback,
+                Direction = dir,
+                Score = Math.Max(0, score),
+                IsValid = false,
+                Reason = reason
             };
         }
 

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -81,11 +81,8 @@ namespace GeminiV26.EntryTypes.METAL
             var buy = EvaluateSide(TradeDirection.Long, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
             var sell = EvaluateSide(TradeDirection.Short, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
 
-            if (!buy.IsValid && !sell.IsValid)
+            if (EntryDecisionPolicy.IsHardInvalid(buy) && EntryDecisionPolicy.IsHardInvalid(sell))
                 return Reject(ctx, tag, session, tuning, buy, sell);
-
-            if (buy.IsValid && !sell.IsValid) return buy;
-            if (!buy.IsValid && sell.IsValid) return sell;
 
             int diff = buy.Score - sell.Score;
 
@@ -113,7 +110,7 @@ namespace GeminiV26.EntryTypes.METAL
             int index)
         {
             int score = (int)tuning.BaseScore;
-            int minScore = (int)tuning.MinScore;
+            int minScore = EntryDecisionPolicy.MinScoreThreshold;
             int setupScore = 0;
 
             var reasons = new List<string>();

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -20,7 +20,7 @@ namespace GeminiV26.EntryTypes.METAL
         public EntryType Type => EntryType.XAU_Impulse;
 
         private const double SlopeEps = 0.0;
-        private const int MinScore = 65;
+        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
         private const double MinAdx = 18.0;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
@@ -94,7 +94,7 @@ namespace GeminiV26.EntryTypes.METAL
             // 6️⃣ M1 TRIGGER (Continuation confirmation)
             // =====================================================
             if (!ctx.M1TriggerInTrendDirection)
-                return Reject(ctx, "NO_M1_TRIGGER");
+                score -= 8;
 
             score += 5;
 
@@ -143,8 +143,6 @@ namespace GeminiV26.EntryTypes.METAL
             if (setupScore <= 0)
                 score = System.Math.Min(score, MinScore - 10);
 
-            if (score < MinScore)
-                return Reject(ctx, $"LOW_SCORE({score})");
 
             string note =
                 $"[XAU_IMPULSE_CONT] {ctx.Symbol} dir={dir} " +

--- a/EntryTypes/METAL/XAU_InstrumentMatrix.cs
+++ b/EntryTypes/METAL/XAU_InstrumentMatrix.cs
@@ -13,7 +13,7 @@ namespace GeminiV26.EntryTypes.METAL
             {
                 ["XAUUSD"] = Build(
                     symbol: "XAUUSD",
-                    
+
                     // ===== instrument karakter =====
                     pullbackStyle: FxPullbackStyle.EMA50,
                     minAtrPips: 10.0,
@@ -51,7 +51,7 @@ namespace GeminiV26.EntryTypes.METAL
                         FlagQualityBonus = 0,
                         RequireM1Trigger = false,
                         AtrExpansionHardBlock = false,
-                        MinScore = 66              // marad magas
+                        MinScore = 55              // marad magas
                     },
                     london: new FxFlagSessionTuning
                     {
@@ -65,7 +65,7 @@ namespace GeminiV26.EntryTypes.METAL
                         FlagQualityBonus = 4,
                         RequireM1Trigger = false,
                         AtrExpansionHardBlock = false,
-                        MinScore = 62             
+                        MinScore = 55
                     },
                     ny: new FxFlagSessionTuning
                     {
@@ -79,7 +79,7 @@ namespace GeminiV26.EntryTypes.METAL
                         FlagQualityBonus = 6,
                         RequireM1Trigger = true,
                         AtrExpansionHardBlock = true,
-                        MinScore = 60              // marad
+                        MinScore = 55              // marad
                     }
                 ),
 
@@ -133,7 +133,7 @@ namespace GeminiV26.EntryTypes.METAL
                         FlagQualityBonus = 3,
                         RequireM1Trigger = false,
                         AtrExpansionHardBlock = false,
-                        MinScore = 65
+                        MinScore = 55
                     },
                     ny: new FxFlagSessionTuning
                     {
@@ -147,7 +147,7 @@ namespace GeminiV26.EntryTypes.METAL
                         FlagQualityBonus = 3,
                         RequireM1Trigger = true,
                         AtrExpansionHardBlock = true,
-                        MinScore = 58
+                        MinScore = 55
                     }
                 )
             };

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -30,11 +30,8 @@ namespace GeminiV26.EntryTypes.METAL
             var buy = EvaluateSide(TradeDirection.Long, ctx, matrix);
             var sell = EvaluateSide(TradeDirection.Short, ctx, matrix);
 
-            if (!buy.IsValid && !sell.IsValid)
+            if (EntryDecisionPolicy.IsHardInvalid(buy) && EntryDecisionPolicy.IsHardInvalid(sell))
                 return RejectBoth(ctx, buy, sell);
-
-            if (buy.IsValid && !sell.IsValid) return buy;
-            if (!buy.IsValid && sell.IsValid) return sell;
 
             int diff = buy.Score - sell.Score;
 
@@ -57,7 +54,7 @@ namespace GeminiV26.EntryTypes.METAL
             SessionMatrixConfig matrix)
         {
             int score = 60;
-            int minScore = 64;
+            int minScore = EntryDecisionPolicy.MinScoreThreshold;
             int setupScore = 0;
 
             var reasons = new List<string>();

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -9,7 +9,7 @@ namespace GeminiV26.EntryTypes.METAL
         public EntryType Type => EntryType.XAU_Reversal;
 
         private const int MinEvidence = 4;
-        private const int MinScore = 50;
+        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
         private const double SlopeEps = 0.0;
 
         private const int NoM1Penalty = 12;
@@ -52,10 +52,12 @@ namespace GeminiV26.EntryTypes.METAL
             // 3️⃣ REVERSAL EVIDENCE
             // =====================================================
             int evidence = ctx.ReversalEvidenceScore;
-            if (evidence < MinEvidence)
-                return RejectDecision(ctx, dir, 0, $"WEAK_EVIDENCE({evidence})", reasons);
-
             int score = evidence * 12 + 20;
+            if (evidence < MinEvidence)
+            {
+                score -= 12;
+                reasons.Add($"WEAK_EVIDENCE({evidence})");
+            }
             reasons.Add($"Evidence={evidence}");
 
             // =====================================================
@@ -63,10 +65,15 @@ namespace GeminiV26.EntryTypes.METAL
             // =====================================================
             // XAU reversalhez kötelező az M1 trigger
             if (!ctx.M1ReversalTrigger)
-                return RejectDecision(ctx, dir, score, "NO_M1_REV", reasons);
-
-            score += 15;
-            reasons.Add("+M1_REV(15)");
+            {
+                score -= NoM1Penalty;
+                reasons.Add("NO_M1_REV");
+            }
+            else
+            {
+                score += 15;
+                reasons.Add("+M1_REV(15)");
+            }
 
             bool hasFlag =
                 dir == TradeDirection.Long
@@ -111,9 +118,6 @@ namespace GeminiV26.EntryTypes.METAL
             // =====================================================
             // 5️⃣ MIN SCORE GATE
             // =====================================================
-            if (score < MinScore)
-                return RejectDecision(ctx, dir, score, $"LOW_SCORE({score})", reasons);
-
             // =====================================================
             // ACCEPT
             // =====================================================

--- a/EntryTypes/TC_FlagEntry.cs
+++ b/EntryTypes/TC_FlagEntry.cs
@@ -23,7 +23,7 @@ namespace GeminiV26.EntryTypes
         // --- Paraméterek ---
         private const double MinSlope = 0.0005;
         private const int ImpulseLookback = 5;
-        private const int MIN_SCORE = 50;
+        private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
@@ -218,7 +218,7 @@ namespace GeminiV26.EntryTypes
                 score = Math.Min(score, MIN_SCORE - 10);
 
             eval.Score = score;
-            eval.IsValid = score >= MIN_SCORE;
+            eval.IsValid = true;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";

--- a/EntryTypes/TC_PullbackEntry.cs
+++ b/EntryTypes/TC_PullbackEntry.cs
@@ -18,7 +18,7 @@ namespace GeminiV26.EntryTypes
 
         private const double MinSlope = 0.0005;
         private const double MaxPullbackATR = 1.2;
-        private const int MIN_SCORE = 50;
+        private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
         public double Atr_M5 { get; set; }
 
         // =========================================================
@@ -404,7 +404,7 @@ namespace GeminiV26.EntryTypes
                 score = Math.Min(score, MIN_SCORE - 10);
 
             eval.Score = score;
-            eval.IsValid = score >= MIN_SCORE;
+            eval.IsValid = true;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";

--- a/EntryTypes/TR_ReversalEntry.cs
+++ b/EntryTypes/TR_ReversalEntry.cs
@@ -25,7 +25,7 @@ namespace GeminiV26.EntryTypes
         public EntryType Type => EntryType.TR_Reversal;
 
         // --- Rulebook 1.0 ---
-        private const int MIN_SCORE = 50;
+        private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
 
         // --- Quality gates ---
         private const int MIN_EVIDENCE = 2;
@@ -200,7 +200,7 @@ namespace GeminiV26.EntryTypes
             // 5️⃣ MIN SCORE (EntryType szinten)
             // =========================================================
             eval.Score = score;
-            eval.IsValid = score >= MIN_SCORE;
+            eval.IsValid = true;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";


### PR DESCRIPTION
### Motivation
- Make Score the single, authoritative decision driver and reduce IsValid to a hard-safety flag so routing and comparisons are globally consistent. 
- Remove per-entry and per-instrument thresholds and dynamic thresholds that prevented high-score setups from being routable. 
- Ensure HTF transitions are handled as score penalties (soft) while keeping explicit HTF hard blocks as the only IsValid=false cases.

### Description
- Add a shared `EntryDecisionPolicy` with `MinScoreThreshold = 55`, hard-safety token classification, soft->score normalization, and a single `Accepts` predicate used across the system (`Core/Entry/EntryDecisionPolicy.cs`).
- Normalize each entry evaluation in the `EntryRouter` by calling `EntryDecisionPolicy.Normalize(eval)` immediately after creation and preserve instrument routing behavior (no router-level filtering by IsValid) (`Core/Entry/EntryRouter.cs`).
- Replace the router selection logic in `TradeRouter` so every candidate is logged with the new `[ENTRY DECISION]` line and the final acceptance rule is strictly `IsValid == true && Score >= EntryDecisionPolicy.MinScoreThreshold`, with the winner chosen as the highest-scoring accepted candidate (tie-break: deterministic type priority) (`Core/TradeRouter.cs`).
- Convert per-entry MIN_SCORE/MinScore constants to reference the shared threshold where appropriate and adjust entry modules to stop hard-failing on soft quality checks (move soft failures into score penalties and keep IsValid=true for score-based decisions), while preserving hard-safety returns (missing data/context, session/profile hard-blocks) in representative FX, METAL, CRYPTO, INDEX and legacy entries (`EntryTypes/*`, many entries updated). 
- Update HTF/transition paths to apply score-only penalties and to skip hard-invalid or directionless candidates when applying boosts/penalties in `TradeCore` (`Core/TradeCore.cs`).
- Normalize instrument matrix MinScore fields (FX/XAU session matrices) to the global 55 so tuning data no longer contains divergent per-session minimum gates (`EntryTypes/FX/FxInstrumentMatrix.cs`, `EntryTypes/METAL/XAU_InstrumentMatrix.cs`).
- Add and standardize logging to surface decision inputs and outcomes, e.g. `[ENTRY DECISION] symbol=... type=... score=... threshold=55 valid=true/false → ACCEPT/REJECT` and preserve existing diagnostic logs.

### Testing
- Ran repository static checks, including `git diff --check`, and the changes produced no trailing-whitespace or diff-check errors (succeeded). 
- Ran codebase-wide pattern searches to verify the new global threshold and normalization hook (searches for `MinScoreThreshold`, `EntryDecisionPolicy.Normalize`, and `[ENTRY DECISION]`) and found the updated references across entry modules and routers (succeeded).
- Performed targeted text transformations and sanity scans to confirm the router now performs the single global gate and entries reference the shared threshold (succeeded). 
- A full C# build could not be executed in this environment because no solution/project compiler runtime was available, so a compile/run validation was not performed (not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc054378cc8328ab1c8a858f2d199e)