### PR TITLE
FX-only final entry acceptance filters

### DIFF
--- a/Core/Entry/EntryEvaluation.cs
+++ b/Core/Entry/EntryEvaluation.cs
@@ -19,5 +19,15 @@
         public EntryState State = EntryState.NONE;
 
         public bool TriggerConfirmed;
+
+        public bool HasTrigger
+        {
+            get => TriggerConfirmed;
+            set => TriggerConfirmed = value;
+        }
+
+        public bool IsHTFMisaligned;
+        public bool IgnoreHTFForDecision;
+        public double HtfConfidence01;
     }
 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1133,7 +1133,7 @@ namespace GeminiV26.Core
                 // =====================================================
                 // ROUTER
                 // =====================================================
-                var selected = _router.SelectEntry(symbolSignals);
+                var selected = _router.SelectEntry(symbolSignals, _ctx);
 
                 _bot.Print($"[TRACE] selected is null = {selected == null}");
 

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -19,6 +19,7 @@
 // =========================================================
 using cAlgo.API;
 using GeminiV26.Core.Entry;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -42,7 +43,7 @@ namespace GeminiV26.Core
         // =========================================================
         // ENTRY PRIORITY SELECTION (RULEBOOK 1.0)
         // =========================================================
-        public EntryEvaluation SelectEntry(List<EntryEvaluation> signals)
+        public EntryEvaluation SelectEntry(List<EntryEvaluation> signals, EntryContext entryContext = null)
         {
             _bot.Print("[TR] SelectEntry CALLED");
 
@@ -63,6 +64,10 @@ namespace GeminiV26.Core
                 _bot.Print($"[BASELINE CHECK] type={candidate.Type} score={candidate.Score} valid={candidate.IsValid.ToString().ToLowerInvariant()} source=ENTRY_ONLY");
 
                 if (!candidate.IsValid)
+                {
+                    decision = "REJECT";
+                }
+                else if (!ApplyFxAcceptanceFilters(candidate, entryContext))
                 {
                     decision = "REJECT";
                 }
@@ -90,6 +95,61 @@ namespace GeminiV26.Core
 
             _bot.Print($"[TR] WINNER: {winner.Type} dir={winner.Direction} score={winner.Score} valid={winner.IsValid} reason={winner.Reason}");
             return winner;
+        }
+
+
+        private bool ApplyFxAcceptanceFilters(EntryEvaluation eval, EntryContext entryContext)
+        {
+            if (eval == null || !eval.IsValid)
+                return false;
+
+            string symbol = eval.Symbol ?? entryContext?.Symbol ?? _bot.SymbolName;
+            var assetClass = SymbolRouting.ResolveInstrumentClass(symbol);
+            if (assetClass != InstrumentClass.FX)
+                return true;
+
+            eval.IgnoreHTFForDecision = false;
+            eval.HtfConfidence01 = entryContext?.FxHtfConfidence01 ?? 0.0;
+            eval.IsHTFMisaligned = entryContext != null
+                && entryContext.FxHtfAllowedDirection != TradeDirection.None
+                && eval.Direction != TradeDirection.None
+                && eval.Direction != entryContext.FxHtfAllowedDirection;
+
+            int decisionScore = eval.Score;
+            if (eval.HtfConfidence01 < 0.5 && eval.IsHTFMisaligned)
+            {
+                eval.IgnoreHTFForDecision = true;
+                decisionScore = Math.Max(0, Math.Min(100, decisionScore + 10));
+            }
+
+            if (decisionScore < EntryDecisionPolicy.MinScoreThreshold)
+                return RejectFxCandidate(eval, decisionScore, "FX_SCORE_BELOW_THRESHOLD");
+
+            if (!eval.HasTrigger)
+            {
+                if (eval.State == EntryState.SETUP_DETECTED)
+                    return RejectFxCandidate(eval, decisionScore, "FX_EARLY_BLOCK");
+
+                return RejectFxCandidate(eval, decisionScore, "FX_TRIGGER_REQUIRED");
+            }
+
+            if (decisionScore < 45)
+                return RejectFxCandidate(eval, decisionScore, "FX_MIN_QUALITY_BLOCK");
+
+            return true;
+        }
+
+        private bool RejectFxCandidate(EntryEvaluation eval, int decisionScore, string reasonToken)
+        {
+            eval.IsValid = false;
+            eval.Reason = string.IsNullOrWhiteSpace(eval.Reason)
+                ? $"[{reasonToken}]"
+                : $"{eval.Reason} [{reasonToken}]";
+
+            _bot.Print(
+                $"[FX FILTER] type={eval.Type} dir={eval.Direction} score={eval.Score} decisionScore={decisionScore} reason={reasonToken}");
+
+            return false;
         }
 
         // =========================================================


### PR DESCRIPTION
### Motivation
- Reduce premature or low-quality FX entries by applying additional decision-stage gating while leaving scoring, entry-type logic, HTF scoring and non-FX behavior unchanged. 
- Ensure protections address missing triggers, early setup breakouts and weak HTF confidence for FX symbols only.

### Description
- Added FX-scoped acceptance filter in `TradeRouter.SelectEntry` that returns early for non-FX instruments and enforces FX-only gating rules (score threshold gating, trigger required, early-setup block, optional minimum-quality block). 
- Introduced an HTF protection flag so weak HTF confidence + HTF misalignment can be ignored for gating (sets `IgnoreHTFForDecision`), without altering stored scores or HTF scoring logic. 
- Passed the live `EntryContext` into the router (`SelectEntry(symbolSignals, _ctx)`) so the filter can read per-symbol HTF confidence/direction at decision time. 
- Extended `EntryEvaluation` with lightweight decision-stage metadata fields (`HasTrigger`, `IsHTFMisaligned`, `IgnoreHTFForDecision`, `HtfConfidence01`) used only in the final acceptance stage. 
- Per-rejection logging added: single-line `[FX FILTER] type=... dir=... score=... reason=...` for every FX candidate blocked.
- Files changed: `Core/TradeRouter.cs`, `Core/TradeCore.cs`, `Core/Entry/EntryEvaluation.cs`.

### Testing
- Ran static assertions/script that verified the FX guard, rejection reason tokens (`FX_SCORE_BELOW_THRESHOLD`, `FX_TRIGGER_REQUIRED`, `FX_EARLY_BLOCK`, `FX_MIN_QUALITY_BLOCK`) and router wiring to `EntryContext`, and those checks succeeded. 
- Ran `git diff --check` and basic repository file checks to validate changes and formatting, which reported no issues. 
- Attempted a full `dotnet build` but the .NET SDK is not available in this environment, so a compile was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc4f4b003c8328914a5811ca8847b9)