### PR TITLE
Stabilize entry scoring and validity: global regime filter, HTF/logic alignment, and soft-invalid preservation

### DIFF
--- a/Core/Entry/EntryDecisionPolicy.cs
+++ b/Core/Entry/EntryDecisionPolicy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GeminiV26.Core;
 
 namespace GeminiV26.Core.Entry
 {
@@ -54,11 +55,15 @@ namespace GeminiV26.Core.Entry
             ["NO_M1_CONFIRMATION"] = 51,
             ["NO_REACTION"] = 50,
             ["WEAK"] = 50,
+            ["WEAK_STRUCTURE"] = 50,
             ["EARLY_PULLBACK"] = 53,
             ["PULLBACK_TOO_LONG"] = 49,
             ["PB_TOO_LONG"] = 49,
             ["PB_TOO_SHALLOW"] = 50,
             ["PB_TOO_DEEP"] = 49,
+            ["ADX_TOO_LOW"] = 50,
+            ["NO_TRIGGER"] = 51,
+            ["FLAG_NOT_PERFECT"] = 52,
             ["STALE_IMPULSE"] = 50,
             ["IMPULSE_TOO_OLD"] = 50,
             ["NO_PULLBACK"] = 50,
@@ -101,6 +106,9 @@ namespace GeminiV26.Core.Entry
                     eval.Score = Math.Max(eval.Score, ResolveSoftScore(eval.Reason));
                     eval.IsValid = true;
                 }
+
+                if (eval.Score >= MinScoreThreshold)
+                    eval.IsValid = true;
             }
             else if (hardInvalid)
             {
@@ -164,6 +172,9 @@ namespace GeminiV26.Core.Entry
             EntryEvaluation longEval,
             EntryEvaluation shortEval)
         {
+            ApplyGlobalCandidatePolicies(ctx, type, longEval);
+            ApplyGlobalCandidatePolicies(ctx, type, shortEval);
+
             double longScore = Math.Max(0, longEval?.Score ?? 0);
             double shortScore = Math.Max(0, shortEval?.Score ?? 0);
             bool longHardInvalid = IsHardInvalid(longEval);
@@ -205,6 +216,158 @@ namespace GeminiV26.Core.Entry
             Console.WriteLine(balanceLog);
 
             return selectedEval;
+        }
+
+        private static void ApplyGlobalCandidatePolicies(EntryContext ctx, EntryType type, EntryEvaluation eval)
+        {
+            if (ctx == null || eval == null || eval.Direction == TradeDirection.None)
+                return;
+
+            int originalScore = eval.Score;
+            int regimePenalty = 0;
+            int directionPenalty = 0;
+            int rangeBonus = 0;
+            bool trendEntry = IsTrendBased(type);
+            bool rangeEntry = IsRangeBased(type);
+            bool confirmedBreakout = IsDirectionalBreakoutConfirmed(ctx, eval.Direction);
+            bool strongImpulse = IsStrongDirectionalImpulse(ctx, eval.Direction);
+            double minTrendAdx = Math.Max(ctx?.SessionMatrixConfig?.MinAdx ?? 0.0, 18.0);
+            bool rangeDetected = ctx.IsRange_M5;
+            bool noTrend = trendEntry &&
+                           ctx.Adx_M5 < minTrendAdx &&
+                           !strongImpulse &&
+                           !confirmedBreakout;
+
+            if (trendEntry && noTrend)
+                regimePenalty += 25;
+
+            if (ctx.Adx_M5 < 15.0 && rangeDetected)
+            {
+                if (trendEntry)
+                    regimePenalty += 25;
+
+                if (rangeEntry)
+                    rangeBonus += 5;
+            }
+
+            eval.Score -= regimePenalty;
+            eval.Score += rangeBonus;
+
+            ctx.Log?.Invoke(
+                $"[REGIME FILTER] type={type} dir={eval.Direction} adx={ctx.Adx_M5:F1} trendEntry={trendEntry} rangeEntry={rangeEntry} " +
+                $"rangeDetected={rangeDetected} strongImpulse={strongImpulse} confirmedBreakout={confirmedBreakout} penalty={regimePenalty} bonus={rangeBonus} score={originalScore}->{eval.Score}");
+
+            var (htfDirection, htfConfidence) = ResolveHtfBias(ctx);
+            if (htfConfidence >= 0.60 && htfDirection != TradeDirection.None && eval.Direction != htfDirection)
+                directionPenalty += 20;
+
+            if (ctx.LogicBiasDirection != TradeDirection.None && ctx.LogicBiasConfidence >= 60 && eval.Direction != ctx.LogicBiasDirection)
+                directionPenalty += 12;
+
+            eval.Score -= directionPenalty;
+            eval.Score = Math.Max(0, Math.Min(100, eval.Score));
+
+            ctx.Log?.Invoke(
+                $"[DIRECTION ALIGN] type={type} entry={eval.Direction} htf={htfDirection} htfConf={htfConfidence:0.00} " +
+                $"logic={ctx.LogicBiasDirection} logicConf={ctx.LogicBiasConfidence} penalty={directionPenalty} score={originalScore}->{eval.Score}");
+
+            bool hardViolation = IsHardInvalidReason(eval.Reason) || eval.Direction == TradeDirection.None;
+            if (!hardViolation && eval.Score >= MinScoreThreshold)
+                eval.IsValid = true;
+            else if (hardViolation)
+                eval.IsValid = false;
+
+            ctx.Log?.Invoke(
+                $"[VALID CHECK] type={type} dir={eval.Direction} score={eval.Score} hardViolation={hardViolation} finalValid={eval.IsValid}");
+        }
+
+        private static (TradeDirection direction, double confidence) ResolveHtfBias(EntryContext ctx)
+        {
+            if (ctx == null)
+                return (TradeDirection.None, 0.0);
+
+            var instrumentClass = SymbolRouting.ResolveInstrumentClass(ctx.Symbol);
+            switch (instrumentClass)
+            {
+                case InstrumentClass.FX:
+                    return (ctx.FxHtfAllowedDirection, ctx.FxHtfConfidence01);
+                case InstrumentClass.CRYPTO:
+                    return (ctx.CryptoHtfAllowedDirection, ctx.CryptoHtfConfidence01);
+                case InstrumentClass.METAL:
+                    return (ctx.MetalHtfAllowedDirection, ctx.MetalHtfConfidence01);
+                case InstrumentClass.INDEX:
+                    return (ctx.IndexHtfAllowedDirection, ctx.IndexHtfConfidence01);
+                default:
+                    return (TradeDirection.None, 0.0);
+            }
+        }
+
+        private static bool IsTrendBased(EntryType type)
+        {
+            switch (type)
+            {
+                case EntryType.FX_Pullback:
+                case EntryType.FX_Flag:
+                case EntryType.FX_FlagContinuation:
+                case EntryType.FX_MicroContinuation:
+                case EntryType.FX_MicroStructure:
+                case EntryType.FX_ImpulseContinuation:
+                case EntryType.Index_Breakout:
+                case EntryType.Index_Pullback:
+                case EntryType.Index_Flag:
+                case EntryType.XAU_Pullback:
+                case EntryType.XAU_Impulse:
+                case EntryType.XAU_Flag:
+                case EntryType.Crypto_Impulse:
+                case EntryType.Crypto_Flag:
+                case EntryType.Crypto_Pullback:
+                case EntryType.TC_Flag:
+                case EntryType.TC_Pullback:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static bool IsRangeBased(EntryType type)
+        {
+            return type == EntryType.FX_RangeBreakout
+                || type == EntryType.Crypto_RangeBreakout
+                || type == EntryType.BR_RangeBreakout;
+        }
+
+        private static bool IsStrongDirectionalImpulse(EntryContext ctx, TradeDirection direction)
+        {
+            if (ctx == null)
+                return false;
+
+            if (direction == TradeDirection.Long)
+                return ctx.HasImpulseLong_M5 && ctx.BarsSinceImpulseLong_M5 <= 2;
+
+            if (direction == TradeDirection.Short)
+                return ctx.HasImpulseShort_M5 && ctx.BarsSinceImpulseShort_M5 <= 2;
+
+            return false;
+        }
+
+        private static bool IsDirectionalBreakoutConfirmed(EntryContext ctx, TradeDirection direction)
+        {
+            if (ctx == null)
+                return false;
+
+            if (direction == TradeDirection.Long)
+            {
+                return (ctx.HasBreakout_M1 && ctx.BreakoutDirection == TradeDirection.Long)
+                    || ctx.FlagBreakoutUpConfirmed;
+            }
+
+            if (direction == TradeDirection.Short)
+            {
+                return (ctx.HasBreakout_M1 && ctx.BreakoutDirection == TradeDirection.Short)
+                    || ctx.FlagBreakoutDownConfirmed;
+            }
+
+            return false;
         }
 
         private static EntryState ResolveState(EntryEvaluation eval)

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -431,14 +431,12 @@ namespace GeminiV26.EntryTypes.FX
         private EntryEvaluation Block(EntryContext ctx, TradeDirection dir, string reason, int score)
         {
             ctx?.Log?.Invoke($"[FX_PullbackEntry] BLOCK {reason} dir={dir} | score={score}");
-
-            // FIX #2:
-            // invalid eval soha ne hordozzon végrehajtható irányt
+            bool hardInvalid = EntryDecisionPolicy.IsHardInvalidReason(reason) || dir == TradeDirection.None;
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = EntryType.FX_Pullback,
-                Direction = TradeDirection.None,
+                Direction = hardInvalid ? TradeDirection.None : dir,
                 Score = score,
                 IsValid = false,
                 Reason = reason

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -53,12 +53,12 @@ namespace GeminiV26.EntryTypes.METAL
                 score -= 8;
 
             if (!ctx.IsAtrExpanding_M5)
-                return Reject(ctx, $"ATR_NOT_EXPANDING_{dir}");
+                return Reject(ctx, $"ATR_NOT_EXPANDING_{dir}", dir, score);
 
             score += 5;
 
             if (!ctx.HasImpulse_M5)
-                return Reject(ctx, $"NO_M5_IMPULSE_{dir}");
+                return Reject(ctx, $"NO_M5_IMPULSE_{dir}", dir, score);
 
             score += 5;
 
@@ -71,7 +71,7 @@ namespace GeminiV26.EntryTypes.METAL
             minAdxRequired = System.Math.Max(minAdxRequired, matrix.MinAdx);
 
             if (ctx.Adx_M5 < minAdxRequired)
-                return Reject(ctx, $"ADX_TOO_LOW_{dir}({ctx.Adx_M5:F1})");
+                return Reject(ctx, $"ADX_TOO_LOW_{dir}({ctx.Adx_M5:F1})", dir, score);
 
             if (ctx.Adx_M5 >= 30)
                 score += 5;
@@ -201,11 +201,17 @@ namespace GeminiV26.EntryTypes.METAL
         }
 
         private EntryEvaluation Reject(EntryContext ctx, string reason)
+            => Reject(ctx, reason, TradeDirection.None, 0);
+
+        private EntryEvaluation Reject(EntryContext ctx, string reason, TradeDirection dir, int score)
         {
+            bool hardInvalid = EntryDecisionPolicy.IsHardInvalidReason(reason) || dir == TradeDirection.None;
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
+                Direction = hardInvalid ? TradeDirection.None : dir,
+                Score = score,
                 IsValid = false,
                 Reason = $"[XAU_IMPULSE_REJECT] {reason}"
             };


### PR DESCRIPTION
### Motivation
- Prevent trend-based entries from being opened in dead/choppy markets by applying score-only regime penalties instead of hard-blocking candidates.
- Ensure HTF and per-instrument logic bias are enforced as score penalties (expensive but not absolute blocks) so direction aligns with higher-timeframe and logic majority.
- Remove asymmetric directional hard-rejects and hidden blockers so high-score candidates are not silently discarded due to soft checks.
- Keep core decision thresholds and routing unchanged (`MinScoreThreshold = 55`, no changes to `TradeRouter`, `Trigger` system, entry types or trade routing logic). 

### Description
- Added a centralized post-score policy function `ApplyGlobalCandidatePolicies` in `Core/Entry/EntryDecisionPolicy.cs` that is applied to both long and short candidates before balanced selection; it implements regime filtering, HTF/logic alignment penalties, range bonuses, and final validity override logic. 
- Implemented regime filter rules: trend-based entries receive a score penalty (25) when `adx < minTrendAdx` and neither `strongImpulse` nor `confirmedBreakout` are present; additional penalties when `adx < 15 && rangeDetected` and a small bonus for range entries.  All changes are applied as score adjustments (0–100 clamped). 
- Implemented HTF and logic-bias penalties after scoring: if HTF confidence >= 0.60 and the candidate direction disagrees, apply a -20 penalty; if `LogicBiasConfidence >= 60` and direction disagrees, apply ~-12 penalty. 
- Expanded soft-reason score map (`ADX_TOO_LOW`, `NO_TRIGGER`, `FLAG_NOT_PERFECT`, `WEAK_STRUCTURE`, etc.) and changed normalization so non-hard reasons do not permanently set `IsValid=false`: normalized candidates with sufficient score (`>= MinScoreThreshold`) are re-enabled as valid. 
- Added mandatory debug logging for the new policies: `[REGIME FILTER]`, `[DIRECTION ALIGN]`, and `[VALID CHECK]` showing ADX, penalties/bonuses, HTF/logic state and final validity. 
- Preserved side/direction information for soft-invalid candidates in affected evaluators: updated `EntryTypes/FX/FX_PullbackEntry.cs` and `EntryTypes/METAL/XAU_ImpulseEntry.cs` so their blocked/ rejected evaluations retain per-side `Direction` and `Score` when the reason is soft (hard safety violations still clear the direction). 

### Testing
- Ran repository searches to verify injected tokens and logging (`rg -n "MinScoreThreshold = 55|\[REGIME FILTER\]|\[DIRECTION ALIGN\]|\[VALID CHECK\]|ADX_TOO_LOW|NO_TRIGGER|FLAG_NOT_PERFECT|WEAK_STRUCTURE"`) which found the expected changes; this check succeeded.
- Ran `git diff --check` and repository diff/stat to validate the patch format and localized changes; this passed.
- Attempted a full build with `dotnet build`, but `dotnet` is not available in this environment so a compile run could not be completed (build not run here).
- Per-file static inspections and targeted grep/sed checks were executed to confirm policy application points and that `MinScoreThreshold` and router/trigger logic were not modified; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc3a96bfd48328b9a524f2df6c1754)