### PR TITLE
Revert EntryDecisionPolicy interference and restore entry-owned scoring; add router baseline log

### DIFF
--- a/Core/Entry/EntryDecisionPolicy.cs
+++ b/Core/Entry/EntryDecisionPolicy.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using GeminiV26.Core;
 
 namespace GeminiV26.Core.Entry
 {
@@ -55,15 +54,11 @@ namespace GeminiV26.Core.Entry
             ["NO_M1_CONFIRMATION"] = 51,
             ["NO_REACTION"] = 50,
             ["WEAK"] = 50,
-            ["WEAK_STRUCTURE"] = 50,
             ["EARLY_PULLBACK"] = 53,
             ["PULLBACK_TOO_LONG"] = 49,
             ["PB_TOO_LONG"] = 49,
             ["PB_TOO_SHALLOW"] = 50,
             ["PB_TOO_DEEP"] = 49,
-            ["ADX_TOO_LOW"] = 50,
-            ["NO_TRIGGER"] = 51,
-            ["FLAG_NOT_PERFECT"] = 52,
             ["STALE_IMPULSE"] = 50,
             ["IMPULSE_TOO_OLD"] = 50,
             ["NO_PULLBACK"] = 50,
@@ -90,33 +85,7 @@ namespace GeminiV26.Core.Entry
             if (eval == null)
                 return null;
 
-            eval.Score = Math.Max(0, Math.Min(100, eval.Score));
-
-            if (!string.IsNullOrWhiteSpace(eval.Reason) &&
-                eval.Reason.IndexOf("WAIT_BREAKOUT", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                eval.TriggerConfirmed = false;
-            }
-
-            bool hardInvalid = IsHardInvalid(eval);
-            if (!hardInvalid && eval.Direction != TradeDirection.None)
-            {
-                if (!eval.IsValid)
-                {
-                    eval.Score = Math.Max(eval.Score, ResolveSoftScore(eval.Reason));
-                    eval.IsValid = true;
-                }
-
-                if (eval.Score >= MinScoreThreshold)
-                    eval.IsValid = true;
-            }
-            else if (hardInvalid)
-            {
-                eval.IsValid = false;
-            }
-
             eval.State = ResolveState(eval);
-
             return eval;
         }
 
@@ -164,17 +133,12 @@ namespace GeminiV26.Core.Entry
             return MinScoreThreshold - 5;
         }
 
-
-
         public static EntryEvaluation SelectBalancedEvaluation(
             EntryContext ctx,
             EntryType type,
             EntryEvaluation longEval,
             EntryEvaluation shortEval)
         {
-            ApplyGlobalCandidatePolicies(ctx, type, longEval);
-            ApplyGlobalCandidatePolicies(ctx, type, shortEval);
-
             double longScore = Math.Max(0, longEval?.Score ?? 0);
             double shortScore = Math.Max(0, shortEval?.Score ?? 0);
             bool longHardInvalid = IsHardInvalid(longEval);
@@ -216,158 +180,6 @@ namespace GeminiV26.Core.Entry
             Console.WriteLine(balanceLog);
 
             return selectedEval;
-        }
-
-        private static void ApplyGlobalCandidatePolicies(EntryContext ctx, EntryType type, EntryEvaluation eval)
-        {
-            if (ctx == null || eval == null || eval.Direction == TradeDirection.None)
-                return;
-
-            int originalScore = eval.Score;
-            int regimePenalty = 0;
-            int directionPenalty = 0;
-            int rangeBonus = 0;
-            bool trendEntry = IsTrendBased(type);
-            bool rangeEntry = IsRangeBased(type);
-            bool confirmedBreakout = IsDirectionalBreakoutConfirmed(ctx, eval.Direction);
-            bool strongImpulse = IsStrongDirectionalImpulse(ctx, eval.Direction);
-            double minTrendAdx = Math.Max(ctx?.SessionMatrixConfig?.MinAdx ?? 0.0, 18.0);
-            bool rangeDetected = ctx.IsRange_M5;
-            bool noTrend = trendEntry &&
-                           ctx.Adx_M5 < minTrendAdx &&
-                           !strongImpulse &&
-                           !confirmedBreakout;
-
-            if (trendEntry && noTrend)
-                regimePenalty += 25;
-
-            if (ctx.Adx_M5 < 15.0 && rangeDetected)
-            {
-                if (trendEntry)
-                    regimePenalty += 25;
-
-                if (rangeEntry)
-                    rangeBonus += 5;
-            }
-
-            eval.Score -= regimePenalty;
-            eval.Score += rangeBonus;
-
-            ctx.Log?.Invoke(
-                $"[REGIME FILTER] type={type} dir={eval.Direction} adx={ctx.Adx_M5:F1} trendEntry={trendEntry} rangeEntry={rangeEntry} " +
-                $"rangeDetected={rangeDetected} strongImpulse={strongImpulse} confirmedBreakout={confirmedBreakout} penalty={regimePenalty} bonus={rangeBonus} score={originalScore}->{eval.Score}");
-
-            var (htfDirection, htfConfidence) = ResolveHtfBias(ctx);
-            if (htfConfidence >= 0.60 && htfDirection != TradeDirection.None && eval.Direction != htfDirection)
-                directionPenalty += 20;
-
-            if (ctx.LogicBiasDirection != TradeDirection.None && ctx.LogicBiasConfidence >= 60 && eval.Direction != ctx.LogicBiasDirection)
-                directionPenalty += 12;
-
-            eval.Score -= directionPenalty;
-            eval.Score = Math.Max(0, Math.Min(100, eval.Score));
-
-            ctx.Log?.Invoke(
-                $"[DIRECTION ALIGN] type={type} entry={eval.Direction} htf={htfDirection} htfConf={htfConfidence:0.00} " +
-                $"logic={ctx.LogicBiasDirection} logicConf={ctx.LogicBiasConfidence} penalty={directionPenalty} score={originalScore}->{eval.Score}");
-
-            bool hardViolation = IsHardInvalidReason(eval.Reason) || eval.Direction == TradeDirection.None;
-            if (!hardViolation && eval.Score >= MinScoreThreshold)
-                eval.IsValid = true;
-            else if (hardViolation)
-                eval.IsValid = false;
-
-            ctx.Log?.Invoke(
-                $"[VALID CHECK] type={type} dir={eval.Direction} score={eval.Score} hardViolation={hardViolation} finalValid={eval.IsValid}");
-        }
-
-        private static (TradeDirection direction, double confidence) ResolveHtfBias(EntryContext ctx)
-        {
-            if (ctx == null)
-                return (TradeDirection.None, 0.0);
-
-            var instrumentClass = SymbolRouting.ResolveInstrumentClass(ctx.Symbol);
-            switch (instrumentClass)
-            {
-                case InstrumentClass.FX:
-                    return (ctx.FxHtfAllowedDirection, ctx.FxHtfConfidence01);
-                case InstrumentClass.CRYPTO:
-                    return (ctx.CryptoHtfAllowedDirection, ctx.CryptoHtfConfidence01);
-                case InstrumentClass.METAL:
-                    return (ctx.MetalHtfAllowedDirection, ctx.MetalHtfConfidence01);
-                case InstrumentClass.INDEX:
-                    return (ctx.IndexHtfAllowedDirection, ctx.IndexHtfConfidence01);
-                default:
-                    return (TradeDirection.None, 0.0);
-            }
-        }
-
-        private static bool IsTrendBased(EntryType type)
-        {
-            switch (type)
-            {
-                case EntryType.FX_Pullback:
-                case EntryType.FX_Flag:
-                case EntryType.FX_FlagContinuation:
-                case EntryType.FX_MicroContinuation:
-                case EntryType.FX_MicroStructure:
-                case EntryType.FX_ImpulseContinuation:
-                case EntryType.Index_Breakout:
-                case EntryType.Index_Pullback:
-                case EntryType.Index_Flag:
-                case EntryType.XAU_Pullback:
-                case EntryType.XAU_Impulse:
-                case EntryType.XAU_Flag:
-                case EntryType.Crypto_Impulse:
-                case EntryType.Crypto_Flag:
-                case EntryType.Crypto_Pullback:
-                case EntryType.TC_Flag:
-                case EntryType.TC_Pullback:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        private static bool IsRangeBased(EntryType type)
-        {
-            return type == EntryType.FX_RangeBreakout
-                || type == EntryType.Crypto_RangeBreakout
-                || type == EntryType.BR_RangeBreakout;
-        }
-
-        private static bool IsStrongDirectionalImpulse(EntryContext ctx, TradeDirection direction)
-        {
-            if (ctx == null)
-                return false;
-
-            if (direction == TradeDirection.Long)
-                return ctx.HasImpulseLong_M5 && ctx.BarsSinceImpulseLong_M5 <= 2;
-
-            if (direction == TradeDirection.Short)
-                return ctx.HasImpulseShort_M5 && ctx.BarsSinceImpulseShort_M5 <= 2;
-
-            return false;
-        }
-
-        private static bool IsDirectionalBreakoutConfirmed(EntryContext ctx, TradeDirection direction)
-        {
-            if (ctx == null)
-                return false;
-
-            if (direction == TradeDirection.Long)
-            {
-                return (ctx.HasBreakout_M1 && ctx.BreakoutDirection == TradeDirection.Long)
-                    || ctx.FlagBreakoutUpConfirmed;
-            }
-
-            if (direction == TradeDirection.Short)
-            {
-                return (ctx.HasBreakout_M1 && ctx.BreakoutDirection == TradeDirection.Short)
-                    || ctx.FlagBreakoutDownConfirmed;
-            }
-
-            return false;
         }
 
         private static EntryState ResolveState(EntryEvaluation eval)

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -50,7 +50,7 @@ namespace GeminiV26.Core
                 return null;
 
             int nonNullCount = signals.Count(e => e != null);
-            int validCount = signals.Count(e => e != null && e.IsValid && e.Score >= EntryDecisionPolicy.MinScoreThreshold);
+            int validCount = signals.Count(e => e != null && e.IsValid);
 
             _bot.Print($"[TR] evals={signals.Count} nonNull={nonNullCount} valid={validCount} threshold={EntryDecisionPolicy.MinScoreThreshold}");
             LogCandidates("CAND", signals);
@@ -60,12 +60,9 @@ namespace GeminiV26.Core
             foreach (var candidate in signals.Where(e => e != null))
             {
                 string decision;
+                _bot.Print($"[BASELINE CHECK] type={candidate.Type} score={candidate.Score} valid={candidate.IsValid.ToString().ToLowerInvariant()} source=ENTRY_ONLY");
 
                 if (!candidate.IsValid)
-                {
-                    decision = "REJECT";
-                }
-                else if (candidate.Score < EntryDecisionPolicy.MinScoreThreshold)
                 {
                     decision = "REJECT";
                 }

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -15,7 +15,7 @@ namespace GeminiV26.EntryTypes.FX
     {
         public EntryType Type => EntryType.FX_Pullback;
 
-        private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
+        private const int MIN_SCORE = 35;
         private const int ATR_REL_LOOKBACK = 20;
         private const double ATR_REL_EXPANSION_FACTOR = 0.85;
 
@@ -41,16 +41,13 @@ namespace GeminiV26.EntryTypes.FX
             var longEval = EvaluateSide(ctx, fx, matrix, TradeDirection.Long);
             var shortEval = EvaluateSide(ctx, fx, matrix, TradeDirection.Short);
 
-            if (ctx.FxHtfAllowedDirection == TradeDirection.Long)
-                longEval.Score += 3;
+            bool longValid = longEval.IsValid;
+            bool shortValid = shortEval.IsValid;
 
-            if (ctx.FxHtfAllowedDirection == TradeDirection.Short)
-                shortEval.Score += 3;
-
-            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
+            if (!longValid && !shortValid)
             {
                 int bestScore = Math.Max(longEval.Score, shortEval.Score);
-                ctx?.Log?.Invoke($"[FX_PullbackEntry] BOTH_HARD_INVALID long={longEval.Score} short={shortEval.Score}");
+                ctx?.Log?.Invoke($"[FX_PullbackEntry] BOTH_INVALID long={longEval.Score} short={shortEval.Score}");
 
                 return new EntryEvaluation
                 {
@@ -63,7 +60,19 @@ namespace GeminiV26.EntryTypes.FX
                 };
             }
 
-            return EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            if (longValid && shortValid)
+            {
+                if (ctx.FxHtfAllowedDirection == TradeDirection.Long)
+                    longEval.Score += 3;
+
+                if (ctx.FxHtfAllowedDirection == TradeDirection.Short)
+                    shortEval.Score += 3;
+
+                var winner = longEval.Score >= shortEval.Score ? longEval : shortEval;
+                return winner;
+            }
+
+            return longValid ? longEval : shortEval;
         }
 
         private EntryEvaluation EvaluateSide(
@@ -73,7 +82,6 @@ namespace GeminiV26.EntryTypes.FX
             TradeDirection dir)
         {
             int score = 60;
-            int setupScore = 0;
             int penalty = 0;
             int penaltyBudget = 14;
 
@@ -122,26 +130,6 @@ namespace GeminiV26.EntryTypes.FX
             int barsSinceImpulse =
                 dir == TradeDirection.Long ? ctx.BarsSinceImpulseLong_M5 :
                 ctx.BarsSinceImpulseShort_M5;
-
-            // === STRICT PULLBACK VALIDATION ===
-
-            // minimum depth
-            if (pullbackDepth < 0.5)
-            {
-                return Block(ctx, dir, "PB_TOO_SHALLOW", score);
-            }
-
-            // minimum bars
-            if (ctx.PullbackBars_M5 < 3)
-            {
-                return Block(ctx, dir, "PB_TOO_SHORT", score);
-            }
-
-            // EMA touch KÖTELEZŐ (ez volt a nagy hiba eddig)
-            if (!ctx.PullbackTouchedEma21_M5)
-            {
-                return Block(ctx, dir, "PB_NO_EMA21_TOUCH", score);
-            }
 
             if (!hasPullback)
             {
@@ -202,7 +190,7 @@ namespace GeminiV26.EntryTypes.FX
             if (weakCount >= 3 && !hasDirectionalM1Trigger)
             {
                 ctx?.Log?.Invoke($"[PB FILTER] dir={dir} weak structure blocked | weakCount={weakCount}");
-                ApplyPenalty(ref score, ref penalty, 12, penaltyBudget, ctx, "PB_WEAK_STRUCTURE");
+                return Block(ctx, dir, "PB_WEAK_STRUCTURE", score);
             }
 
             if (!ctx.PullbackTouchedEma21_M5)
@@ -245,7 +233,7 @@ namespace GeminiV26.EntryTypes.FX
                 if (!compressionDetected)
                 {
                     ctx.Log?.Invoke($"[PB] dir={dir} rejected: deep pullback without compression");
-                    ApplyPenalty(ref score, ref penalty, 10, penaltyBudget, ctx, "PB_TOO_DEEP_NO_COMPRESSION");
+                    return Block(ctx, dir, "PB_TOO_DEEP", score);
                 }
 
                 TradeDirection impulseDirection =
@@ -258,7 +246,7 @@ namespace GeminiV26.EntryTypes.FX
                 if (!breakoutAligned)
                 {
                     ctx.Log?.Invoke($"[PB] dir={dir} rejected: breakout against impulse");
-                    ApplyPenalty(ref score, ref penalty, 10, penaltyBudget, ctx, "PB_BREAKOUT_AGAINST_IMPULSE");
+                    return Block(ctx, dir, "PB_TOO_DEEP", score);
                 }
 
                 ctx.Log?.Invoke($"[PB] dir={dir} DeepPullbackContinuation accepted");
@@ -321,16 +309,6 @@ namespace GeminiV26.EntryTypes.FX
                 ctx.FxHtfAllowedDirection != TradeDirection.None &&
                 ctx.FxHtfAllowedDirection != dir;
 
-            // === COUNTER-TREND STRICT FILTER ===
-            if (htfMismatch)
-            {
-                // ha trend ellen megyünk, legyen EXTRA szigor
-                if (pullbackDepth < 0.7 || !hasDirectionalM1Trigger)
-                {
-                    return Block(ctx, dir, "HTF_COUNTER_WEAK", score);
-                }
-            }
-
             if (htfMismatch)
             {
                 double conf = ctx.FxHtfConfidence01;
@@ -346,37 +324,11 @@ namespace GeminiV26.EntryTypes.FX
 
             if (penaltyBudget > 0 && penalty > penaltyBudget)
             {
-                ctx?.Log?.Invoke($"[FX_PullbackEntry] BLOCK PENALTY_BUDGET_EXCEEDED {penalty}/{penaltyBudget}");
-                return Block(ctx, dir, "PB_TOO_WEAK", score);
+                int overflow = penalty - penaltyBudget;
+                score -= overflow;
+                ctx?.Log?.Invoke($"[FX_PullbackEntry] SOFT_BUDGET_OVERFLOW -{overflow} | score={score}");
             }
-
-            bool continuationSignal = hasDirectionalM1Trigger;
-
-            bool hasStructure =
-                pullbackDepth >= 0.5;
-
-            if (!hasStructure)
-                setupScore -= 35;
-            else
-                setupScore += 15;
-
-            bool hasContinuation =
-                continuationSignal;
-
-            if (hasContinuation)
-                setupScore += 20;
-
-            bool breakoutDetected =
-                hasDirectionalM1Trigger ||
-                (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
-            bool strongCandle = lastBarInDir;
-            bool followThrough = continuationSignal || ctx.HasReactionCandle_M5;
-            score = TriggerScoreModel.Apply(ctx, $"FX_PULLBACK_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_PULLBACK_TRIGGER");
             score += (int)System.Math.Round(matrix.EntryScoreModifier);
-            score += setupScore;
-
-            if (setupScore <= 0)
-                score = System.Math.Min(score, MIN_SCORE - 10);
 
             if (score < MIN_SCORE)
                 return Block(ctx, dir, $"LOW_SCORE_{score}", score);
@@ -431,12 +383,11 @@ namespace GeminiV26.EntryTypes.FX
         private EntryEvaluation Block(EntryContext ctx, TradeDirection dir, string reason, int score)
         {
             ctx?.Log?.Invoke($"[FX_PullbackEntry] BLOCK {reason} dir={dir} | score={score}");
-            bool hardInvalid = EntryDecisionPolicy.IsHardInvalidReason(reason) || dir == TradeDirection.None;
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = EntryType.FX_Pullback,
-                Direction = hardInvalid ? TradeDirection.None : dir,
+                Direction = TradeDirection.None,
                 Score = score,
                 IsValid = false,
                 Reason = reason

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -53,12 +53,12 @@ namespace GeminiV26.EntryTypes.METAL
                 score -= 8;
 
             if (!ctx.IsAtrExpanding_M5)
-                return Reject(ctx, $"ATR_NOT_EXPANDING_{dir}", dir, score);
+                return Reject(ctx, $"ATR_NOT_EXPANDING_{dir}");
 
             score += 5;
 
             if (!ctx.HasImpulse_M5)
-                return Reject(ctx, $"NO_M5_IMPULSE_{dir}", dir, score);
+                return Reject(ctx, $"NO_M5_IMPULSE_{dir}");
 
             score += 5;
 
@@ -71,7 +71,7 @@ namespace GeminiV26.EntryTypes.METAL
             minAdxRequired = System.Math.Max(minAdxRequired, matrix.MinAdx);
 
             if (ctx.Adx_M5 < minAdxRequired)
-                return Reject(ctx, $"ADX_TOO_LOW_{dir}({ctx.Adx_M5:F1})", dir, score);
+                return Reject(ctx, $"ADX_TOO_LOW_{dir}({ctx.Adx_M5:F1})");
 
             if (ctx.Adx_M5 >= 30)
                 score += 5;
@@ -201,17 +201,11 @@ namespace GeminiV26.EntryTypes.METAL
         }
 
         private EntryEvaluation Reject(EntryContext ctx, string reason)
-            => Reject(ctx, reason, TradeDirection.None, 0);
-
-        private EntryEvaluation Reject(EntryContext ctx, string reason, TradeDirection dir, int score)
         {
-            bool hardInvalid = EntryDecisionPolicy.IsHardInvalidReason(reason) || dir == TradeDirection.None;
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
-                Direction = hardInvalid ? TradeDirection.None : dir,
-                Score = score,
                 IsValid = false,
                 Reason = $"[XAU_IMPULSE_REJECT] {reason}"
             };


### PR DESCRIPTION
### Motivation
- Undo the recent refactor that caused `EntryDecisionPolicy` to modify entry scores, enforce regime/direction penalties and override validity, and restore the original separation of concerns where entries compute score/validity.
- Ensure entries (FX/XAU) again own scoring and valid decisions so no policy layer silently changes entry behavior.
- Provide a short, mandatory baseline debug log in `TradeRouter` to help verify that decisions come from entries only.

### Description
- Restored `Core/Entry/EntryDecisionPolicy.cs` to baseline behavior by removing global candidate policies and any logic that adjusted `Score`/`IsValid`/`Direction`; `Normalize` now only computes `State` (and hard-safety helpers remain available).
- Reverted `EntryTypes/FX/FX_PullbackEntry.cs` to entry-owned flow so the entry computes score and validity, returns `Direction = TradeDirection.None` for invalid blocks, does not rely on policy to adjust score/validity, and returns side winner logic locally.
- Reverted `EntryTypes/METAL/XAU_ImpulseEntry.cs` reject handling so rejected evaluations no longer carry injected score/direction overrides and the entry remains responsible for scoring/validity.
- Updated `Core/TradeRouter.cs` to keep router selection strictly based on entry-provided `IsValid` and added the temporary `[BASELINE CHECK]` debug print line (`source=ENTRY_ONLY`) to log `type`, `score`, and `valid` for each candidate.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues and it passed.
- Executed a repository verification Python script that validates the reverted policy/entry conditions and presence of the router baseline log, and all checks returned success.
- No full build/test was executed because there is no solution/project file in the repository root to run a native CI build, so no compiled test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc3d98e05883288ad66c0a65d464ee)