### PR TITLE
Balance long and short entry scoring

### DIFF
--- a/Core/Entry/EntryDecisionPolicy.cs
+++ b/Core/Entry/EntryDecisionPolicy.cs
@@ -156,6 +156,57 @@ namespace GeminiV26.Core.Entry
             return MinScoreThreshold - 5;
         }
 
+
+
+        public static EntryEvaluation SelectBalancedEvaluation(
+            EntryContext ctx,
+            EntryType type,
+            EntryEvaluation longEval,
+            EntryEvaluation shortEval)
+        {
+            double longScore = Math.Max(0, longEval?.Score ?? 0);
+            double shortScore = Math.Max(0, shortEval?.Score ?? 0);
+            bool longHardInvalid = IsHardInvalid(longEval);
+            bool shortHardInvalid = IsHardInvalid(shortEval);
+
+            EntryEvaluation selectedEval;
+            if (!longHardInvalid && !shortHardInvalid && Math.Abs(longScore - shortScore) < 1.0)
+            {
+                selectedEval = new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = type,
+                    Direction = TradeDirection.None,
+                    Score = (int)Math.Round(Math.Max(longScore, shortScore)),
+                    IsValid = false,
+                    Reason = "SCORE_BALANCE_TIE"
+                };
+            }
+            else if (longHardInvalid && shortHardInvalid)
+            {
+                selectedEval = longScore > shortScore ? longEval : shortEval;
+            }
+            else if (longHardInvalid)
+            {
+                selectedEval = shortEval;
+            }
+            else if (shortHardInvalid)
+            {
+                selectedEval = longEval;
+            }
+            else
+            {
+                selectedEval = longScore > shortScore ? longEval : shortEval;
+            }
+
+            var selectedDirection = selectedEval?.Direction ?? TradeDirection.None;
+            string balanceLog = $"[SCORE BALANCE] type={type} longScore={longScore:0.##} shortScore={shortScore:0.##} selected={selectedDirection}";
+            ctx?.Log?.Invoke(balanceLog);
+            Console.WriteLine(balanceLog);
+
+            return selectedEval;
+        }
+
         private static EntryState ResolveState(EntryEvaluation eval)
         {
             if (eval == null)

--- a/EntryTypes/BR_RangeBreakoutEntry.cs
+++ b/EntryTypes/BR_RangeBreakoutEntry.cs
@@ -32,11 +32,45 @@ namespace GeminiV26.EntryTypes
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            if (ctx == null || !ctx.IsReady)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "CTX_NOT_READY;"
+                };
+            }
+
+            if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MinRangeBars)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NoRange;"
+                };
+            }
+
+            var longEval = EvaluateSide(ctx, TradeDirection.Long);
+            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
+
+        private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
+        {
             var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
-                Direction = TradeDirection.None,
+                Direction = dir,
                 Score = 0,
                 IsValid = false,
                 Reason = ""
@@ -127,7 +161,7 @@ namespace GeminiV26.EntryTypes
             else
             {
                 double pullbackDepthR =
-                    ctx.RangeBreakDirection == TradeDirection.Short
+                    dir == TradeDirection.Short
                         ? ctx.PullbackDepthRShort_M5
                         : ctx.PullbackDepthRLong_M5;
 
@@ -144,14 +178,12 @@ namespace GeminiV26.EntryTypes
             // 2️⃣ BREAKOUT (HARD LÉTEZÉSI FELTÉTEL)
             // =========================================================
 
-            if (ctx.RangeBreakDirection == TradeDirection.None)
-            {
+            if (ctx.RangeBreakDirection == dir)
+                score += 15;
+            else if (ctx.RangeBreakDirection != TradeDirection.None)
+                score -= 15;
+            else
                 eval.Reason += "NoBreak;";
-                return eval;
-            }
-
-            eval.Direction = ctx.RangeBreakDirection;
-            score += 15;
 
             // Break ereje ATR-ben (minőségi súlyozás)
             if (ctx.RangeBreakAtrSize_M5 >= MinBreakATR * 1.5)
@@ -201,7 +233,7 @@ namespace GeminiV26.EntryTypes
             if (instrumentClass == InstrumentClass.METAL)
             {
                 bool hasConfirmation =
-                    ctx.RangeBreakDirection != TradeDirection.None
+                    ctx.RangeBreakDirection == dir
                     || ctx.M1TriggerInTrendDirection;
 
                 if (hasConfirmation)
@@ -210,7 +242,7 @@ namespace GeminiV26.EntryTypes
             else if (instrumentClass == InstrumentClass.INDEX)
             {
                 bool continuationSignal =
-                    ctx.RangeBreakDirection != TradeDirection.None;
+                    ctx.RangeBreakDirection == dir;
                 bool breakoutConfirmed = continuationSignal;
 
                 if (continuationSignal || breakoutConfirmed)
@@ -219,7 +251,7 @@ namespace GeminiV26.EntryTypes
             else if (instrumentClass == InstrumentClass.CRYPTO)
             {
                 bool continuationSignal =
-                    ctx.RangeBreakDirection != TradeDirection.None;
+                    ctx.RangeBreakDirection == dir;
 
                 if (continuationSignal)
                     setupScore += 20;
@@ -227,7 +259,7 @@ namespace GeminiV26.EntryTypes
             else
             {
                 bool continuationSignal =
-                    ctx.RangeBreakDirection != TradeDirection.None;
+                    ctx.RangeBreakDirection == dir;
 
                 if (continuationSignal)
                     setupScore += 20;
@@ -236,16 +268,14 @@ namespace GeminiV26.EntryTypes
             // =========================================================
             // HARD RULE – irány nélkül nincs setup
             // =========================================================
-            if (eval.Direction == TradeDirection.None)
-            {
-                eval.Reason += "NoDirection;";
-                return eval;
-            }
-
-            bool breakoutDetected = ctx.RangeBreakDirection == eval.Direction;
-            bool strongCandle = ctx.LastClosedBarInTrendDirection;
-            bool followThrough = ctx.M1TriggerInTrendDirection || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
-            score = TriggerScoreModel.Apply(ctx, $"BR_RANGE_BREAKOUT_{eval.Direction}", score, breakoutDetected, strongCandle, followThrough, "NO_RANGE_BREAK_TRIGGER");
+            int lastClosed = ctx.M5.Count - 2;
+            var bar = ctx.M5[lastClosed];
+            bool breakoutDetected = ctx.RangeBreakDirection == dir;
+            bool strongCandle =
+                (dir == TradeDirection.Long && bar.Close > bar.Open) ||
+                (dir == TradeDirection.Short && bar.Close < bar.Open);
+            bool followThrough = ctx.M1TriggerInTrendDirection || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
+            score = TriggerScoreModel.Apply(ctx, $"BR_RANGE_BREAKOUT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_RANGE_BREAK_TRIGGER");
 
             // =========================================================
             // MIN SCORE – ENTRYTYPE SZINTEN
@@ -256,7 +286,7 @@ namespace GeminiV26.EntryTypes
                 score = Math.Min(score, MIN_SCORE - 10);
 
             eval.Score = score;
-            eval.IsValid = true;
+            eval.IsValid = score >= MIN_SCORE;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -99,7 +99,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 return Invalid(ctx, "FLAG_DIRECTION_INVALID");
             }
 
-            return longEval.Score >= shortEval.Score ? longEval : shortEval;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
         }
 
         private EntryEvaluation EvaluateSide(

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -13,6 +13,25 @@ namespace GeminiV26.EntryTypes.Crypto
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            if (ctx == null || !ctx.IsReady)
+                return Block(ctx, "CTX_NOT_READY", 36);
+
+            var originalTrendDirection = ctx.TrendDirection;
+            try
+            {
+                var longEval = EvaluateDirectional(ctx, TradeDirection.Long);
+                var shortEval = EvaluateDirectional(ctx, TradeDirection.Short);
+
+                return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            }
+            finally
+            {
+                ctx.TrendDirection = originalTrendDirection;
+            }
+        }
+
+        private EntryEvaluation EvaluateDirectional(EntryContext ctx, TradeDirection forcedDirection)
+        {
             int score = 36;
             int setupScore = 0;
 
@@ -31,15 +50,16 @@ namespace GeminiV26.EntryTypes.Crypto
                 return Block(ctx, "NO_CRYPTO_PROFILE", score);
 
             var bars = ctx.M5;
-            int lastClosed = bars.Count - 2;
-
-            var bar = bars[lastClosed];
-
             if (bars == null || bars.Count < 20)
                 return Block(ctx, "M5_NOT_READY", score);
 
-            TradeDirection dir = ctx.TrendDirection;
+            int lastClosed = bars.Count - 2;
+            var bar = bars[lastClosed];
+
             var originalTrendDir = ctx.TrendDirection;
+            ctx.TrendDirection = forcedDirection;
+
+            TradeDirection dir = forcedDirection;
 
             // =========================
             // HTF DIRECTIONAL BIAS (score-only)

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -10,22 +10,8 @@ namespace GeminiV26.EntryTypes.Crypto
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            // =========================
-            // HARD GUARDS
-            // =========================
             if (!ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
-
-            int score = 25;
-            int setupScore = 0;
-
-            // =========================
-            // VOL REGIME – SOFT
-            // =========================
-            if (!ctx.IsVolatilityAcceptable_Crypto)
-            {
-                score -= 15;   // SOFT penalty, NEM return
-            }
 
             var crypto = CryptoInstrumentMatrix.Get(ctx.Symbol);
 
@@ -35,9 +21,19 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MIN_RANGE_BARS)
                 return Invalid(ctx, "NO_RANGE");
 
-            TradeDirection dir = ctx.RangeBreakDirection;
-            if (dir == TradeDirection.None)
-                return Invalid(ctx, "NO_BREAK_DIR");
+            var longEval = EvaluateSide(ctx, TradeDirection.Long);
+            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
+
+        private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
+        {
+            int score = 25;
+            int setupScore = 0;
+
+            if (!ctx.IsVolatilityAcceptable_Crypto)
+                score -= 15;
 
             var eval = NewEval(ctx, dir);
 
@@ -101,8 +97,15 @@ namespace GeminiV26.EntryTypes.Crypto
             if (ctx.IsAtrExpanding_M5)
                 score += 10;
 
+            if (ctx.RangeBreakDirection != dir && ctx.RangeBreakDirection != TradeDirection.None)
+                score -= 12;
+
             bool breakoutDetected = ctx.RangeBreakDirection == dir;
-            bool strongCandle = ctx.LastClosedBarInTrendDirection;
+            int lastClosed = ctx.M5.Count - 2;
+            var bar = ctx.M5[lastClosed];
+            bool strongCandle =
+                (dir == TradeDirection.Long && bar.Close > bar.Open) ||
+                (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = ctx.M1TriggerInTrendDirection || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
             score = TriggerScoreModel.Apply(ctx, $"BTC_RANGE_BREAKOUT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_RANGE_BREAK_TRIGGER");
             score += setupScore;
@@ -111,7 +114,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 score = System.Math.Min(score, MIN_SCORE - 10);
 
             eval.Score = score;
-            eval.IsValid = true;
+            eval.IsValid = score >= MIN_SCORE;
 
             if (!eval.IsValid)
                 eval.Reason += $"LowScore({score});";

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -1,10 +1,12 @@
 using GeminiV26.Core.Entry;
+using System;
 
 namespace GeminiV26.EntryTypes.Crypto
 {
     public class Crypto_ImpulseEntry : IEntryType
     {
         public EntryType Type => EntryType.Crypto_Impulse;
+        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
@@ -14,18 +16,44 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsVolatilityAcceptable_Crypto)
                 return Invalid(ctx, "CRYPTO_VOL_DISABLED");
 
-            if (ctx.ImpulseDirection == TradeDirection.None && ctx.TrendDirection == TradeDirection.None)
-                return Invalid(ctx, "NO_DIRECTION");
+            var longEval = EvaluateSide(ctx, TradeDirection.Long);
+            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
 
-            TradeDirection dir =
-                ctx.ImpulseDirection != TradeDirection.None ? ctx.ImpulseDirection : ctx.TrendDirection;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
 
+        private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
+        {
             int score = 60;
-            bool breakoutDetected = ctx.HasImpulse_M1 || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
-            bool strongCandle = ctx.LastClosedBarInTrendDirection;
-            bool followThrough = breakoutDetected || ctx.IsAtrExpanding_M5;
+            bool directionalImpulse = ctx.ImpulseDirection == dir;
+            bool directionalTrend = ctx.TrendDirection == dir;
+
+            if (!directionalImpulse && !directionalTrend &&
+                (ctx.ImpulseDirection != TradeDirection.None || ctx.TrendDirection != TradeDirection.None))
+            {
+                score -= 18;
+            }
+
+            if (directionalImpulse)
+                score += 10;
+
+            if (directionalTrend)
+                score += 8;
+
+            int lastClosed = ctx.M5.Count - 2;
+            var bar = ctx.M5[lastClosed];
+            bool breakoutDetected =
+                (ctx.HasImpulse_M1 && directionalImpulse) ||
+                (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
+            bool strongCandle =
+                (dir == TradeDirection.Long && bar.Close > bar.Open) ||
+                (dir == TradeDirection.Short && bar.Close < bar.Open);
+            bool followThrough = breakoutDetected || (ctx.IsAtrExpanding_M5 && (directionalImpulse || directionalTrend));
 
             score = TriggerScoreModel.Apply(ctx, $"CRYPTO_IMPULSE_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_IMPULSE_TRIGGER");
+
+            if (score < MinScore)
+                return Invalid(ctx, $"LOW_SCORE_{dir}_{score}", dir, score);
 
             return new EntryEvaluation
             {
@@ -39,11 +67,15 @@ namespace GeminiV26.EntryTypes.Crypto
         }
 
         private EntryEvaluation Invalid(EntryContext ctx, string reason)
+            => Invalid(ctx, reason, TradeDirection.None, 0);
+
+        private EntryEvaluation Invalid(EntryContext ctx, string reason, TradeDirection dir, int score)
             => new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
-                Direction = TradeDirection.None,
+                Direction = dir,
+                Score = score,
                 IsValid = false,
                 Reason = reason
             };

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -22,7 +22,7 @@ namespace GeminiV26.EntryTypes.FX
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
                 return Invalid(ctx, "NO_VALID_SIDE");
 
-            return longEval.Score >= shortEval.Score ? longEval : shortEval;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
         }
 
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -60,9 +60,15 @@ namespace GeminiV26.EntryTypes.FX
 
             // Prefer VALID; if both valid -> higher score wins
             if (buyValid && sellValid)
-                return (longEval.Score >= shortEval.Score) ? longEval : shortEval;
+                return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
 
-            if (buyValid) return longEval;
+            if (buyValid)
+            {
+                EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+                return longEval;
+            }
+
+            EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
             return shortEval;
         }
 

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -29,7 +29,7 @@ namespace GeminiV26.EntryTypes.FX
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
                 return Invalid(ctx, "NO_VALID_SIDE");
 
-            return longEval.Score >= shortEval.Score ? longEval : shortEval;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
         }
 
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -33,7 +33,7 @@ namespace GeminiV26.EntryTypes.FX
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
                 return Invalid(ctx, "NO_VALID_SIDE");
 
-            return longEval.Score >= shortEval.Score ? longEval : shortEval;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
         }
 
         private EntryEvaluation EvaluateSide(

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -29,12 +29,12 @@ namespace GeminiV26.EntryTypes.FX
             var shortEval = EvalForDir(ctx, fx, TradeDirection.Short);
 
             if (longEval.IsValid && shortEval.IsValid)
-                return longEval.Score >= shortEval.Score ? longEval : shortEval;
+                return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
 
             if (longEval.IsValid) return longEval;
             if (shortEval.IsValid) return shortEval;
 
-            return longEval.Score >= shortEval.Score ? longEval : shortEval;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
         }
 
         private static EntryEvaluation EvalForDir(

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -63,7 +63,7 @@ namespace GeminiV26.EntryTypes.FX
                 };
             }
 
-            return longEval.Score >= shortEval.Score ? longEval : shortEval;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
         }
 
         private EntryEvaluation EvaluateSide(

--- a/EntryTypes/FX/FX_RangeBreakoutEntry.cs
+++ b/EntryTypes/FX/FX_RangeBreakoutEntry.cs
@@ -39,38 +39,53 @@ namespace GeminiV26.EntryTypes.FX
                 };
             }
 
+            if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MinRangeBars)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NoRange;"
+                };
+            }
+
+            if (Math.Abs(ctx.Ema21Slope_M5) > MaxSlopeForRange)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "Trending;"
+                };
+            }
+
+            var longEval = EvaluateSide(ctx, TradeDirection.Long);
+            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
+
+        private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
+        {
             var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
-                Direction = TradeDirection.None,
+                Direction = dir,
                 Score = 0,
                 IsValid = false,
                 Reason = ""
             };
 
-            if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MinRangeBars)
-            {
-                eval.Reason += "NoRange;";
-                return eval;
-            }
-
-            if (Math.Abs(ctx.Ema21Slope_M5) > MaxSlopeForRange)
-            {
-                eval.Reason += "Trending;";
-                return eval;
-            }
-
-            if (ctx.RangeBreakDirection == TradeDirection.None)
-            {
-                eval.Reason += "NoBreak;";
-                return eval;
-            }
-
-            eval.Direction = ctx.RangeBreakDirection;
             int score = 20;
 
-            if (ctx.RangeBreakAtrSize_M5 >= MinBreakATR)
+            if (ctx.RangeBreakDirection == dir && ctx.RangeBreakAtrSize_M5 >= MinBreakATR)
                 score += 15;
             else
                 score -= 10;
@@ -80,14 +95,21 @@ namespace GeminiV26.EntryTypes.FX
             else
                 score -= 15;
 
-            bool breakoutDetected = ctx.RangeBreakDirection == eval.Direction;
-            bool strongCandle = ctx.LastClosedBarInTrendDirection;
-            bool followThrough = ctx.M1TriggerInTrendDirection || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
+            int lastClosed = ctx.M5.Count - 2;
+            var bar = ctx.M5[lastClosed];
+            bool breakoutDetected = ctx.RangeBreakDirection == dir;
+            bool strongCandle =
+                (dir == TradeDirection.Long && bar.Close > bar.Open) ||
+                (dir == TradeDirection.Short && bar.Close < bar.Open);
+            bool followThrough = (ctx.RangeBreakDirection == dir && ctx.M1TriggerInTrendDirection) || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
 
             if (ctx.IsAtrExpanding_M5)
                 score += 5;
 
-            score = TriggerScoreModel.Apply(ctx, $"FX_RANGE_BREAKOUT_{eval.Direction}", score, breakoutDetected, strongCandle, followThrough, "NO_RANGE_BREAK_TRIGGER");
+            if (ctx.RangeBreakDirection != dir && ctx.RangeBreakDirection != TradeDirection.None)
+                score -= 10;
+
+            score = TriggerScoreModel.Apply(ctx, $"FX_RANGE_BREAKOUT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_RANGE_BREAK_TRIGGER");
             eval.Score = score;
 
             if (score < MIN_SCORE)

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -31,12 +31,17 @@ namespace GeminiV26.EntryTypes.FX
             if (!fx.MeanReversionFriendly)
                 return Invalid(ctx, "NO_MEAN_REVERSION");
 
-            if (ctx.ReversalDirection == TradeDirection.None)
-                return Invalid(ctx, "NO_DIRECTION");
-
             if (ctx.ReversalEvidenceScore < MIN_EVIDENCE)
                 return Invalid(ctx, "WEAK_EVIDENCE");
 
+            var longEval = EvaluateSide(ctx, TradeDirection.Long);
+            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
+
+        private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
+        {
             int score = 0;
             int setupScore = 0;
 
@@ -69,7 +74,7 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx.FxHtfAllowedDirection != TradeDirection.None &&
                 ctx.FxHtfConfidence01 > 0.0)
             {
-                if (ctx.ReversalDirection != ctx.FxHtfAllowedDirection)
+                if (dir != ctx.FxHtfAllowedDirection)
                 {
                     // Reversal HTF ellen: enyhe büntetés
                     int htfPenalty = (int)(4 + 3 * ctx.FxHtfConfidence01);
@@ -84,11 +89,14 @@ namespace GeminiV26.EntryTypes.FX
             }
 
             double pullbackDepthR =
-                ctx.ReversalDirection == TradeDirection.Long
+                dir == TradeDirection.Long
                     ? ctx.PullbackDepthRLong_M5
                     : ctx.PullbackDepthRShort_M5;
 
-            bool continuationSignal = ctx.M1ReversalTrigger;
+            if (ctx.ReversalDirection == dir)
+                score += 12;
+            else if (ctx.ReversalDirection != TradeDirection.None)
+                score -= 12;
 
             bool hasStructure =
                 pullbackDepthR >= 0.15;
@@ -99,7 +107,7 @@ namespace GeminiV26.EntryTypes.FX
                 setupScore += 15;
 
             bool hasContinuation =
-                continuationSignal;
+                ctx.M1ReversalTrigger;
 
             if (hasContinuation)
                 setupScore += 20;
@@ -108,26 +116,26 @@ namespace GeminiV26.EntryTypes.FX
             var bar = ctx.M5[lastClosed];
             bool breakoutDetected =
                 ctx.M1ReversalTrigger ||
-                (ctx.HasBreakout_M1 && ctx.BreakoutDirection == ctx.ReversalDirection);
+                (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
             bool strongCandle =
-                (ctx.ReversalDirection == TradeDirection.Long && bar.Close > bar.Open) ||
-                (ctx.ReversalDirection == TradeDirection.Short && bar.Close < bar.Open);
-            bool followThrough = continuationSignal || ctx.HasReactionCandle_M5;
+                (dir == TradeDirection.Long && bar.Close > bar.Open) ||
+                (dir == TradeDirection.Short && bar.Close < bar.Open);
+            bool followThrough = ctx.M1ReversalTrigger || ctx.HasReactionCandle_M5;
 
-            score = TriggerScoreModel.Apply(ctx, $"FX_REV_{ctx.ReversalDirection}", score, breakoutDetected, strongCandle, followThrough, "NO_REVERSAL_TRIGGER");
+            score = TriggerScoreModel.Apply(ctx, $"FX_REV_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_REVERSAL_TRIGGER");
             score += setupScore;
 
             if (setupScore <= 0)
                 score = System.Math.Min(score, MIN_SCORE - 10);
 
             var eval = BaseEval(ctx);
-            eval.Direction = ctx.ReversalDirection;
+            eval.Direction = dir;
             eval.Score = score;
-            eval.IsValid = true;
+            eval.IsValid = score >= MIN_SCORE;
 
             eval.Reason =
                 $"FX_REV dir={eval.Direction} score={score} " +
-                $"evid={ctx.ReversalEvidenceScore} m1={ctx.M1ReversalTrigger} " +
+                $"evid={ctx.ReversalEvidenceScore} reversalDir={ctx.ReversalDirection} m1={ctx.M1ReversalTrigger} " +
                 $"range={ctx.IsRange_M5} sess={ctx.Session};";
 
             return eval;

--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -15,25 +15,28 @@ namespace GeminiV26.EntryTypes.INDEX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            int score = 0;
-            int setupScore = 0;
-
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowBreakout)
                 return Reject(ctx, "SESSION_MATRIX_ALLOWBREAKOUT_DISABLED", 0, TradeDirection.None);
 
             if (ctx == null || !ctx.IsReady)
-                return Reject(ctx, "CTX_NOT_READY", score, TradeDirection.None);
+                return Reject(ctx, "CTX_NOT_READY", 0, TradeDirection.None);
 
             var p = IndexInstrumentMatrix.Get(ctx.Symbol);
+            var longEval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
+            var shortEval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
 
-            TradeDirection dir =
-                ctx.BreakoutDirection != TradeDirection.None ? ctx.BreakoutDirection :
-                ctx.RangeBreakDirection != TradeDirection.None ? ctx.RangeBreakDirection :
-                ctx.TrendDirection;
-            if (dir == TradeDirection.None)
-                return Reject(ctx, "NO_BREAKOUT_DIR", score, TradeDirection.None);
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
 
+        private EntryEvaluation EvaluateSide(
+            EntryContext ctx,
+            dynamic p,
+            SessionMatrixConfig matrix,
+            TradeDirection dir)
+        {
+            int score = 0;
+            int setupScore = 0;
             score = BaseScore;
 
             // =============================
@@ -119,6 +122,16 @@ namespace GeminiV26.EntryTypes.INDEX
 
             if (hasContinuation)
                 setupScore += 20;
+
+            if (ctx.BreakoutDirection == dir)
+                score += 8;
+            else if (ctx.BreakoutDirection != TradeDirection.None)
+                score -= 8;
+
+            if (ctx.RangeBreakDirection == dir)
+                score += 6;
+            else if (ctx.RangeBreakDirection != TradeDirection.None)
+                score -= 6;
 
             // =====================================================
             // Core breakout scoring

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -108,7 +108,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 return Reject(ctx, "FLAG_DIRECTION_INVALID", Math.Max(longEval.Score, shortEval.Score), TradeDirection.None);
             }
 
-            return longEval.Score >= shortEval.Score ? longEval : shortEval;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
         }
 
         private EntryEvaluation EvaluateDir(

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -34,7 +34,7 @@ namespace GeminiV26.EntryTypes.INDEX
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
                 return Reject(ctx, TradeDirection.None, Math.Max(longEval?.Score ?? 0, shortEval?.Score ?? 0), "IDX_PULLBACK_NO_SIDE");
 
-            return longEval.Score >= shortEval.Score ? longEval : shortEval;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
         }
 
         private EntryEvaluation EvaluateSide(

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -95,7 +95,7 @@ namespace GeminiV26.EntryTypes.METAL
                     return sell;
             }
 
-            return diff >= 0 ? buy : sell;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, buy, sell);
         }
 
         private EntryEvaluation EvaluateSide(

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -32,35 +32,35 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null)
                 return Reject(ctx, "CTX_NOT_READY");
 
-            int score = 60; // base impulse score
+            var longEval = EvaluateSide(ctx, matrix, TradeDirection.Long);
+            var shortEval = EvaluateSide(ctx, matrix, TradeDirection.Short);
+
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
+
+        private EntryEvaluation EvaluateSide(EntryContext ctx, SessionMatrixConfig matrix, TradeDirection dir)
+        {
+            int score = 60;
             int setupScore = 0;
 
             // =====================================================
-            // 1️⃣ IRÁNY
+            // 1️⃣ DIRECTIONAL CONTEXT
             // =====================================================
-            TradeDirection dir = ResolveXauDirection(ctx);
-            if (dir == TradeDirection.None)
-                return Reject(ctx, "NO_CLEAR_DIRECTION");
+            TradeDirection slopeDirection = ResolveXauDirection(ctx);
+            if (slopeDirection == dir)
+                score += 8;
+            else if (slopeDirection != TradeDirection.None)
+                score -= 8;
 
-            // =====================================================
-            // 2️⃣ ATR EXPANSION
-            // =====================================================
             if (!ctx.IsAtrExpanding_M5)
-                return Reject(ctx, "ATR_NOT_EXPANDING");
+                return Reject(ctx, $"ATR_NOT_EXPANDING_{dir}");
 
             score += 5;
 
-            // =====================================================
-            // 3️⃣ IMPULSE M5
-            // =====================================================
             if (!ctx.HasImpulse_M5)
-                return Reject(ctx, "NO_M5_IMPULSE");
+                return Reject(ctx, $"NO_M5_IMPULSE_{dir}");
 
             score += 5;
-
-            // =====================================================
-            // 4️⃣ ADX FILTER (XAU stricter momentum control)
-            // =====================================================
 
             double minAdxRequired = 18.0;
 
@@ -71,7 +71,7 @@ namespace GeminiV26.EntryTypes.METAL
             minAdxRequired = System.Math.Max(minAdxRequired, matrix.MinAdx);
 
             if (ctx.Adx_M5 < minAdxRequired)
-                return Reject(ctx, $"ADX_TOO_LOW({ctx.Adx_M5:F1})");
+                return Reject(ctx, $"ADX_TOO_LOW_{dir}({ctx.Adx_M5:F1})");
 
             if (ctx.Adx_M5 >= 30)
                 score += 5;
@@ -164,7 +164,7 @@ namespace GeminiV26.EntryTypes.METAL
                 Type = Type,
                 Direction = dir,
                 Score = score,
-                IsValid = true,
+                IsValid = score >= MinScore,
                 Reason = note
             };
         }

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -45,7 +45,7 @@ namespace GeminiV26.EntryTypes.METAL
                     return sell;
             }
 
-            return diff >= 0 ? buy : sell;
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, buy, sell);
         }
 
         private EntryEvaluation EvaluateSide(

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -19,26 +19,23 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null)
                 return Reject(ctx, "CTX_NOT_READY");
 
+            var longEval = EvaluateSide(ctx, TradeDirection.Long);
+            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
+
+        private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
+        {
             var reasons = new List<string>(8);
             int setupScore = 0;
 
-            // =====================================================
-            // 1️⃣ TREND IRÁNY (XAU saját)
-            // =====================================================
             TradeDirection trendDir = ResolveXauDirection(ctx);
             if (trendDir == TradeDirection.None)
-                return Reject(ctx, "NO_TREND_DIR");
-
-            // Reversal irány = trend ellen
-            TradeDirection dir = trendDir == TradeDirection.Long
-                ? TradeDirection.Short
-                : TradeDirection.Long;
+                return Reject(ctx, $"NO_TREND_DIR_{dir}");
 
             reasons.Add($"Trend={trendDir}");
 
-            // =====================================================
-            // 2️⃣ RANGE KÖTELEZŐ
-            // =====================================================
             if (!ctx.IsRange_M5)
                 return RejectDecision(ctx, dir, 0, "NOT_RANGE", reasons);
 
@@ -59,6 +56,11 @@ namespace GeminiV26.EntryTypes.METAL
                 reasons.Add($"WEAK_EVIDENCE({evidence})");
             }
             reasons.Add($"Evidence={evidence}");
+
+            if (trendDir != dir)
+                score += 12;
+            else
+                score -= 12;
 
             // =====================================================
             // 4️⃣ M1 REVERSAL TRIGGER
@@ -141,7 +143,7 @@ namespace GeminiV26.EntryTypes.METAL
                 Type = Type,
                 Direction = dir,
                 Score = score,
-                IsValid = true,
+                IsValid = score >= MinScore,
                 Reason = note
             };
         }

--- a/EntryTypes/TC_FlagEntry.cs
+++ b/EntryTypes/TC_FlagEntry.cs
@@ -27,32 +27,43 @@ namespace GeminiV26.EntryTypes
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            var eval = new EntryEvaluation
+            if (ctx == null || !ctx.IsReady)
             {
-                Symbol = ctx.Symbol,
-                Type = Type,
-                Direction = TradeDirection.None,
-                Score = 0,
-                IsValid = false,
-                Reason = ""
-            };
+                return new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "CTX_NOT_READY;"
+                };
+            }
 
-            int score = 0;
-            int setupScore = 0;
-
-            // =========================================================
-            // 1️⃣ IMPULSE – HARD (M5)
-            // =========================================================
             if (!ctx.HasImpulse_M5)
             {
-                eval.Reason += "NoImpulse;";
-                return eval;
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NoImpulse;"
+                };
             }
 
             if (ctx.M5.Count < ImpulseLookback + 1)
             {
-                eval.Reason += "NotEnoughBars;";
-                return eval;
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NotEnoughBars;"
+                };
             }
 
             double impulseMove =
@@ -62,9 +73,37 @@ namespace GeminiV26.EntryTypes
             // Gyenge impulse kiszűrése
             if (Math.Abs(impulseMove) < ctx.AtrM5 * 0.8)
             {
-                eval.Reason += "WeakImpulse;";
-                return eval;
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "WeakImpulse;"
+                };
             }
+
+            var longEval = EvaluateSide(ctx, impulseMove, TradeDirection.Long);
+            var shortEval = EvaluateSide(ctx, impulseMove, TradeDirection.Short);
+
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
+
+        private EntryEvaluation EvaluateSide(EntryContext ctx, double impulseMove, TradeDirection dir)
+        {
+            var eval = new EntryEvaluation
+            {
+                Symbol = ctx.Symbol,
+                Type = Type,
+                Direction = dir,
+                Score = 0,
+                IsValid = false,
+                Reason = ""
+            };
+
+            int score = 0;
+            int setupScore = 0;
 
             TradeDirection impulseDirection =
                 impulseMove > 0 ? TradeDirection.Long : TradeDirection.Short;
@@ -90,20 +129,15 @@ namespace GeminiV26.EntryTypes
             bool trendUp = ctx.Ema21Slope_M15 > MinSlope;
             bool trendDown = ctx.Ema21Slope_M15 < -MinSlope;
 
-            if (trendUp && impulseDirection == TradeDirection.Long)
+            if ((dir == TradeDirection.Long && trendUp && impulseDirection == dir) ||
+                (dir == TradeDirection.Short && trendDown && impulseDirection == dir))
             {
-                eval.Direction = TradeDirection.Long;
-                score += 25;
-            }
-            else if (trendDown && impulseDirection == TradeDirection.Short)
-            {
-                eval.Direction = TradeDirection.Short;
                 score += 25;
             }
             else
             {
                 eval.Reason += "TrendImpulseMismatch;";
-                return eval;
+                score -= 20;
             }
 
             // =========================================================
@@ -134,7 +168,7 @@ namespace GeminiV26.EntryTypes
                     setupScore += 20;
 
                 bool hasConfirmation =
-                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
+                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
 
                 if (hasConfirmation)
                     setupScore += 20;
@@ -154,7 +188,7 @@ namespace GeminiV26.EntryTypes
                     setupScore += 10;
 
                 bool continuationSignal =
-                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
+                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
                 bool breakoutConfirmed = continuationSignal;
 
                 if (continuationSignal || breakoutConfirmed)
@@ -175,7 +209,7 @@ namespace GeminiV26.EntryTypes
                     setupScore += 15;
 
                 bool continuationSignal =
-                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
+                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
 
                 if (continuationSignal)
                     setupScore += 20;
@@ -183,7 +217,7 @@ namespace GeminiV26.EntryTypes
             else
             {
                 double pullbackDepthR =
-                    eval.Direction == TradeDirection.Short
+                    dir == TradeDirection.Short
                         ? ctx.PullbackDepthRShort_M5
                         : ctx.PullbackDepthRLong_M5;
 
@@ -196,7 +230,7 @@ namespace GeminiV26.EntryTypes
                     setupScore += 15;
 
                 bool continuationSignal =
-                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
+                    ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
 
                 if (continuationSignal)
                     setupScore += 20;
@@ -213,10 +247,14 @@ namespace GeminiV26.EntryTypes
 
             bool breakoutDetected =
                 ctx.M1FlagBreakTrigger ||
-                (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
-            bool strongCandle = ctx.LastClosedBarInTrendDirection;
+                (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
+            int lastClosed = ctx.M5.Count - 2;
+            var bar = ctx.M5[lastClosed];
+            bool strongCandle =
+                (dir == TradeDirection.Long && bar.Close > bar.Open) ||
+                (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = breakoutDetected || ctx.IsAtrExpanding_M5;
-            score = TriggerScoreModel.Apply(ctx, $"TC_FLAG_{eval.Direction}", score, breakoutDetected, strongCandle, followThrough, "NO_FLAG_BREAK_TRIGGER");
+            score = TriggerScoreModel.Apply(ctx, $"TC_FLAG_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_FLAG_BREAK_TRIGGER");
 
             // =========================================================
             // 6️⃣ MIN SCORE – ENTRYTYPE SZINT
@@ -227,7 +265,7 @@ namespace GeminiV26.EntryTypes
                 score = Math.Min(score, MIN_SCORE - 10);
 
             eval.Score = score;
-            eval.IsValid = true;
+            eval.IsValid = score >= MIN_SCORE;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";

--- a/EntryTypes/TC_PullbackEntry.cs
+++ b/EntryTypes/TC_PullbackEntry.cs
@@ -28,6 +28,27 @@ namespace GeminiV26.EntryTypes
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            if (ctx == null || !ctx.IsReady)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "CTX_NOT_READY;"
+                };
+            }
+
+            var longEval = EvaluateDirectional(ctx, TradeDirection.Long);
+            var shortEval = EvaluateDirectional(ctx, TradeDirection.Short);
+
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
+
+        private EntryEvaluation EvaluateDirectional(EntryContext ctx, TradeDirection forcedDirection)
+        {
             var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
@@ -80,17 +101,24 @@ namespace GeminiV26.EntryTypes
                 Math.Abs(ctx.Ema21Slope_M15) > MinSlope * 1.5 &&
                 Math.Abs(ctx.Ema21Slope_M5) > MinSlope;
 
-            if (ctx.Ema21Slope_M15 > 0 && ctx.Ema21Slope_M5 > 0)
+            bool longTrend = ctx.Ema21Slope_M15 > 0 && ctx.Ema21Slope_M5 > 0;
+            bool shortTrend = ctx.Ema21Slope_M15 < 0 && ctx.Ema21Slope_M5 < 0;
+            bool dirTrendOk =
+                forcedDirection == TradeDirection.Long ? longTrend :
+                forcedDirection == TradeDirection.Short ? shortTrend :
+                false;
+
+            eval.Direction = forcedDirection;
+
+            if (dirTrendOk)
             {
-                eval.Direction = TradeDirection.Long;
                 score += strongTrend ? 30 : 20;
             }
-            else if (ctx.Ema21Slope_M15 < 0 && ctx.Ema21Slope_M5 < 0)
+            else
             {
-                eval.Direction = TradeDirection.Short;
-                score += strongTrend ? 30 : 20;
+                score -= 20;
+                eval.Reason += "WeakTrend;";
             }
-            else eval.Reason += "WeakTrend;";
 
             // =========================================================
             // 3️⃣ PULLBACK
@@ -392,12 +420,6 @@ namespace GeminiV26.EntryTypes
             // =========================================================
             // FINAL RULES
             // =========================================================
-            if (eval.Direction == TradeDirection.None)
-            {
-                eval.Reason += "NoDirection;";
-                return eval;
-            }
-
             bool breakoutDetected =
                 !noM1Trigger ||
                 (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
@@ -410,7 +432,7 @@ namespace GeminiV26.EntryTypes
                 score = Math.Min(score, MIN_SCORE - 10);
 
             eval.Score = score;
-            eval.IsValid = true;
+            eval.IsValid = score >= MIN_SCORE;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";

--- a/EntryTypes/TR_ReversalEntry.cs
+++ b/EntryTypes/TR_ReversalEntry.cs
@@ -32,11 +32,45 @@ namespace GeminiV26.EntryTypes
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            if (ctx == null || !ctx.IsReady)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "CTX_NOT_READY;"
+                };
+            }
+
+            if (ctx.ReversalEvidenceScore < MIN_EVIDENCE)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = $"WeakEvidence({ctx.ReversalEvidenceScore});"
+                };
+            }
+
+            var longEval = EvaluateSide(ctx, TradeDirection.Long);
+            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+
+            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+        }
+
+        private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
+        {
             var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
-                Direction = TradeDirection.None,
+                Direction = dir,
                 Score = 0,
                 IsValid = false,
                 Reason = ""
@@ -45,36 +79,13 @@ namespace GeminiV26.EntryTypes
             int score = 0;
             int setupScore = 0;
 
-            // =========================================================
-            // 1️⃣ REVERSAL EVIDENCE (HARD QUALITY GATE)
-            // =========================================================
-            // EvidenceScore egy összegzett kontextus jel:
-            // (pl. divergencia / túlterjedés / SR / momentum gyengülés stb.)
-            if (ctx.ReversalEvidenceScore < MIN_EVIDENCE)
-            {
-                eval.Score = 0;
-                eval.IsValid = false;
-                eval.Reason += $"WeakEvidence({ctx.ReversalEvidenceScore});";
-                return eval;
-            }
-
-            // Evidence pontozás: minél több, annál jobb (de nem végtelen)
-            // 3 = ok, 4-5 = jobb, 6+ = nagyon erős
-            score += ctx.ReversalEvidenceScore * 12; // 3->36, 4->48, 5->60
-
-            // =========================================================
-            // 2️⃣ IRÁNY (HARD RULE)
-            // =========================================================
-            if (ctx.ReversalDirection == TradeDirection.None)
-            {
-                eval.Score = 0;
-                eval.IsValid = false;
-                eval.Reason += "NoDirection;";
-                return eval;
-            }
-
-            eval.Direction = ctx.ReversalDirection;
+            score += ctx.ReversalEvidenceScore * 12;
             score += 20;
+
+            if (ctx.ReversalDirection == dir)
+                score += 12;
+            else if (ctx.ReversalDirection != TradeDirection.None)
+                score -= 12;
 
             // =========================================================
             // 3️⃣ TRIGGER MINŐSÉG (soft, de erős hatás)
@@ -116,7 +127,7 @@ namespace GeminiV26.EntryTypes
             if (instrumentClass == InstrumentClass.METAL)
             {
                 bool hasStructure =
-                    (eval.Direction == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5)
+                    (dir == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5)
                     || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5)
                     || ctx.HasEarlyPullback_M5;
 
@@ -157,7 +168,7 @@ namespace GeminiV26.EntryTypes
                     setupScore -= 30;
 
                 bool hasStructure =
-                    (eval.Direction == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5)
+                    (dir == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5)
                     || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5);
 
                 if (!hasStructure)
@@ -173,7 +184,7 @@ namespace GeminiV26.EntryTypes
             else
             {
                 double pullbackDepthR =
-                    eval.Direction == TradeDirection.Short
+                    dir == TradeDirection.Short
                         ? ctx.PullbackDepthRShort_M5
                         : ctx.PullbackDepthRLong_M5;
 
@@ -191,20 +202,21 @@ namespace GeminiV26.EntryTypes
                     setupScore += 20;
             }
 
-            bool breakoutDetected = ctx.M1ReversalTrigger;
-            bool strongCandle = ctx.LastClosedBarInTrendDirection;
+            int lastClosed = ctx.M5.Count - 2;
+            var bar = ctx.M5[lastClosed];
+            bool breakoutDetected = ctx.M1ReversalTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
+            bool strongCandle =
+                (dir == TradeDirection.Long && bar.Close > bar.Open) ||
+                (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = breakoutDetected || ctx.HasReactionCandle_M5;
-            score = TriggerScoreModel.Apply(ctx, $"TR_REV_{eval.Direction}", score, breakoutDetected, strongCandle, followThrough, "NO_REVERSAL_TRIGGER");
+            score = TriggerScoreModel.Apply(ctx, $"TR_REV_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_REVERSAL_TRIGGER");
             score += setupScore;
 
             if (setupScore <= 0)
                 score = Math.Min(score, MIN_SCORE - 10);
 
-            // =========================================================
-            // 5️⃣ MIN SCORE (EntryType szinten)
-            // =========================================================
             eval.Score = score;
-            eval.IsValid = true;
+            eval.IsValid = score >= MIN_SCORE;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";


### PR DESCRIPTION
### Motivation
- Remove systematic directional bias by ensuring every entry type evaluates both LONG and SHORT candidates instead of one-sided logic. 
- Mirror direction-dependent conditions and normalize penalties so symmetric market structure yields approximately equal scores for long vs short. 
- Provide deterministic tie handling and mandatory score-balance logging to avoid implicit long/short fallbacks.

### Description
- Added `EntryDecisionPolicy.SelectBalancedEvaluation(...)` which compares `longEval` and `shortEval`, forces near-ties to `TradeDirection.None`, and logs a `[SCORE BALANCE]` line including `longScore`, `shortScore`, and `selected` direction. 
- Updated entry modules to always compute both `longEval` and `shortEval` and route selection through `SelectBalancedEvaluation`; affected families include FX, INDEX, METAL, CRYPTO, BR/TC/TR and individual entries such as `FX_FlagEntry`, `FX_PullbackEntry`, `FX_MicroStructureEntry`, `Index_BreakoutEntry`, `XAU_*`, `BTC_*`, etc. 
- Mirrored directional logic inside per-side evaluators so checks, penalties, and bonuses apply symmetrically (e.g., HTF checks, breakout/reversal triggers, pullback depth, strong-candle tests, and setupScore adjustments). 
- Normalized validity and score gates so per-side evaluators return consistent `IsValid` and `Score` behavior and near-equal scores result in `Direction=None` instead of a default side.

### Testing
- Ran `git diff --check` to detect whitespace/patch problems and reported no blocking issues. 
- Executed a repository scan script to ensure every non-empty `*Entry.cs` now calls `SelectBalancedEvaluation` and confirmed no entry files were missed. 
- Ran a brace-balance verification script across changed files to validate syntactic block consistency and it completed successfully. 
- Note: no full C# build or runtime tests were executed in this environment because `dotnet`/`csc` toolchain was not available here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc30a28f9883289c081b1358e71816)