### PR TITLE
Throttle TTM/Exit logs: state-change guards for TP2, trailing, runner and profile

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -362,6 +362,26 @@ namespace GeminiV26.Core
 
         public double? LastTrailingStopTarget { get; set; }
 
+        public string LastTp2LogState { get; set; } = string.Empty;
+
+        public double? LastTp2LogValue { get; set; }
+
+        public string LastTp2ExtensionLogState { get; set; } = string.Empty;
+
+        public double? LastTp2ExtensionLogValue { get; set; }
+
+        public bool RunnerActivationLogged { get; set; }
+
+        public string LastProfileLogBucket { get; set; } = string.Empty;
+
+        public bool? LastTtmAllowTp2Extension { get; set; }
+
+        public double? LastTtmTp2Multiplier { get; set; }
+
+        public bool LoggedNoImprovement { get; set; }
+
+        public bool LoggedNoStructure { get; set; }
+
         public bool MarketTrend { get; set; }
 
         public double Adx_M5 { get; set; }

--- a/Core/TradeManagement/AdaptiveTrailingEngine.cs
+++ b/Core/TradeManagement/AdaptiveTrailingEngine.cs
@@ -8,6 +8,7 @@ namespace GeminiV26.Core.TradeManagement
 {
     public sealed class AdaptiveTrailingEngine
     {
+        private const double LogEpsilon = 0.0001;
         private readonly Robot _bot;
         private readonly AverageTrueRange _atr;
 
@@ -39,6 +40,9 @@ namespace GeminiV26.Core.TradeManagement
             string trailMode = "FALLBACK";
             string reason = string.Empty;
             bool valid = false;
+            string structureLog = null;
+            string fallbackVolatilityLog = null;
+            string fallbackLog = null;
             bool forceFallback = ctx.Tp1Hit
                 && !ctx.LastTrailingStopTarget.HasValue
                 && ctx.BarsSinceEntryM5 >= profile.ForceVolatilityTrailAfterBars;
@@ -50,7 +54,7 @@ namespace GeminiV26.Core.TradeManagement
                 {
                     trailMode = "STRUCTURE";
                     reason = $"structure_anchor barsAgo={anchorBarsAgo}";
-                    _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=STRUCTURE slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason={reason}");
+                    structureLog = $"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=STRUCTURE slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason={reason}";
                 }
                 else
                 {
@@ -67,8 +71,8 @@ namespace GeminiV26.Core.TradeManagement
                 BuildVolatilityStop(isLong, profile, atr, decision.SlAtrMultiplier, out newSl, out string regime, out double multiplier);
                 trailMode = "VOLATILITY_FALLBACK";
                 reason = string.IsNullOrWhiteSpace(reason) ? $"fallback regime={regime}" : $"{reason} regime={regime}";
-                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=VOLATILITY_FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason={reason} multiplier={multiplier:0.00}");
-                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason={reason}");
+                fallbackVolatilityLog = $"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=VOLATILITY_FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason={reason} multiplier={multiplier:0.00}";
+                fallbackLog = $"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason={reason}";
             }
 
             if (trailMode == "VOLATILITY_FALLBACK")
@@ -105,19 +109,24 @@ namespace GeminiV26.Core.TradeManagement
                 }
 
                 fallbackSl = Normalize(fallbackSl);
-                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=VOLATILITY_FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(fallbackSl)} tp={FormatPrice(pos.TakeProfit)} reason=structure_static regime={fallbackRegime} multiplier={fallbackMultiplier:0.00}");
-                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(fallbackSl)} tp={FormatPrice(pos.TakeProfit)} reason=structure_static");
+                fallbackVolatilityLog = $"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=VOLATILITY_FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(fallbackSl)} tp={FormatPrice(pos.TakeProfit)} reason=structure_static regime={fallbackRegime} multiplier={fallbackMultiplier:0.00}";
+                fallbackLog = $"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(fallbackSl)} tp={FormatPrice(pos.TakeProfit)} reason=structure_static";
 
                 if (ImprovesStop(isLong, fallbackSl, oldSl))
                 {
                     newSl = fallbackSl;
                     trailMode = "VOLATILITY_FALLBACK";
+                    structureLog = null;
                 }
             }
 
             if (!ImprovesStop(isLong, newSl, oldSl))
             {
-                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=no_improvement");
+                if (!ctx.LoggedNoImprovement)
+                {
+                    ctx.LoggedNoImprovement = true;
+                    _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=no_improvement");
+                }
                 return;
             }
 
@@ -133,6 +142,10 @@ namespace GeminiV26.Core.TradeManagement
                 _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=duplicate_target");
                 return;
             }
+
+            TryLogTrailCandidate(ctx, reason, structureLog, oldSl, newSl, isLong);
+            TryLogTrailCandidate(ctx, reason, fallbackVolatilityLog, oldSl, newSl, isLong);
+            TryLogTrailCandidate(ctx, reason, fallbackLog, oldSl, newSl, isLong);
 
             var result = _bot.ModifyPosition(pos, newSl, pos.TakeProfit);
 
@@ -240,6 +253,28 @@ namespace GeminiV26.Core.TradeManagement
             return isLong
                 ? candidate > current
                 : candidate < current;
+        }
+
+        private bool CanLogTrailChange(bool isLong, double oldSl, double candidateSl)
+        {
+            return ImprovesStop(isLong, candidateSl, oldSl) &&
+                   Math.Abs(candidateSl - oldSl) >= Math.Max(LogEpsilon, _bot.Symbol.TickSize);
+        }
+
+        private void TryLogTrailCandidate(PositionContext ctx, string reason, string message, double oldSl, double candidateSl, bool isLong)
+        {
+            if (string.IsNullOrWhiteSpace(message) || !CanLogTrailChange(isLong, oldSl, candidateSl))
+                return;
+
+            if (reason.Contains("no_structure_anchor", StringComparison.Ordinal))
+            {
+                if (ctx.LoggedNoStructure)
+                    return;
+
+                ctx.LoggedNoStructure = true;
+            }
+
+            _bot.Print(message);
         }
 
         private double Normalize(double price)

--- a/Core/TradeManagement/TrendTradeManager.cs
+++ b/Core/TradeManagement/TrendTradeManager.cs
@@ -34,6 +34,7 @@ namespace GeminiV26.Core.TradeManagement
 
     public sealed class TrendTradeManager
     {
+        private const double LogEpsilon = 0.0001;
         private readonly Robot _bot;
         private readonly AverageTrueRange _atr;
         private readonly ExponentialMovingAverage _ema21;
@@ -73,8 +74,12 @@ namespace GeminiV26.Core.TradeManagement
             bool isRunner = ctx.Tp1Hit;
             if (isRunner)
             {
-                _bot.Print($"[TTM] Runner mode activated.");
-                _bot.Print($"[TTM][RUNNER] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} pos={position.Id} sl={FormatPrice(position.StopLoss)} tp={FormatPrice(position.TakeProfit)} reason=tp1_hit");
+                if (!ctx.RunnerActivationLogged)
+                {
+                    ctx.RunnerActivationLogged = true;
+                    _bot.Print($"[TTM] Runner mode activated.");
+                    _bot.Print($"[TTM][RUNNER] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} pos={position.Id} sl={FormatPrice(position.StopLoss)} tp={FormatPrice(position.TakeProfit)} reason=tp1_hit");
+                }
             }
 
             double priceNow = isLong ? _bot.Symbol.Bid : _bot.Symbol.Ask;
@@ -138,7 +143,16 @@ namespace GeminiV26.Core.TradeManagement
                 _ => profile.LowConfidenceTpAtrMultiplier
             };
 
-            _bot.Print($"[TTM][PROFILE] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} state={state} score={score} slMult={slAtrMultiplier:0.00} tpMult={tpAtrMultiplier:0.00} reason=confidence_profile");
+            string confidenceBucket = GetConfidenceBucket(score);
+            bool shouldLogProfile =
+                ctx.PostTp1TrendState != state.ToString() ||
+                ctx.LastProfileLogBucket != confidenceBucket;
+
+            if (shouldLogProfile)
+            {
+                _bot.Print($"[TTM][PROFILE] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} state={state} score={score} slMult={slAtrMultiplier:0.00} tpMult={tpAtrMultiplier:0.00} reason=confidence_profile");
+                ctx.LastProfileLogBucket = confidenceBucket;
+            }
 
             bool allowTp2Extension = isRunner && profile.AllowTp2Extension;
             TryExtendTp2(position, ctx, isLong, atr, tpAtrMultiplier, profile, allowTp2Extension);
@@ -173,19 +187,19 @@ namespace GeminiV26.Core.TradeManagement
 
             if (!ctx.Tp1Hit)
             {
-                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp=NA delta=0.00000 result=SKIPPED reason=tp1_not_hit");
+                TryLogTp2(ctx, "tp1_not_hit", null, $"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp=NA delta=0.00000 result=SKIPPED reason=tp1_not_hit");
                 return;
             }
 
             if (!allowTp2Extension)
             {
-                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp=NA delta=0.00000 result=SKIPPED reason=extension_disabled");
+                TryLogTp2(ctx, "extension_disabled", null, $"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp=NA delta=0.00000 result=SKIPPED reason=extension_disabled");
                 return;
             }
 
             if (currentTp <= 0 || atr <= 0)
             {
-                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp=NA delta=0.00000 result=SKIPPED reason=missing_tp_or_atr");
+                TryLogTp2(ctx, "missing_tp_or_atr", null, $"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp=NA delta=0.00000 result=SKIPPED reason=missing_tp_or_atr");
                 return;
             }
 
@@ -202,21 +216,21 @@ namespace GeminiV26.Core.TradeManagement
 
             if (!outward)
             {
-                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(candidateTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=SKIPPED reason=not_outward_enough minDelta={minDelta:0.00000}");
+                TryLogTp2(ctx, "not_outward_enough", candidateTp, $"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(candidateTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=SKIPPED reason=not_outward_enough minDelta={minDelta:0.00000}");
                 return;
             }
 
             double normalizedTp = Normalize(candidateTp);
             if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - normalizedTp) < _bot.Symbol.PipSize)
             {
-                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(normalizedTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=SKIPPED reason=already_extended minDelta={minDelta:0.00000}");
+                TryLogTp2(ctx, "already_extended", normalizedTp, $"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(normalizedTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=SKIPPED reason=already_extended minDelta={minDelta:0.00000}");
                 return;
             }
 
             var result = _bot.ModifyPosition(pos, pos.StopLoss, normalizedTp);
             if (!result.IsSuccessful)
             {
-                _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(normalizedTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=SKIPPED reason=modify_failed error={result.Error}");
+                TryLogTp2(ctx, "modify_failed", normalizedTp, $"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(normalizedTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=SKIPPED reason=modify_failed error={result.Error}");
                 return;
             }
 
@@ -227,7 +241,35 @@ namespace GeminiV26.Core.TradeManagement
                 ctx.Tp2ExtensionMultiplierApplied = desiredR / ctx.Tp2R;
             }
 
-            _bot.Print($"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(normalizedTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=EXTENDED minDelta={minDelta:0.00000}");
+            TryLogTp2(ctx, "extended", normalizedTp, $"[TTM][TP2] symbol={pos.SymbolName} direction={direction} currentTp={FormatPrice(currentTp)} candidateTp={FormatPrice(normalizedTp)} livePrice={FormatPrice(livePrice)} sl={FormatPrice(pos.StopLoss)} delta={delta:0.00000} result=EXTENDED minDelta={minDelta:0.00000}");
+        }
+
+        private void TryLogTp2(PositionContext ctx, string state, double? value, string message)
+        {
+            if (ctx == null)
+                return;
+
+            bool stateChanged = !string.Equals(ctx.LastTp2LogState, state, StringComparison.Ordinal);
+            bool valueChanged =
+                (ctx.LastTp2LogValue.HasValue != value.HasValue) ||
+                (ctx.LastTp2LogValue.HasValue && value.HasValue && Math.Abs(ctx.LastTp2LogValue.Value - value.Value) >= Math.Max(LogEpsilon, _bot.Symbol.TickSize));
+
+            if (!stateChanged && !valueChanged)
+                return;
+
+            ctx.LastTp2LogState = state;
+            ctx.LastTp2LogValue = value;
+            _bot.Print(message);
+        }
+
+        private static string GetConfidenceBucket(int score)
+        {
+            return score switch
+            {
+                <= 1 => "LOW",
+                <= 3 => "MEDIUM",
+                _ => "HIGH"
+            };
         }
 
         private static double EstimatePullbackDepth(bool isLong, StructureSnapshot structure, double priceNow)

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -244,27 +244,50 @@ namespace GeminiV26.Instruments.BTCUSD
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+                bool trailingWasActive = ctx.TrailingActivated;
+                double? stopLossBeforeTrail = ctx.LastStopLossPrice ?? pos.StopLoss;
+                bool ttmStateChanged =
+                    ctx.PostTp1TrendScore != decision.Score ||
+                    ctx.PostTp1TrendState != decision.State.ToString() ||
+                    ctx.PostTp1TrailingMode != decision.TrailingMode.ToString() ||
+                    ctx.LastTtmAllowTp2Extension != decision.AllowTp2Extension ||
+                    !ctx.LastTtmTp2Multiplier.HasValue ||
+                    Math.Abs(ctx.LastTtmTp2Multiplier.Value - decision.Tp2ExtensionMultiplier) >= 0.0001;
 
                 ctx.PostTp1TrendScore = decision.Score;
                 ctx.PostTp1TrendState = decision.State.ToString();
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
+                ctx.LastTtmAllowTp2Extension = decision.AllowTp2Extension;
+                ctx.LastTtmTp2Multiplier = decision.Tp2ExtensionMultiplier;
 
-                _bot.Print(
-                    $"[BTCUSD][TTM] pos={pos.Id} " +
-                    $"score={decision.Score:0.00} state={decision.State} " +
-                    $"mode={decision.TrailingMode} allowTp2Ext={decision.AllowTp2Extension} " +
-                    $"mult={decision.Tp2ExtensionMultiplier:0.00}"
-                );
+                if (ttmStateChanged)
+                {
+                    _bot.Print(
+                        $"[BTCUSD][TTM] pos={pos.Id} " +
+                        $"score={decision.Score:0.00} state={decision.State} " +
+                        $"mode={decision.TrailingMode} allowTp2Ext={decision.AllowTp2Extension} " +
+                        $"mult={decision.Tp2ExtensionMultiplier:0.00}"
+                    );
+                }
 
                 TryExtendTp2(pos, ctx, decision);
 
-                _bot.Print(
-                    $"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} " +
-                    $"direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} " +
-                    $"sl={pos.StopLoss} tp={pos.TakeProfit}"
-                );
-
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
+
+                double? stopLossAfterTrail = ctx.LastStopLossPrice ?? pos.StopLoss;
+                bool stopLossUpdated =
+                    stopLossBeforeTrail.HasValue &&
+                    stopLossAfterTrail.HasValue &&
+                    Math.Abs(stopLossAfterTrail.Value - stopLossBeforeTrail.Value) >= Math.Max(0.0001, _bot.Symbol.TickSize);
+
+                if ((!trailingWasActive && ctx.TrailingActivated) || stopLossUpdated)
+                {
+                    _bot.Print(
+                        $"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} " +
+                        $"direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} " +
+                        $"sl={stopLossAfterTrail} tp={pos.TakeProfit}"
+                    );
+                }
             }
         }
 
@@ -452,7 +475,7 @@ namespace GeminiV26.Instruments.BTCUSD
             if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
             {
                 if (!decision.AllowTp2Extension)
-                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                    TryLogTp2Extension(ctx, "notAllowed", null, "[TTM] TP2 extension skipped=notAllowed");
                 return;
             }
 
@@ -464,7 +487,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
             if (desiredR <= currentR + 0.0001)
             {
-                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                TryLogTp2Extension(ctx, "no progression", null, "[TTM] TP2 extension skipped=no progression");
                 return;
             }
 
@@ -477,13 +500,13 @@ namespace GeminiV26.Instruments.BTCUSD
 
             if (!outward)
             {
-                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                TryLogTp2Extension(ctx, "not outward", newTp, "[TTM] TP2 extension skipped=not outward");
                 return;
             }
 
             if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
             {
-                _bot.Print("[TTM] TP2 extension skipped=same target");
+                TryLogTp2Extension(ctx, "same target", newTp, "[TTM] TP2 extension skipped=same target");
                 return;
             }
 
@@ -499,7 +522,22 @@ namespace GeminiV26.Instruments.BTCUSD
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
 
-            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+            TryLogTp2Extension(ctx, "extended", newTp, $"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
+        private void TryLogTp2Extension(PositionContext ctx, string state, double? value, string message)
+        {
+            bool stateChanged = !string.Equals(ctx.LastTp2ExtensionLogState, state, StringComparison.Ordinal);
+            bool valueChanged =
+                (ctx.LastTp2ExtensionLogValue.HasValue != value.HasValue) ||
+                (ctx.LastTp2ExtensionLogValue.HasValue && value.HasValue && Math.Abs(ctx.LastTp2ExtensionLogValue.Value - value.Value) >= Math.Max(0.0001, _bot.Symbol.TickSize));
+
+            if (!stateChanged && !valueChanged)
+                return;
+
+            ctx.LastTp2ExtensionLogState = state;
+            ctx.LastTp2ExtensionLogValue = value;
+            _bot.Print(message);
         }
         private static bool IsLong(PositionContext ctx)
         {

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -241,14 +241,26 @@ namespace GeminiV26.Instruments.XAUUSD
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
+                bool trailingWasActive = ctx.TrailingActivated;
+                double? stopLossBeforeTrail = ctx.LastStopLossPrice ?? pos.StopLoss;
 
                 ctx.PostTp1TrendScore = decision.Score;
                 ctx.PostTp1TrendState = decision.State.ToString();
                 ctx.PostTp1TrailingMode = decision.TrailingMode.ToString();
 
                 TryExtendTp2(pos, ctx, decision);
-                _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} sl={pos.StopLoss} tp={pos.TakeProfit}");
                 _adaptiveTrailingEngine.Apply(pos, ctx, decision, structure, profile);
+
+                double? stopLossAfterTrail = ctx.LastStopLossPrice ?? pos.StopLoss;
+                bool stopLossUpdated =
+                    stopLossBeforeTrail.HasValue &&
+                    stopLossAfterTrail.HasValue &&
+                    Math.Abs(stopLossAfterTrail.Value - stopLossBeforeTrail.Value) >= Math.Max(0.0001, _bot.Symbol.TickSize);
+
+                if ((!trailingWasActive && ctx.TrailingActivated) || stopLossUpdated)
+                {
+                    _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} sl={stopLossAfterTrail} tp={pos.TakeProfit}");
+                }
             }
         }
 
@@ -504,7 +516,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
             {
                 if (!decision.AllowTp2Extension)
-                    _bot.Print("[TTM] TP2 extension skipped=notAllowed");
+                    TryLogTp2Extension(ctx, "notAllowed", null, "[TTM] TP2 extension skipped=notAllowed");
                 return;
             }
 
@@ -515,7 +527,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
             if (desiredR <= currentR + 0.0001)
             {
-                _bot.Print("[TTM] TP2 extension skipped=no progression");
+                TryLogTp2Extension(ctx, "no progression", null, "[TTM] TP2 extension skipped=no progression");
                 return;
             }
 
@@ -527,13 +539,13 @@ namespace GeminiV26.Instruments.XAUUSD
             bool outward = IsLong(ctx) ? newTp > currentTp : newTp < currentTp;
             if (!outward)
             {
-                _bot.Print("[TTM] TP2 extension skipped=not outward");
+                TryLogTp2Extension(ctx, "not outward", newTp, "[TTM] TP2 extension skipped=not outward");
                 return;
             }
 
             if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
             {
-                _bot.Print("[TTM] TP2 extension skipped=same target");
+                TryLogTp2Extension(ctx, "same target", newTp, "[TTM] TP2 extension skipped=same target");
                 return;
             }
 
@@ -541,7 +553,22 @@ namespace GeminiV26.Instruments.XAUUSD
             _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} oldTp={currentTp} newTp={newTp}");
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
-            _bot.Print($"[TTM] TP2 extended from {currentTp} to {newTp}");
+            TryLogTp2Extension(ctx, "extended", newTp, $"[TTM] TP2 extended from {currentTp} to {newTp}");
+        }
+
+        private void TryLogTp2Extension(PositionContext ctx, string state, double? value, string message)
+        {
+            bool stateChanged = !string.Equals(ctx.LastTp2ExtensionLogState, state, StringComparison.Ordinal);
+            bool valueChanged =
+                (ctx.LastTp2ExtensionLogValue.HasValue != value.HasValue) ||
+                (ctx.LastTp2ExtensionLogValue.HasValue && value.HasValue && Math.Abs(ctx.LastTp2ExtensionLogValue.Value - value.Value) >= Math.Max(0.0001, _bot.Symbol.TickSize));
+
+            if (!stateChanged && !valueChanged)
+                return;
+
+            ctx.LastTp2ExtensionLogState = state;
+            ctx.LastTp2ExtensionLogValue = value;
+            _bot.Print(message);
         }
 
         private static bool IsLong(PositionContext ctx)


### PR DESCRIPTION
### Motivation
- Reduce noisy per-tick TTM / exit logging while making no changes to decision, scoring, or execution logic by logging only on state/value changes.
- Preserve all trading behavior and numeric parameters and only adjust logging conditions, placement and frequency. 

### Description
- Added per-position log state fields to `PositionContext` (`LastTp2LogState`, `LastTp2LogValue`, `LastTp2ExtensionLogState`, `LastTp2ExtensionLogValue`, `RunnerActivationLogged`, `LastProfileLogBucket`, `LastTtmAllowTp2Extension`, `LastTtmTp2Multiplier`, `LoggedNoImprovement`, `LoggedNoStructure`) to track previous log state and avoid repeated messages. (modified `Core/PositionContext.cs`).
- Throttled TP2 logging in `TrendTradeManager` by replacing unconditional `_bot.Print` calls with `TryLogTp2` so TP2 messages print only when the TP2 state or candidate value actually changes, using a small epsilon (`LogEpsilon = 0.0001`) and tick-size-aware comparisons. (modified `Core/TradeManagement/TrendTradeManager.cs`).
- Reduced trailing spam in `AdaptiveTrailingEngine` by composing candidate log messages, emitting them only when the candidate SL genuinely improves beyond epsilon/tick-size, and suppressing repeat `reason=no_improvement` and `reason=no_structure_anchor` messages after the first occurrence per position. (modified `Core/TradeManagement/AdaptiveTrailingEngine.cs`).
- Prevented repeated runner activation and TTM/profile summary spam by logging runner activation only once per position and emitting `[TTM][PROFILE]` only when the trend state or confidence bucket changes. (modified `Core/TradeManagement/TrendTradeManager.cs`).
- Guarded `[EXIT] TRAILING ACTIVE` in instrument exit managers so it prints only when trailing becomes active (first time) or when the SL actually updates, and applied the same TP2 extension throttling to XAU and BTC flows via `TryLogTp2Extension`. (modified `Instruments/XAUUSD/XauExitManager.cs` and `Instruments/BTCUSD/BtcUsdExitManager.cs`).
- No trading formulas, numeric thresholds, decision paths, or modify/close calls were altered; only logging guards and helper methods were added. 

### Testing
- Ran `git diff --check` to verify no whitespace or diff issues and inspected diffs for logging-only changes, which passed without errors. 
- Performed targeted repo searches (`rg`) and manual code review of modified call sites to confirm logging changes are limited to guards and state-tracking without altering calculation or execution code. 
- Could not run a full C# build in this environment because .NET tooling was unavailable, so no compile/run tests were executed here (please run `dotnet build` / integration tests in CI or locally to validate compilation and runtime behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc4a89f88083289c006f9757a55d75)