### PR TITLE
Convert trigger hard-gates into soft scoring impact

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1674,14 +1674,14 @@ namespace GeminiV26.Core
                     continue;
                 }
 
-                candidate.TriggerConfirmed = trigger.TriggerConfirmed;
-                candidate.State = candidate.TriggerConfirmed ? EntryState.TRIGGERED : EntryState.ARMED;
+                candidate.TriggerConfirmed = true;
+                candidate.State = EntryState.TRIGGERED;
 
-                if (candidate.State == EntryState.ARMED)
+                if (!trigger.TriggerConfirmed)
                 {
                     UpsertArmedSetup(candidate, barsSinceBreak);
-                    _bot.Print($"[SETUP DETECTED] symbol={candidate.Symbol} score={candidate.Score} state={candidate.State} type={candidate.Type} dir={candidate.Direction}");
-                    _bot.Print($"[TRIGGER WAIT] symbol={candidate.Symbol} reason={trigger.WaitReason} type={candidate.Type} dir={candidate.Direction}");
+                    _bot.Print($"[SETUP DETECTED] symbol={candidate.Symbol} score={candidate.Score} state=ARMED type={candidate.Type} dir={candidate.Direction}");
+                    _bot.Print($"[TRIGGER WAIT] symbol={candidate.Symbol} reason={trigger.WaitReason} type={candidate.Type} dir={candidate.Direction} impact=score_only");
                 }
                 else
                 {

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -117,6 +117,7 @@ namespace GeminiV26.EntryTypes.Crypto
 
             int score = 0;
             int setupScore = 0;
+            double triggerScore = 0;
 
             if (!ctx.HasImpulse_M5)
             {
@@ -246,15 +247,12 @@ namespace GeminiV26.EntryTypes.Crypto
 
             bool longValid = bullBreak || bullReclaim || (dir == TradeDirection.Long && breakoutSignal);
             bool shortValid = bearBreak || bearReclaim || (dir == TradeDirection.Short && breakoutSignal);
+            bool breakoutDetected = dir == TradeDirection.Long ? longValid : shortValid;
+            bool strongCandle =
+                (dir == TradeDirection.Long && close > open) ||
+                (dir == TradeDirection.Short && close < open);
 
-            if (dir == TradeDirection.Long && !longValid)
-                return Invalid(ctx, dir, "NO_BREAK_LONG", 51);
-
-            if (dir == TradeDirection.Short && !shortValid)
-                return Invalid(ctx, dir, "NO_BREAK_SHORT", 51);
-
-            if (dir == TradeDirection.Long && close > open) score += 6;
-            if (dir == TradeDirection.Short && close < open) score += 6;
+            if (strongCandle) score += 6;
 
             if (ctx.TrendDirection != TradeDirection.None &&
                 dir != ctx.TrendDirection)
@@ -273,6 +271,32 @@ namespace GeminiV26.EntryTypes.Crypto
             }
 
             score += setupScore;
+
+            bool followThrough = continuationSignal;
+
+            if (breakoutDetected)
+                triggerScore += 1;
+
+            if (strongCandle)
+                triggerScore += 1;
+
+            if (followThrough)
+                triggerScore += 2;
+
+            score += (int)Math.Round(triggerScore * 5);
+
+            if (triggerScore == 0)
+                score -= 15;
+
+            bool minimalTrigger = breakoutDetected || strongCandle;
+            if (!minimalTrigger)
+                score -= 10;
+
+            if (!breakoutDetected)
+                score -= 8;
+
+            ctx.Log?.Invoke(
+                $"[TRIGGER SCORE] breakout={(breakoutDetected ? 1 : 0)} strong={(strongCandle ? 1 : 0)} follow={(followThrough ? 1 : 0)} total={triggerScore:F0} finalScore={score}");
 
             if (setupScore <= 0)
                 score = Math.Min(score, MinScore - 10);

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -78,6 +78,7 @@ namespace GeminiV26.EntryTypes.FX
             int score = 0;
             int setupScore = 0;
             int penaltyBudget = 0;
+            double triggerScore = 0;
 
             const int maxPenalty = 15;   // FX-en ennyi össz negatív korrekció lehet max
             int minBoost = 0;
@@ -411,7 +412,7 @@ namespace GeminiV26.EntryTypes.FX
             );
 
             if (!breakoutConfirmed)
-                return Invalid(ctx, flagDir, "WAIT_BREAKOUT", score);
+                ctx.Log?.Invoke($"[TRIGGER WAIT] candDir={flagDir} reason=WAIT_BREAKOUT score={score}");
 
             string flagDirReason = breakoutReason;
 
@@ -554,10 +555,17 @@ namespace GeminiV26.EntryTypes.FX
                     !ctx.IsRange_M5;
 
                 if (!strongContext)
-                    return Invalid(ctx, flagDir, "M1_TRIGGER_REQUIRED", score);
+                {
+                    ApplyPenalty(5);
+                    minBoost += 1;
+                    ctx.Log?.Invoke($"[{ctx.Symbol}][B_M1_SOFT] candDir={flagDir} reason=M1_TRIGGER_REQUIRED impact=penalty5 score={score}");
+                }
 
-                ApplyPenalty(2);
-                ctx.Log?.Invoke($"[{ctx.Symbol}][B_M1_SOFT] candDir={flagDir} no M1 trigger, strongContext => penalty=2 score={score}");
+                if (strongContext)
+                {
+                    ApplyPenalty(2);
+                    ctx.Log?.Invoke($"[{ctx.Symbol}][B_M1_SOFT] candDir={flagDir} no M1 trigger, strongContext => penalty=2 score={score}");
+                }
             }
 
             int barsSinceBreak =
@@ -940,6 +948,31 @@ namespace GeminiV26.EntryTypes.FX
             if (min < 0) min = 0;
 
             score += setupScore;
+
+            bool breakoutDetected = breakoutConfirmed || breakout;
+            bool strongCandle = strongBody || lastStrongBody;
+            bool followThrough = hasM1Confirmation || continuationSignal;
+
+            if (breakoutDetected)
+                triggerScore += 1;
+
+            if (strongCandle)
+                triggerScore += 1;
+
+            if (followThrough)
+                triggerScore += 2;
+
+            score += (int)Math.Round(triggerScore * 5);
+
+            if (triggerScore == 0)
+                score -= 15;
+
+            bool minimalTrigger = breakoutDetected || strongCandle;
+            if (!minimalTrigger)
+                score -= 10;
+
+            ctx.Log?.Invoke(
+                $"[TRIGGER SCORE] breakout={(breakoutDetected ? 1 : 0)} strong={(strongCandle ? 1 : 0)} follow={(followThrough ? 1 : 0)} total={triggerScore:F0} finalScore={score}");
 
             if (setupScore <= 0)
                 score = Math.Min(score, min - 10);

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -44,6 +44,7 @@ namespace GeminiV26.EntryTypes.FX
         {
             int score = 54;   // base score aligned with FlagEntry universe
             int setupScore = 0;
+            double triggerScore = 0;
 
             ctx.Log?.Invoke(
                 $"[FX_MICRO START] sym={ctx.Symbol} dir={dir} " +
@@ -125,9 +126,6 @@ namespace GeminiV26.EntryTypes.FX
                 breakout = true;
             }
 
-            if (!breakout)
-                return Invalid(ctx, dir, "WAIT_BREAKOUT", score);
-
             bool continuationSignal = breakout;
 
             bool hasStructure =
@@ -158,9 +156,20 @@ namespace GeminiV26.EntryTypes.FX
 
             double body = Math.Abs(last.Close - last.Open);
             double range = last.High - last.Low;
+            bool strongCandle = range > 0 && body / range > 0.55;
+            bool followThrough = continuationSignal;
 
-            if (range > 0 && body / range > 0.55)
+            if (strongCandle)
                 score += 2;
+
+            if (breakout)
+                triggerScore += 1;
+
+            if (strongCandle)
+                triggerScore += 1;
+
+            if (followThrough)
+                triggerScore += 2;
 
             // -----------------------------------------------------
             // STRUCTURE FRESHNESS
@@ -192,6 +201,18 @@ namespace GeminiV26.EntryTypes.FX
             int minScore = EntryDecisionPolicy.MinScoreThreshold;
 
             score += setupScore;
+
+            score += (int)Math.Round(triggerScore * 5);
+
+            if (triggerScore == 0)
+                score -= 15;
+
+            bool minimalTrigger = breakout || strongCandle;
+            if (!minimalTrigger)
+                score -= 10;
+
+            ctx.Log?.Invoke(
+                $"[TRIGGER SCORE] breakout={(breakout ? 1 : 0)} strong={(strongCandle ? 1 : 0)} follow={(followThrough ? 1 : 0)} total={triggerScore:F0} finalScore={score}");
 
             if (setupScore <= 0)
                 score = Math.Min(score, minScore - 10);

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -130,6 +130,7 @@ namespace GeminiV26.EntryTypes.INDEX
             int score = BaseScore;
             int setupScore = 0;
             int penaltyBudget = 0;
+            double triggerScore = 0;
             const int maxPenalty = 22;
 
             void ApplyPenalty(int p)
@@ -396,9 +397,6 @@ namespace GeminiV26.EntryTypes.INDEX
             if (hasContinuation)
                 setupScore += 20;
 
-            if (!breakoutConfirmed)
-                return Reject(ctx, "NO_FLAG_BREAKOUT", score, dir);
-
             double breakDist = 0;
 
             if (hasValidRange)
@@ -410,15 +408,22 @@ namespace GeminiV26.EntryTypes.INDEX
             }
 
             double follow = ctx.AtrM5 * 0.12;
+            bool followThrough = true;
 
             if (hasValidRange)
             {
                 if (dir == TradeDirection.Long && close < hi + follow)
-                    return Reject(ctx, "WEAK_BREAKOUT_NO_FOLLOW", score, dir);
+                    followThrough = false;
 
                 if (dir == TradeDirection.Short && close > lo - follow)
-                    return Reject(ctx, "WEAK_BREAKOUT_NO_FOLLOW", score, dir);
+                    followThrough = false;
             }
+
+            if (!breakoutConfirmed)
+                ApplyPenalty(8);
+
+            if (!followThrough)
+                ApplyPenalty(6);
 
             // =====================================================
             // BREAKOUT BAR QUALITY
@@ -432,16 +437,16 @@ namespace GeminiV26.EntryTypes.INDEX
             double breakoutBarAtr = barRange / ctx.AtrM5;
 
             if (bodyRatio < MinBreakoutBodyRatio)
-                return Reject(ctx, $"WEAK_BODY({bodyRatio:F2})", score, dir);
+                ApplyPenalty(6);
 
             if (breakoutBarAtr < MinBreakoutBarAtr)
-                return Reject(ctx, $"BREAKOUT_TOO_SMALL({breakoutBarAtr:F2})", score, dir);
+                ApplyPenalty(6);
 
             if (dir == TradeDirection.Long && close <= open)
-                return Reject(ctx, "BREAKOUT_BAR_NOT_BULLISH", score, dir);
+                ApplyPenalty(8);
 
             if (dir == TradeDirection.Short && close >= open)
-                return Reject(ctx, "BREAKOUT_BAR_NOT_BEARISH", score, dir);
+                ApplyPenalty(8);
 
             // =====================================================
             // M1 CONFIRMATION
@@ -451,9 +456,9 @@ namespace GeminiV26.EntryTypes.INDEX
                 HasDirectionalM1FollowThrough(ctx, dir);
 
             if (!m1Ok)
-                return Reject(ctx, "NO_M1_CONFIRMATION", score, dir);
-
-            ApplyReward(5);
+                ApplyPenalty(6);
+            else
+                ApplyReward(5);
 
             // =====================================================
             // EXTRA QUALITY
@@ -503,6 +508,33 @@ namespace GeminiV26.EntryTypes.INDEX
             }
 
             score += setupScore;
+
+            bool breakoutDetected = breakoutConfirmed;
+            bool strongCandle =
+                bodyRatio >= MinBreakoutBodyRatio &&
+                ((dir == TradeDirection.Long && close > open) || (dir == TradeDirection.Short && close < open));
+            followThrough = followThrough && m1Ok;
+
+            if (breakoutDetected)
+                triggerScore += 1;
+
+            if (strongCandle)
+                triggerScore += 1;
+
+            if (followThrough)
+                triggerScore += 2;
+
+            score += (int)Math.Round(triggerScore * 5);
+
+            if (triggerScore == 0)
+                score -= 15;
+
+            bool minimalTrigger = breakoutDetected || strongCandle;
+            if (!minimalTrigger)
+                score -= 10;
+
+            ctx.Log?.Invoke(
+                $"[TRIGGER SCORE] breakout={(breakoutDetected ? 1 : 0)} strong={(strongCandle ? 1 : 0)} follow={(followThrough ? 1 : 0)} total={triggerScore:F0} finalScore={score}");
 
             if (setupScore <= 0)
                 score = Math.Min(score, MinScore - 10);

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -112,6 +112,7 @@ namespace GeminiV26.EntryTypes.METAL
             int score = (int)tuning.BaseScore;
             int minScore = EntryDecisionPolicy.MinScoreThreshold;
             int setupScore = 0;
+            double triggerScore = 0;
 
             var reasons = new List<string>();
 
@@ -318,6 +319,31 @@ namespace GeminiV26.EntryTypes.METAL
                 return InvalidDir(ctx, dir, "HIGHER_LOW", score);
 
             score += setupScore;
+
+            bool breakoutDetected = breakoutConfirmed || earlyBreakout;
+            bool strongCandle = strongBody;
+            bool followThrough = confirmedBreakout;
+
+            if (breakoutDetected)
+                triggerScore += 1;
+
+            if (strongCandle)
+                triggerScore += 1;
+
+            if (followThrough)
+                triggerScore += 2;
+
+            score += (int)Math.Round(triggerScore * 5);
+
+            if (triggerScore == 0)
+                score -= 15;
+
+            bool minimalTrigger = breakoutDetected || strongCandle;
+            if (!minimalTrigger)
+                score -= 10;
+
+            ctx.Log?.Invoke(
+                $"[TRIGGER SCORE] breakout={(breakoutDetected ? 1 : 0)} strong={(strongCandle ? 1 : 0)} follow={(followThrough ? 1 : 0)} total={triggerScore:F0} finalScore={score}");
 
             if (setupScore <= 0)
                 score = Math.Min(score, minScore - 10);


### PR DESCRIPTION
### Motivation
- The trigger subsystem acted as a hidden second hard gate that frequently invalidated entries and made the system "dead", so the intent is to convert trigger logic into a score modifier while keeping the primary score/threshold decision path unchanged.
- Keep the change minimal and focused only on trigger behavior without refactoring architecture, renaming classes, changing routing, touching `EntryDecisionPolicy`, `MinScoreThreshold` logic, or altering unrelated scoring weights.

### Description
- Treat unresolved trigger waits as informational in `Core/TradeCore.cs` by setting `TriggerConfirmed=true` / `State=TRIGGERED` for managed types while logging `WAIT_BREAKOUT` as `impact=score_only` instead of invalidating the candidate, and retain `UpsertArmedSetup` when trigger isn't yet confirmed.
- Introduce a per-evaluation `double triggerScore` in the impacted entry evaluators (`EntryTypes/FX/FX_FlagEntry.cs`, `EntryTypes/FX/FX_MicroStructureEntry.cs`, `EntryTypes/INDEX/Index_FlagEntry.cs`, `EntryTypes/METAL/XAU_FlagEntry.cs`, `EntryTypes/CRYPTO/BTC_FlagEntry.cs`) and compute it as: `breakout -> +1`, `strong candle -> +1`, `followThrough -> +2`.
- Apply trigger impact to final score with `score += (int)Math.Round(triggerScore * 5)`, penalize missing trigger evidence with `if (triggerScore == 0) score -= 15;`, and enforce a very light minimal-trigger floor `if (!minimalTrigger) score -= 10;` while preserving `valid && score >= threshold` logic elsewhere.
- Replace prior immediate `return Invalid(...)` / `Reject(...)` behavior for trigger-related reasons (examples: `WAIT_BREAKOUT`, `NO_FLAG_BREAKOUT`, `NO_M1_CONFIRMATION`, `NO_BREAK_LONG/SHORT`, weak follow-through) with either informational logs or soft `ApplyPenalty(...)` calls, and add `[TRIGGER SCORE]` logging lines that report `breakout/strong/follow/total/finalScore`.

### Testing
- Ran `git diff --check` and static checks which passed without whitespace or patch errors.
- Verified (via `rg`) that trigger wait reasons are still logged but no longer returned as hard invalidation in the modified evaluators, and confirmed presence of `[TRIGGER SCORE]` logging lines in the modified files.
- Committed changes and created a descriptive branch commit; full compile/time-based unit tests were not executed because no C# compiler (`dotnet`/`mcs`/`csc`) was available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc15df33648328848081854a5b0ac2)