### PR TITLE
Add trigger-gated armed entry flow

### DIFF
--- a/Core/Entry/ArmedSetup.cs
+++ b/Core/Entry/ArmedSetup.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace GeminiV26.Core.Entry
+{
+    public sealed class ArmedSetup
+    {
+        public string Symbol { get; set; } = string.Empty;
+        public TradeDirection Direction { get; set; } = TradeDirection.None;
+        public double Score { get; set; }
+        public DateTime DetectedAt { get; set; }
+        public int BarsSince { get; set; }
+
+        public EntryType EntryType { get; set; }
+        public string Reason { get; set; } = string.Empty;
+    }
+}

--- a/Core/Entry/EntryDecisionPolicy.cs
+++ b/Core/Entry/EntryDecisionPolicy.cs
@@ -87,6 +87,12 @@ namespace GeminiV26.Core.Entry
 
             eval.Score = Math.Max(0, Math.Min(100, eval.Score));
 
+            if (!string.IsNullOrWhiteSpace(eval.Reason) &&
+                eval.Reason.IndexOf("WAIT_BREAKOUT", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                eval.TriggerConfirmed = false;
+            }
+
             bool hardInvalid = IsHardInvalid(eval);
             if (!hardInvalid && eval.Direction != TradeDirection.None)
             {
@@ -100,6 +106,8 @@ namespace GeminiV26.Core.Entry
             {
                 eval.IsValid = false;
             }
+
+            eval.State = ResolveState(eval);
 
             return eval;
         }
@@ -146,6 +154,23 @@ namespace GeminiV26.Core.Entry
             }
 
             return MinScoreThreshold - 5;
+        }
+
+        private static EntryState ResolveState(EntryEvaluation eval)
+        {
+            if (eval == null)
+                return EntryState.NONE;
+
+            if (eval.TriggerConfirmed && eval.Score >= MinScoreThreshold && eval.Direction != TradeDirection.None)
+                return EntryState.TRIGGERED;
+
+            if (eval.Score >= MinScoreThreshold && eval.Direction != TradeDirection.None && !IsHardInvalid(eval))
+                return EntryState.ARMED;
+
+            if (eval.Score > 0 && eval.Direction != TradeDirection.None && !IsHardInvalid(eval))
+                return EntryState.SETUP_DETECTED;
+
+            return EntryState.NONE;
         }
     }
 }

--- a/Core/Entry/EntryEvaluation.cs
+++ b/Core/Entry/EntryEvaluation.cs
@@ -15,5 +15,9 @@
         public int LogicConfidence;
 
         public string Reason;
+
+        public EntryState State = EntryState.NONE;
+
+        public bool TriggerConfirmed;
     }
 }

--- a/Core/Entry/EntryState.cs
+++ b/Core/Entry/EntryState.cs
@@ -1,0 +1,10 @@
+namespace GeminiV26.Core.Entry
+{
+    public enum EntryState
+    {
+        NONE,
+        SETUP_DETECTED,
+        ARMED,
+        TRIGGERED
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -81,6 +81,7 @@ namespace GeminiV26.Core
         private readonly LogWriter _logWriter;
         private readonly ITradeLogger _logger;
         private readonly Dictionary<long, PositionContext> _positionContexts = new();
+        private readonly Dictionary<string, ArmedSetup> _armedSetups = new();
         private readonly TradeMetaStore _tradeMetaStore = new();
         private readonly TradeStatsTracker _statsTracker;
         private readonly string _symbolCanonical;
@@ -1127,6 +1128,8 @@ namespace GeminiV26.Core
             ApplyHtfBiasScoreOnly(symbolSignals, bias, "INDEX");
         }
 
+                UpdateExecutionStateMachine(_ctx, symbolSignals);
+
                 // =====================================================
                 // ROUTER
                 // =====================================================
@@ -1229,6 +1232,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _xauExecutor?.ExecuteEntry(selected, _ctx);
             }
             else if (IsNasSymbol(_bot.SymbolName))
@@ -1245,12 +1249,14 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _nasExecutor?.ExecuteEntry(selected, _ctx);
             }
             else if (IsUs30(_bot.SymbolName))
             {
                 if (!_us30SessionGate.AllowEntry(gateDir)) return;
                 if (!_us30ImpulseGate.AllowEntry(gateDir)) return;
+                LogEntryExecuted(selected);
                 _us30Executor.ExecuteEntry(selected, _ctx);
             }
             else if (IsSymbol("GER40"))
@@ -1267,6 +1273,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _ger40Executor?.ExecuteEntry(selected, _ctx);
             }
 
@@ -1284,6 +1291,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _eurUsdExecutor?.ExecuteEntry(selected, _ctx);
               
             }
@@ -1301,6 +1309,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _usdJpyExecutor?.ExecuteEntry(selected, _ctx);
             }
             else if (IsSymbol("GBPUSD"))
@@ -1317,6 +1326,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _gbpUsdExecutor?.ExecuteEntry(selected, _ctx);
             }
 
@@ -1334,6 +1344,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _audUsdExecutor.ExecuteEntry(selected, _ctx);
             }
 
@@ -1351,6 +1362,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _audNzdExecutor.ExecuteEntry(selected, _ctx);
             }
 
@@ -1368,6 +1380,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _eurJpyExecutor.ExecuteEntry(selected, _ctx);
             }
 
@@ -1385,6 +1398,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _gbpJpyExecutor.ExecuteEntry(selected, _ctx);
             }
 
@@ -1402,6 +1416,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _nzdUsdExecutor.ExecuteEntry(selected, _ctx);
             }
 
@@ -1419,6 +1434,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _usdCadExecutor.ExecuteEntry(selected, _ctx);
             }
 
@@ -1436,6 +1452,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
+                LogEntryExecuted(selected);
                 _usdChfExecutor.ExecuteEntry(selected, _ctx);
             }
 
@@ -1464,6 +1481,7 @@ namespace GeminiV26.Core
                 }
 
                 _bot.Print("[BTC GATE] ALLOWED (Session+Impulse)");
+                LogEntryExecuted(selected);
                 _btcUsdExecutor?.ExecuteEntry(selected, _ctx);
             }
 
@@ -1492,12 +1510,14 @@ namespace GeminiV26.Core
                 }
 
                 _bot.Print("[ETH GATE] ALLOWED (Session+Impulse)");
+                LogEntryExecuted(selected);
                 _ethUsdExecutor?.ExecuteEntry(selected, _ctx);
             }
             else if (IsGer40(_bot.SymbolName))
             {
                 if (!_ger40SessionGate.AllowEntry(gateDir)) return;
                 if (!_ger40ImpulseGate.AllowEntry(gateDir)) return;
+                LogEntryExecuted(selected);
                 _ger40Executor.ExecuteEntry(selected, _ctx);
             }
         }
@@ -1606,6 +1626,219 @@ namespace GeminiV26.Core
                 default:
                     return 0;
             }
+        }
+
+        private void UpdateExecutionStateMachine(EntryContext ctx, List<EntryEvaluation> symbolSignals)
+        {
+            if (ctx == null || symbolSignals == null)
+                return;
+
+            foreach (var candidate in symbolSignals)
+            {
+                if (candidate == null)
+                    continue;
+
+                candidate.TriggerConfirmed = false;
+                candidate.State = EntryState.NONE;
+
+                if (candidate.Direction == TradeDirection.None || EntryDecisionPolicy.IsHardInvalid(candidate))
+                {
+                    ClearArmedSetup(candidate);
+                    continue;
+                }
+
+                if (candidate.Score > 0)
+                    candidate.State = EntryState.SETUP_DETECTED;
+
+                int barsSinceBreak = GetBarsSinceBreak(ctx, candidate.Direction);
+                if (barsSinceBreak == 0)
+                {
+                    int originalScore = candidate.Score;
+                    candidate.Score = Math.Max(0, candidate.Score - 15);
+                    candidate.Reason = $"{candidate.Reason} [EARLY_BREAK_PENALTY]";
+                    _bot.Print($"[ENTRY][EARLY_PROTECT] symbol={candidate.Symbol} type={candidate.Type} dir={candidate.Direction} score={originalScore}->{candidate.Score} barsSinceBreak={barsSinceBreak}");
+                }
+
+                if (candidate.Score < EntryDecisionPolicy.MinScoreThreshold)
+                {
+                    ClearArmedSetup(candidate);
+                    continue;
+                }
+
+                var trigger = ResolveTriggerDiagnostics(ctx, candidate);
+
+                if (!trigger.IsManaged)
+                {
+                    candidate.TriggerConfirmed = true;
+                    candidate.State = EntryState.TRIGGERED;
+                    continue;
+                }
+
+                candidate.TriggerConfirmed = trigger.TriggerConfirmed;
+                candidate.State = candidate.TriggerConfirmed ? EntryState.TRIGGERED : EntryState.ARMED;
+
+                if (candidate.State == EntryState.ARMED)
+                {
+                    UpsertArmedSetup(candidate, barsSinceBreak);
+                    _bot.Print($"[SETUP DETECTED] symbol={candidate.Symbol} score={candidate.Score} state={candidate.State} type={candidate.Type} dir={candidate.Direction}");
+                    _bot.Print($"[TRIGGER WAIT] symbol={candidate.Symbol} reason={trigger.WaitReason} type={candidate.Type} dir={candidate.Direction}");
+                }
+                else
+                {
+                    UpsertArmedSetup(candidate, barsSinceBreak);
+                    _bot.Print($"[TRIGGER CONFIRMED] symbol={candidate.Symbol} breakoutClose={trigger.BreakoutClose.ToString().ToLowerInvariant()} structureBreak={trigger.StructureBreak.ToString().ToLowerInvariant()} m1Break={trigger.M1Break.ToString().ToLowerInvariant()} type={candidate.Type} dir={candidate.Direction}");
+                }
+            }
+        }
+
+        private TriggerDiagnostics ResolveTriggerDiagnostics(EntryContext ctx, EntryEvaluation candidate)
+        {
+            var diagnostics = new TriggerDiagnostics();
+            if (ctx == null || candidate == null)
+                return diagnostics;
+
+            diagnostics.IsManaged = IsTriggerManaged(candidate.Type);
+            if (!diagnostics.IsManaged)
+            {
+                diagnostics.TriggerConfirmed = true;
+                return diagnostics;
+            }
+
+            if (!string.IsNullOrWhiteSpace(candidate.Reason) &&
+                candidate.Reason.IndexOf("WAIT_BREAKOUT", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                diagnostics.WaitReason = "WAIT_BREAKOUT";
+                diagnostics.TriggerConfirmed = false;
+                return diagnostics;
+            }
+
+            int lastClosedM5 = ctx.M5?.Count >= 2 ? ctx.M5.Count - 2 : -1;
+            double buffer = ctx.FlagAtr_M5 > 0 ? ctx.FlagAtr_M5 * 0.10 : ctx.AtrM5 * 0.10;
+
+            if (lastClosedM5 >= 1)
+            {
+                double rangeHigh = ctx.FlagHigh;
+                double rangeLow = ctx.FlagLow;
+
+                if (rangeHigh > rangeLow)
+                {
+                    double close = ctx.M5.ClosePrices[lastClosedM5];
+                    diagnostics.BreakoutClose =
+                        close > rangeHigh + buffer ||
+                        close < rangeLow - buffer;
+                }
+
+                double prevHigh = ctx.M5.HighPrices[lastClosedM5 - 1];
+                double prevLow = ctx.M5.LowPrices[lastClosedM5 - 1];
+                double currentHigh = ctx.M5.HighPrices[lastClosedM5];
+                double currentLow = ctx.M5.LowPrices[lastClosedM5];
+
+                diagnostics.StructureBreak =
+                    currentHigh > prevHigh ||
+                    currentLow < prevLow ||
+                    ctx.BrokeLastSwingHigh_M5 ||
+                    ctx.BrokeLastSwingLow_M5;
+            }
+
+            diagnostics.M1Break =
+                ctx.HasBreakout_M1 &&
+                ctx.BreakoutDirection == candidate.Direction;
+
+            diagnostics.TriggerConfirmed =
+                diagnostics.BreakoutClose ||
+                diagnostics.StructureBreak ||
+                diagnostics.M1Break;
+
+            if (!diagnostics.TriggerConfirmed && string.IsNullOrWhiteSpace(diagnostics.WaitReason))
+                diagnostics.WaitReason = "WAIT_BREAKOUT";
+
+            return diagnostics;
+        }
+
+        private static bool IsTriggerManaged(EntryType type)
+        {
+            switch (type)
+            {
+                case EntryType.FX_Flag:
+                case EntryType.FX_MicroStructure:
+                case EntryType.FX_RangeBreakout:
+                case EntryType.FX_FlagContinuation:
+                case EntryType.FX_MicroContinuation:
+                case EntryType.FX_ImpulseContinuation:
+                case EntryType.Index_Flag:
+                case EntryType.Index_Breakout:
+                case EntryType.Crypto_Flag:
+                case EntryType.Crypto_RangeBreakout:
+                case EntryType.XAU_Flag:
+                case EntryType.XAU_Impulse:
+                case EntryType.TC_Flag:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private static int GetBarsSinceBreak(EntryContext ctx, TradeDirection direction)
+        {
+            if (ctx == null)
+                return int.MaxValue;
+
+            return direction == TradeDirection.Long
+                ? ctx.BarsSinceHighBreak_M5
+                : direction == TradeDirection.Short
+                    ? ctx.BarsSinceLowBreak_M5
+                    : int.MaxValue;
+        }
+
+        private void UpsertArmedSetup(EntryEvaluation candidate, int barsSinceBreak)
+        {
+            if (candidate == null)
+                return;
+
+            string key = GetArmedSetupKey(candidate);
+            _armedSetups[key] = new ArmedSetup
+            {
+                Symbol = candidate.Symbol ?? _bot.SymbolName,
+                Direction = candidate.Direction,
+                Score = candidate.Score,
+                DetectedAt = _bot.Server.Time,
+                BarsSince = barsSinceBreak,
+                EntryType = candidate.Type,
+                Reason = candidate.Reason ?? string.Empty
+            };
+        }
+
+        private void ClearArmedSetup(EntryEvaluation candidate)
+        {
+            if (candidate == null)
+                return;
+
+            _armedSetups.Remove(GetArmedSetupKey(candidate));
+        }
+
+        private static string GetArmedSetupKey(EntryEvaluation candidate)
+        {
+            return $"{candidate?.Symbol}:{candidate?.Type}:{candidate?.Direction}";
+        }
+
+        private void LogEntryExecuted(EntryEvaluation candidate)
+        {
+            if (candidate == null)
+                return;
+
+            ClearArmedSetup(candidate);
+            _bot.Print($"[ENTRY EXECUTED] symbol={candidate.Symbol ?? _bot.SymbolName} score={candidate.Score} type={candidate.Type} dir={candidate.Direction}");
+        }
+
+        private sealed class TriggerDiagnostics
+        {
+            public bool IsManaged { get; set; }
+            public bool TriggerConfirmed { get; set; }
+            public bool BreakoutClose { get; set; }
+            public bool StructureBreak { get; set; }
+            public bool M1Break { get; set; }
+            public string WaitReason { get; set; } = string.Empty;
         }
         
         // =========================================================
@@ -1976,10 +2209,6 @@ namespace GeminiV26.Core
             if (symbolSignals == null || bias == null)
                 return;
 
-            const double MisalignedPenalty = 0.70;
-            const double TransitionPenalty = 0.85;
-            const double AlignedDirectionalBoost = 1.10;
-
             _bot.Print($"[HTF][BIAS] asset={assetTag} direction={bias.AllowedDirection} state={bias.State} impact=ScoreOnly conf={bias.Confidence01:0.00}");
 
             int alignedCandidates = 0;
@@ -2000,31 +2229,24 @@ namespace GeminiV26.Core
                 if (misaligned)
                     misalignedCandidates++;
 
-                double multiplier = 1.0;
+                int originalScore = candidate.Score;
+
+                if (aligned)
+                    candidate.Score += 5;
 
                 if (misaligned)
-                    multiplier *= MisalignedPenalty;
+                    candidate.Score -= 10;
 
-                if (bias.State == HtfBiasState.Transition)
-                    multiplier *= TransitionPenalty;
-                else if (aligned && (bias.State == HtfBiasState.Bull || bias.State == HtfBiasState.Bear))
-                    multiplier *= AlignedDirectionalBoost;
-
-                int originalScore = candidate.Score;
-                candidate.Score = Math.Max(1, (int)Math.Round(candidate.Score * multiplier));
+                candidate.Score = Math.Max(0, Math.Min(100, candidate.Score));
 
                 _bot.Print(
                     $"[HTF][CANDIDATE] asset={assetTag} type={candidate.Type} dir={candidate.Direction} " +
-                    $"aligned={aligned} multiplier={multiplier:0.00} score={originalScore}->{candidate.Score} state={bias.State}");
+                    $"aligned={aligned} misaligned={misaligned} score={originalScore}->{candidate.Score} state={bias.State}");
             }
-
-            string statePenaltyText = bias.State == HtfBiasState.Transition
-                ? TransitionPenalty.ToString("0.00")
-                : "1.00";
 
             _bot.Print(
                 $"[HTF][APPLIED] asset={assetTag} dir={bias.AllowedDirection} state={bias.State} " +
-                $"penalty={statePenaltyText} directionalPenalty={MisalignedPenalty:0.00} " +
+                $"alignedBonus=5 misalignedPenalty=10 " +
                 $"alignedCandidates={alignedCandidates} misaligned={misalignedCandidates}");
         }
 

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -50,7 +50,7 @@ namespace GeminiV26.Core
                 return null;
 
             int nonNullCount = signals.Count(e => e != null);
-            int validCount = signals.Count(e => e != null && e.IsValid);
+            int validCount = signals.Count(e => e != null && e.State == EntryState.TRIGGERED && e.TriggerConfirmed);
 
             _bot.Print($"[TR] evals={signals.Count} nonNull={nonNullCount} valid={validCount} threshold={EntryDecisionPolicy.MinScoreThreshold}");
             LogCandidates("CAND", signals);
@@ -61,7 +61,11 @@ namespace GeminiV26.Core
             {
                 string decision;
 
-                if (!candidate.IsValid)
+                if (candidate.State == EntryState.ARMED && !candidate.TriggerConfirmed)
+                {
+                    decision = "ARMED";
+                }
+                else if (candidate.State != EntryState.TRIGGERED || !candidate.TriggerConfirmed)
                 {
                     decision = "REJECT";
                 }
@@ -82,7 +86,7 @@ namespace GeminiV26.Core
                     }
                 }
 
-                _bot.Print($"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} score={candidate.Score} threshold={EntryDecisionPolicy.MinScoreThreshold} valid={candidate.IsValid.ToString().ToLowerInvariant()} → {decision}");
+                _bot.Print($"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} score={candidate.Score} threshold={EntryDecisionPolicy.MinScoreThreshold} valid={candidate.IsValid.ToString().ToLowerInvariant()} state={candidate.State} trigger={candidate.TriggerConfirmed.ToString().ToLowerInvariant()} → {decision}");
             }
 
             if (winner == null)
@@ -105,7 +109,7 @@ namespace GeminiV26.Core
             foreach (var e in list)
             {
                 if (e == null) continue;
-                _bot.Print($"[TR] {scope} {e.Type} dir={e.Direction} valid={e.IsValid} score={e.Score} reason={e.Reason}");
+                _bot.Print($"[TR] {scope} {e.Type} dir={e.Direction} valid={e.IsValid} state={e.State} trigger={e.TriggerConfirmed} score={e.Score} reason={e.Reason}");
             }
         }
 

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -104,19 +104,11 @@ namespace GeminiV26.EntryTypes.FX
 
             if (ctx.FxHtfAllowedDirection == dir)
             {
-                double conf = ctx.FxHtfConfidence01;
-
-                if (conf > 0.75) score += 6;
-                else if (conf > 0.55) score += 4;
-                else if (conf > 0.35) score += 2;
+                score += 5;
             }
             else if (ctx.FxHtfAllowedDirection != TradeDirection.None)
             {
-                double conf = ctx.FxHtfConfidence01;
-
-                if (conf > 0.60) score -= 10;
-                else if (conf > 0.40) score -= 7;
-                else score -= 4;
+                score -= 10;
             }
 
             // -----------------------------------------------------


### PR DESCRIPTION
### Motivation

- Prevent early/immediate entries by separating setup detection from execution and requiring an explicit trigger confirmation before entry.
- Persist armed setups across bars so valid setups are not lost between evaluation passes and can be executed only after managed triggers fire.
- Make HTF influence score-only (no gating) and ensure `WAIT_BREAKOUT` cannot be treated as an entry confirmation.

### Description

- Added an execution state model with `EntryState { NONE, SETUP_DETECTED, ARMED, TRIGGERED }` and per-candidate `TriggerConfirmed` on `EntryEvaluation` (`Core/Entry/EntryState.cs`, `Core/Entry/EntryEvaluation.cs`).
- Implemented `ArmedSetup` persistence and an `_armedSetups` store to keep armed setups across bars and updated `TradeCore` to maintain/clear these entries (`Core/Entry/ArmedSetup.cs`, `Core/TradeCore.cs`).
- Introduced `UpdateExecutionStateMachine(...)` in `Core/TradeCore.cs` which: applies an early-entry protection penalty (`-15` when `barsSinceBreak == 0`), resolves trigger diagnostics (breakout close / structure break / M1 break), sets `State` to `ARMED` or `TRIGGERED`, persists armed setups, and emits the mandated logs (`[SETUP DETECTED]`, `[TRIGGER WAIT]`, `[TRIGGER CONFIRMED]`, `[ENTRY EXECUTED]`).
- Ensured `WAIT_BREAKOUT` is explicitly treated as non-confirmation by forcing `TriggerConfirmed = false` where applicable (`Core/Entry/EntryDecisionPolicy.cs` and `Core/TradeCore.cs`).
- Changed router selection to only accept `TRIGGERED` candidates with `TriggerConfirmed == true` and to log `ARMED` candidates (no execution) (`Core/TradeRouter.cs`).
- Converted HTF adjustments to score-only fixed deltas (`+5` aligned, `-10` misaligned) and aligned FX microstructure HTF weighting to the new rule (`Core/TradeCore.cs`, `EntryTypes/FX/FX_MicroStructureEntry.cs`).
- Added helper functions for trigger diagnostics, armed setup keying/management, and execution logging in `Core/TradeCore.cs` and preserved prior gate checks before executing entries.

### Testing

- Ran `git diff --check` which returned clean output (no whitespace errors). ✅
- Ran `git status --short` to validate working tree, which showed expected staged/committed changes. ✅
- Attempted `dotnet build` but the environment lacks the SDK (`/bin/bash: dotnet: command not found`), so a full compile/test could not be executed here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0f47f0b48328aae6f6a0b3f4ae11)