### PR TITLE
Enforce HTF, logic-bias and low-ADX score adjustments across all entry modules

### DIFF
--- a/EntryTypes/BR_RangeBreakoutEntry.cs
+++ b/EntryTypes/BR_RangeBreakoutEntry.cs
@@ -1,4 +1,4 @@
-﻿// =========================================================
+// =========================================================
 // GEMINI V26 – BR_RangeBreakoutEntry (Quality + Format pass)
 // Rulebook 1.0 compliant EntryType
 //
@@ -275,6 +275,7 @@ namespace GeminiV26.EntryTypes
                 (dir == TradeDirection.Long && bar.Close > bar.Open) ||
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = ctx.M1TriggerInTrendDirection || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
             score = TriggerScoreModel.Apply(ctx, $"BR_RANGE_BREAKOUT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_RANGE_BREAK_TRIGGER");
 
             // =========================================================
@@ -293,5 +294,58 @@ namespace GeminiV26.EntryTypes
 
             return eval;
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -1,4 +1,5 @@
-﻿using cAlgo.API;
+using cAlgo.API;
+using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using System;
 
@@ -270,6 +271,7 @@ namespace GeminiV26.EntryTypes.Crypto
                     $"symbol={ctx.Symbol} entry={EntryType.Crypto_Flag} penalty=6 score={score}");
             }
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score += setupScore;
 
             bool followThrough = continuationSignal;
@@ -335,5 +337,58 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = false,
                 Reason = reason
             };
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.EntryTypes.Crypto;
@@ -853,6 +853,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
             bool strongCandle = ctx.LastClosedBarInTrendDirection;
             bool followThrough = continuationSignal || validPullbackReaction;
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score = TriggerScoreModel.Apply(ctx, $"BTC_PULLBACK_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_PULLBACK_TRIGGER");
             score += setupScore;
 
@@ -890,5 +891,58 @@ namespace GeminiV26.EntryTypes.Crypto
                 Reason = reason
             };
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -1,4 +1,5 @@
-﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Entry;
+using GeminiV26.Core;
 
 namespace GeminiV26.EntryTypes.Crypto
 {
@@ -107,6 +108,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 (dir == TradeDirection.Long && bar.Close > bar.Open) ||
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = ctx.M1TriggerInTrendDirection || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
             score = TriggerScoreModel.Apply(ctx, $"BTC_RANGE_BREAKOUT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_RANGE_BREAK_TRIGGER");
             score += setupScore;
 
@@ -139,5 +141,58 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = false,
                 Reason = reason + ";"
             };
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -1,4 +1,5 @@
-﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Entry;
+using GeminiV26.Core;
 using System;
 
 namespace GeminiV26.EntryTypes.Crypto
@@ -50,6 +51,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = breakoutDetected || (ctx.IsAtrExpanding_M5 && (directionalImpulse || directionalTrend));
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score = TriggerScoreModel.Apply(ctx, $"CRYPTO_IMPULSE_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_IMPULSE_TRIGGER");
 
             if (score < MinScore)
@@ -79,5 +81,58 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = false,
                 Reason = reason
             };
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -1,4 +1,5 @@
-﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Entry;
+using GeminiV26.Core;
 using GeminiV26.Instruments.FX;
 
 namespace GeminiV26.EntryTypes.FX
@@ -106,6 +107,7 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx.IsRange_M5)
                 score -= 10;
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score = TriggerScoreModel.Apply(ctx, $"FX_FLAG_CONT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_M1_CONFIRM");
             score += setupScore;
 
@@ -145,5 +147,58 @@ namespace GeminiV26.EntryTypes.FX
                 IsValid = false,
                 Reason = reason
             };
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -1,4 +1,4 @@
-﻿// =========================================================
+// =========================================================
 // FX_FlagEntry – Phase 3.9 PATCH (Two-direction true search)
 // Goal: KEEP EVERYTHING (score system, ATR/ADX gates, penalties, boosts, etc.)
 // Change ONLY:
@@ -155,7 +155,7 @@ namespace GeminiV26.EntryTypes.FX
                     score >= (EntryDecisionPolicy.MinScoreThreshold + 6) &&
                     !ctx.IsRange_M5;
 
-                if (adxNow < hardFloor - 2)
+                if (adxNow >= 15.0 && adxNow < hardFloor - 2)
                 {
                     if (!strongContextForAdx)
                         return Invalid(ctx, flagDir, $"VERY_LOW_ADX {adxNow:F1}<{hardFloor - 2:F1}", score);
@@ -957,6 +957,7 @@ namespace GeminiV26.EntryTypes.FX
 
             if (min < 0) min = 0;
 
+            score = ApplyMandatoryEntryAdjustments(ctx, flagDir, score, true);
             score += setupScore;
 
             bool breakoutDetected = breakoutConfirmed || breakout;
@@ -1182,5 +1183,58 @@ namespace GeminiV26.EntryTypes.FX
             if (eval == null || matrix == null) return;
             eval.Score += (int)System.Math.Round(matrix.EntryScoreModifier);
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -1,4 +1,5 @@
-﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Entry;
+using GeminiV26.Core;
 using GeminiV26.Instruments.FX;
 
 namespace GeminiV26.EntryTypes.FX
@@ -75,7 +76,7 @@ namespace GeminiV26.EntryTypes.FX
             // =====================================================
             // IMPULSE CONDITIONS (REAL CONTEXT FIELDS)
             // =====================================================
-            if (ctx.Adx_M5 < 22)
+            if (ctx.Adx_M5 >= 15 && ctx.Adx_M5 < 22)
                 return Invalid(ctx, dir, "WeakTrend", 50);
 
             if (!hasImpulse)
@@ -124,6 +125,7 @@ namespace GeminiV26.EntryTypes.FX
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = continuationSignal || (ctx.LastClosedBarInTrendDirection && ctx.HasReactionCandle_M5);
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score = TriggerScoreModel.Apply(ctx, $"FX_IMPULSE_CONT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_CONTINUATION_SIGNAL");
             score += setupScore;
 
@@ -166,5 +168,58 @@ namespace GeminiV26.EntryTypes.FX
                 IsValid = false,
                 Reason = reason
             };
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
@@ -120,6 +120,7 @@ namespace GeminiV26.EntryTypes.FX
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = continuationSignal;
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score = TriggerScoreModel.Apply(ctx, $"FX_MICRO_CONT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_CONTINUATION_SIGNAL");
             score += setupScore;
 
@@ -159,5 +160,58 @@ namespace GeminiV26.EntryTypes.FX
                 IsValid = false,
                 Reason = reason
             };
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
@@ -188,7 +188,7 @@ namespace GeminiV26.EntryTypes.FX
             if (TryGetDouble(ctx, "Adx_M5", out var adx))
             {
                 if (adx < 14)
-                    return Invalid(ctx, dir, $"ADX_TOO_LOW {adx:F1}", score);
+                    score -= 6;
 
                 if (adx > 28)
                     score += 2;
@@ -200,6 +200,7 @@ namespace GeminiV26.EntryTypes.FX
 
             int minScore = EntryDecisionPolicy.MinScoreThreshold;
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
             score += setupScore;
 
             score += (int)Math.Round(triggerScore * 5);
@@ -319,5 +320,58 @@ namespace GeminiV26.EntryTypes.FX
                 return false;
             }
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Matrix;
@@ -139,7 +139,7 @@ namespace GeminiV26.EntryTypes.FX
             double dynamicMinAdx = (ctx.Session == FxSession.Asia) ? 18.0 : 20.0;
             dynamicMinAdx = System.Math.Max(dynamicMinAdx, matrix.MinAdx);
 
-            if (ctx.Adx_M5 < dynamicMinAdx)
+            if (ctx.Adx_M5 >= 15 && ctx.Adx_M5 < dynamicMinAdx)
                 return Block(ctx, dir, $"ADX_TOO_LOW_{ctx.Adx_M5:0.0}", score);
 
             if (ctx.Adx_M5 < 23.0)
@@ -328,6 +328,7 @@ namespace GeminiV26.EntryTypes.FX
                 score -= overflow;
                 ctx?.Log?.Invoke($"[FX_PullbackEntry] SOFT_BUDGET_OVERFLOW -{overflow} | score={score}");
             }
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score += (int)System.Math.Round(matrix.EntryScoreModifier);
 
             if (score < MIN_SCORE)
@@ -415,5 +416,58 @@ namespace GeminiV26.EntryTypes.FX
 
             return trSum / lookback;
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/FX/FX_RangeBreakoutEntry.cs
+++ b/EntryTypes/FX/FX_RangeBreakoutEntry.cs
@@ -1,4 +1,5 @@
-﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Entry;
+using GeminiV26.Core;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.FX;
 using System;
@@ -109,6 +110,7 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx.RangeBreakDirection != dir && ctx.RangeBreakDirection != TradeDirection.None)
                 score -= 10;
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
             score = TriggerScoreModel.Apply(ctx, $"FX_RANGE_BREAKOUT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_RANGE_BREAK_TRIGGER");
             eval.Score = score;
 
@@ -124,5 +126,58 @@ namespace GeminiV26.EntryTypes.FX
 
             return eval;
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -1,4 +1,4 @@
-﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Entry;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core;
 
@@ -122,6 +122,7 @@ namespace GeminiV26.EntryTypes.FX
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = ctx.M1ReversalTrigger || ctx.HasReactionCandle_M5;
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
             score = TriggerScoreModel.Apply(ctx, $"FX_REV_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_REVERSAL_TRIGGER");
             score += setupScore;
 
@@ -160,5 +161,58 @@ namespace GeminiV26.EntryTypes.FX
                 IsValid = false,
                 Reason = reason
             };
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -1,4 +1,5 @@
-﻿using cAlgo.API;
+using cAlgo.API;
+using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.INDEX;
@@ -183,6 +184,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = continuationSignal || (ctx.IsAtrExpanding_M5 && freshImpulse);
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
             score = TriggerScoreModel.Apply(ctx, $"IDX_BREAKOUT_{dir}", score, breakoutConfirmed, strongCandle, followThrough, "NO_BREAKOUT_M1");
 
             score += (int)Math.Round(matrix.EntryScoreModifier);
@@ -237,5 +239,58 @@ namespace GeminiV26.EntryTypes.INDEX
                 Reason = reason
             };
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -1,4 +1,5 @@
-﻿using cAlgo.API;
+using cAlgo.API;
+using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.INDEX;
@@ -199,11 +200,11 @@ namespace GeminiV26.EntryTypes.INDEX
             if (ctx.MarketState?.IsLowVol == true)
                 return Reject(ctx, "LOW_VOL_ENV", score, dir);
 
-            if (ctx.Adx_M5 < minAdxTrend)
+            if (ctx.Adx_M5 >= 15 && ctx.Adx_M5 < minAdxTrend)
                 return Reject(ctx, $"ADX_TOO_LOW({ctx.Adx_M5:F1}<{minAdxTrend:F1})", score, dir);
 
             bool chopZone =
-                ctx.Adx_M5 < chopAdxThreshold &&
+                ctx.Adx_M5 >= 15 && ctx.Adx_M5 < chopAdxThreshold &&
                 Math.Abs(ctx.PlusDI_M5 - ctx.MinusDI_M5) < chopDiDiff &&
                 !ctx.IsAtrExpanding_M5;
                 
@@ -507,6 +508,7 @@ namespace GeminiV26.EntryTypes.INDEX
                     $"symbol={ctx.Symbol} entry={Type} penalty=6 score={score}");
             }
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score += setupScore;
 
             bool breakoutDetected = breakoutConfirmed;
@@ -635,5 +637,58 @@ namespace GeminiV26.EntryTypes.INDEX
                 Reason = reason
             };
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -1,4 +1,5 @@
-﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Entry;
+using GeminiV26.Core;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.INDEX;
 using System;
@@ -264,6 +265,7 @@ namespace GeminiV26.EntryTypes.INDEX
             bool breakoutDetected = breakoutConfirmed || ctx.RangeBreakDirection == dir;
             bool strongCandle = lastBarInDir;
             bool followThrough = continuationSignal || ctx.HasReactionCandle_M5;
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score = TriggerScoreModel.Apply(ctx, $"IDX_PULLBACK_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_PULLBACK_TRIGGER");
             score += setupScore;
 
@@ -335,5 +337,58 @@ namespace GeminiV26.EntryTypes.INDEX
 
             return false;
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
@@ -318,6 +318,7 @@ namespace GeminiV26.EntryTypes.METAL
             if (dir == TradeDirection.Short && IsHigherLow(ctx.M5, index))
                 return InvalidDir(ctx, dir, "HIGHER_LOW", score);
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score += setupScore;
 
             bool breakoutDetected = breakoutConfirmed || earlyBreakout;
@@ -434,5 +435,58 @@ namespace GeminiV26.EntryTypes.METAL
                 Reason = reason
             };
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -1,4 +1,4 @@
-﻿using GeminiV26.Core.Entry;
+using GeminiV26.Core.Entry;
 using GeminiV26.Core;
 using GeminiV26.Core.Matrix;
 
@@ -70,7 +70,7 @@ namespace GeminiV26.EntryTypes.METAL
 
             minAdxRequired = System.Math.Max(minAdxRequired, matrix.MinAdx);
 
-            if (ctx.Adx_M5 < minAdxRequired)
+            if (ctx.Adx_M5 >= 15 && ctx.Adx_M5 < minAdxRequired)
                 return Reject(ctx, $"ADX_TOO_LOW_{dir}({ctx.Adx_M5:F1})");
 
             if (ctx.Adx_M5 >= 30)
@@ -142,6 +142,7 @@ namespace GeminiV26.EntryTypes.METAL
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = hasConfirmation;
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score = TriggerScoreModel.Apply(ctx, $"XAU_IMPULSE_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_IMPULSE_TRIGGER");
 
             // =====================================================
@@ -210,5 +211,58 @@ namespace GeminiV26.EntryTypes.METAL
                 Reason = $"[XAU_IMPULSE_REJECT] {reason}"
             };
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using GeminiV26.Core;
 using System.Collections.Generic;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Matrix;
@@ -261,6 +262,7 @@ namespace GeminiV26.EntryTypes.METAL
             // =========================
             // FINAL
             // =========================
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score = TriggerScoreModel.Apply(ctx, $"XAU_PULLBACK_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_PULLBACK_TRIGGER");
             score += (int)Math.Round(matrix.EntryScoreModifier);
             score += setupScore;
@@ -330,5 +332,58 @@ namespace GeminiV26.EntryTypes.METAL
                 Reason = reason
             };
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using GeminiV26.Core;
 using System.Collections.Generic;
 using GeminiV26.Core.Entry;
 
@@ -120,6 +121,7 @@ namespace GeminiV26.EntryTypes.METAL
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = hasConfirmation;
 
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
             score = TriggerScoreModel.Apply(ctx, $"XAU_REV_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_REVERSAL_TRIGGER");
             score += setupScore;
 
@@ -212,5 +214,58 @@ namespace GeminiV26.EntryTypes.METAL
                 Reason = note
             };
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/TC_FlagEntry.cs
+++ b/EntryTypes/TC_FlagEntry.cs
@@ -1,4 +1,4 @@
-﻿// =========================================================
+// =========================================================
 // GEMINI V26 – TC_FlagEntry (STRICT FLAG VERSION)
 // Rulebook 1.0 compliant EntryType
 //
@@ -254,6 +254,7 @@ namespace GeminiV26.EntryTypes
                 (dir == TradeDirection.Long && bar.Close > bar.Open) ||
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = breakoutDetected || ctx.IsAtrExpanding_M5;
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score = TriggerScoreModel.Apply(ctx, $"TC_FLAG_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_FLAG_BREAK_TRIGGER");
 
             // =========================================================
@@ -272,5 +273,58 @@ namespace GeminiV26.EntryTypes
 
             return eval;
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/TC_PullbackEntry.cs
+++ b/EntryTypes/TC_PullbackEntry.cs
@@ -1,4 +1,4 @@
-﻿// =========================================================
+// =========================================================
 // GEMINI V26 – TC_PullbackEntry
 // Rulebook 1.0 compliant EntryType
 // =========================================================
@@ -425,6 +425,7 @@ namespace GeminiV26.EntryTypes
                 (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
             bool strongCandle = ctx.LastClosedBarInTrendDirection;
             bool followThrough = breakoutDetected || ctx.HasReactionCandle_M5;
+            score = ApplyMandatoryEntryAdjustments(ctx, eval.Direction, score, true);
             score = TriggerScoreModel.Apply(ctx, $"TC_PULLBACK_{eval.Direction}", score, breakoutDetected, strongCandle, followThrough, "NO_PULLBACK_TRIGGER");
             score += setupScore;
 
@@ -516,5 +517,58 @@ namespace GeminiV26.EntryTypes
                 // ❗ SOHA nem akadályozhatja a trade-et
             }
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }

--- a/EntryTypes/TR_ReversalEntry.cs
+++ b/EntryTypes/TR_ReversalEntry.cs
@@ -1,4 +1,4 @@
-﻿// =========================================================
+// =========================================================
 // GEMINI V26 – TR_ReversalEntry (Quality + Format pass)
 // Rulebook 1.0 compliant EntryType
 //
@@ -209,6 +209,7 @@ namespace GeminiV26.EntryTypes
                 (dir == TradeDirection.Long && bar.Close > bar.Open) ||
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = breakoutDetected || ctx.HasReactionCandle_M5;
+            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
             score = TriggerScoreModel.Apply(ctx, $"TR_REV_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_REVERSAL_TRIGGER");
             score += setupScore;
 
@@ -223,5 +224,58 @@ namespace GeminiV26.EntryTypes
 
             return eval;
         }
+
+        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
+        {
+            const int htfPenalty = 30;
+            const int logicPenalty = 12;
+            const int rangePenalty = 25;
+
+            TradeDirection htfDirection = TradeDirection.None;
+            double htfConfidence = 0.0;
+
+            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
+            {
+                score -= htfPenalty;
+                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
+            {
+                score -= logicPenalty;
+                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
+            }
+
+            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
+            {
+                score -= rangePenalty;
+                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
+            }
+
+            return score;
+        }
+
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure consistent direction/regime behavior across all entry modules by applying score-only penalties for HTF misalignment, logic-bias mismatch, and low-ADX regime, while keeping all changes localized to entry modules only.
- Preserve existing decision policy semantics and runtime flow by not changing `EntryDecisionPolicy`, `TradeRouter`, or adding any global/shared logic.

### Description

- Added a per-entry helper `ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)` into each `IEntryType` implementation and called it after base scoring and before final trigger/score adjustments so both long and short sides are adjusted symmetrically; the helper applies: HTF mismatch penalty (30) when HTF confidence >= 0.7, logic-bias mismatch penalty (12) when logic confidence >= 60, and an ADX regime penalty (25) when `applyTrendRegimePenalty` is true and `ctx.Adx_M5 < 15.0`, and logs every application with the required tags (`[ENTRY HTF ALIGN]`, `[ENTRY LOGIC ALIGN]`, `[ENTRY REGIME]`).
- Inserted the adjustment call at the canonical post-setup/pre-trigger point in every entry evaluation so `longEval` and `shortEval` both call `ApplyMandatoryEntryAdjustments` (symmetry requirement satisfied) and no `valid=false`/hard rejections were introduced by these rules.
- Softened a few pre-existing hard ADX gates to let low-ADX (<15) pass into scoring so the new score-only regime penalty can take effect (examples: `FX_FlagEntry`, `FX_PullbackEntry`, `FX_ImpulseContinuationEntry`, `Index_FlagEntry`, `XAU_ImpulseEntry`, `FX_MicroStructureEntry`).
- Changes applied to 23 entry modules under `EntryTypes/` (examples): `BR_RangeBreakoutEntry.cs`, `CRYPTO/*` (BTC_* and Crypto_Impulse), `FX/*` (Flag, Pullback, ImpulseContinuation, MicroStructure, RangeBreakout, Reversal, etc.), `INDEX/*`, `METAL/*` (XAU_*), `TC_*`, and `TR_ReversalEntry.cs`.

### Testing

- Ran `git diff --check` to ensure there are no whitespace/patch errors and the check passed.
- Ran repository validation scripts that verify every entry `*.cs` contains `ApplyMandatoryEntryAdjustments` and the required log tags, and confirmed all 23 entry modules include the helper and logs (`entry_count 23`, `missing 0`).
- Ran a focused check that the subset of trend-type entries include the ADX regime condition (`applyTrendRegimePenalty && ctx.Adx_M5 < 15.0`) and confirmed presence for the expected modules (zero missing entries reported).
- Note: there is no solution/project file in the tree so no full compile/unit test run was available in-repo; automated textual and structural checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc42bb9e9083288c8f4ce112a048b7)