### PR TITLE
Add per-entrytype direction-quality scoring and logging for FX/INDEX/METAL/CRYPTO

### DIFF
--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -1,6 +1,7 @@
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using System;
 
 namespace GeminiV26.EntryTypes.Crypto
@@ -96,11 +97,14 @@ namespace GeminiV26.EntryTypes.Crypto
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
                 ctx.Log?.Invoke($"[FLAG][REJECT] No hard-tradable direction long={longEval.Score}/{longEval.IsValid} short={shortEval.Score}/{shortEval.IsValid}");
                 return Invalid(ctx, "FLAG_DIRECTION_INVALID");
             }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(
@@ -340,54 +344,15 @@ namespace GeminiV26.EntryTypes.Crypto
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "BTC_FlagEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -1,6 +1,7 @@
 using System;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.EntryTypes.Crypto;
 
 namespace GeminiV26.EntryTypes.Crypto
@@ -22,7 +23,9 @@ namespace GeminiV26.EntryTypes.Crypto
                 var longEval = EvaluateDirectional(ctx, TradeDirection.Long);
                 var shortEval = EvaluateDirectional(ctx, TradeDirection.Short);
 
-                return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+                var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+                return EntryDecisionPolicy.Normalize(selected);
             }
             finally
             {
@@ -894,54 +897,15 @@ namespace GeminiV26.EntryTypes.Crypto
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "BTC_PullbackEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -1,4 +1,5 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core;
 
 namespace GeminiV26.EntryTypes.Crypto
@@ -25,7 +26,9 @@ namespace GeminiV26.EntryTypes.Crypto
             var longEval = EvaluateSide(ctx, TradeDirection.Long);
             var shortEval = EvaluateSide(ctx, TradeDirection.Short);
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
@@ -144,54 +147,15 @@ namespace GeminiV26.EntryTypes.Crypto
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "BTC_RangeBreakoutEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -1,4 +1,5 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core;
 using System;
 
@@ -20,7 +21,9 @@ namespace GeminiV26.EntryTypes.Crypto
             var longEval = EvaluateSide(ctx, TradeDirection.Long);
             var shortEval = EvaluateSide(ctx, TradeDirection.Short);
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
@@ -84,54 +87,15 @@ namespace GeminiV26.EntryTypes.Crypto
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "Crypto_ImpulseEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/EntryDirectionQuality.cs
+++ b/EntryTypes/EntryDirectionQuality.cs
@@ -1,0 +1,269 @@
+using System;
+using GeminiV26.Core;
+using GeminiV26.Core.Entry;
+
+namespace GeminiV26.EntryTypes
+{
+    internal sealed class DirectionQualityRequest
+    {
+        public string TypeTag { get; init; }
+        public bool ApplyTrendRegimePenalty { get; init; }
+    }
+
+    internal static class EntryDirectionQuality
+    {
+        public static int Apply(
+            EntryContext ctx,
+            TradeDirection direction,
+            int score,
+            DirectionQualityRequest request)
+        {
+            if (ctx == null)
+                return score;
+
+            ResolveHtf(ctx, out var instrumentClass, out var htfDirection, out var htfConfidence);
+
+            bool breakoutConfirmed = HasDirectionalBreakout(ctx, direction);
+            bool impulseAligned = HasDirectionalImpulse(ctx, direction);
+            bool pullbackAligned = HasDirectionalPullback(ctx, direction);
+            bool flagAligned = HasDirectionalFlag(ctx, direction);
+            bool structureAligned = breakoutConfirmed || flagAligned || pullbackAligned || impulseAligned;
+            bool oppositeStructure = HasDirectionalStructure(ctx, Opposite(direction));
+            bool momentumAligned = HasDirectionalMomentum(ctx, direction);
+            bool regimeCompatible = IsRegimeCompatible(ctx, instrumentClass, direction, request.ApplyTrendRegimePenalty, breakoutConfirmed, impulseAligned, momentumAligned, structureAligned, out var regime);
+
+            int penalty = 0;
+            int bonus = 0;
+
+            if (structureAligned)
+            {
+                bonus += 6;
+                if (!oppositeStructure)
+                    bonus += 2;
+            }
+            else
+            {
+                penalty += instrumentClass == InstrumentClass.FX ? 18 : 14;
+
+                if (request.ApplyTrendRegimePenalty)
+                    penalty += 2;
+            }
+
+            if (!oppositeStructure && request.ApplyTrendRegimePenalty)
+                bonus += 2;
+
+            if (breakoutConfirmed)
+                bonus += 4;
+
+            if (!momentumAligned)
+            {
+                penalty += instrumentClass switch
+                {
+                    InstrumentClass.CRYPTO => 20,
+                    InstrumentClass.INDEX => 16,
+                    InstrumentClass.METAL => 14,
+                    _ => 12
+                };
+            }
+            else
+            {
+                bonus += 3;
+            }
+
+            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70)
+            {
+                if (direction != htfDirection)
+                    penalty += 30;
+                else
+                    bonus += 5;
+            }
+
+            var logicBias = ctx.LogicBiasDirection;
+            var logicConfidence = ctx.LogicBiasConfidence;
+            if (logicBias != TradeDirection.None && logicConfidence >= 60)
+            {
+                if (direction != logicBias)
+                    penalty += 12;
+                else
+                    bonus += 4;
+            }
+
+            if (!regimeCompatible)
+                penalty += 20;
+
+            if (instrumentClass == InstrumentClass.INDEX &&
+                htfDirection != TradeDirection.None &&
+                htfConfidence >= 0.70 &&
+                logicBias != TradeDirection.None &&
+                logicConfidence >= 60 &&
+                htfDirection == logicBias &&
+                direction != htfDirection)
+            {
+                penalty += 10;
+            }
+
+            if (instrumentClass == InstrumentClass.METAL &&
+                request.ApplyTrendRegimePenalty &&
+                !structureAligned &&
+                !breakoutConfirmed)
+            {
+                penalty += 10;
+            }
+
+            score += bonus;
+            score -= penalty;
+
+            string structure =
+                breakoutConfirmed ? "BreakoutConfirmed" :
+                flagAligned ? "FlagAligned" :
+                pullbackAligned ? "PullbackAligned" :
+                impulseAligned ? "ImpulseAligned" :
+                "None";
+
+            ctx.Log?.Invoke(
+                $"[DIR QUALITY] type={request.TypeTag} side={direction} structure={structure} " +
+                $"logicBias={logicBias} logicConf={logicConfidence} htfDir={htfDirection} htfConf={htfConfidence:F2} " +
+                $"regime={regime} penalty={penalty} bonus={bonus} finalScore={score}");
+
+            return score;
+        }
+
+        public static void LogDecision(EntryContext ctx, string typeTag, EntryEvaluation longEval, EntryEvaluation shortEval, TradeDirection selected)
+        {
+            ctx?.Log?.Invoke(
+                $"[DIR DECISION] type={typeTag} longScore={longEval?.Score ?? 0} shortScore={shortEval?.Score ?? 0} selected={selected}");
+        }
+
+        private static void ResolveHtf(
+            EntryContext ctx,
+            out InstrumentClass instrumentClass,
+            out TradeDirection htfDirection,
+            out double htfConfidence)
+        {
+            instrumentClass = SymbolRouting.ResolveInstrumentClass(ctx.Symbol);
+            htfDirection = TradeDirection.None;
+            htfConfidence = 0.0;
+
+            switch (instrumentClass)
+            {
+                case InstrumentClass.FX:
+                    htfDirection = ctx.FxHtfAllowedDirection;
+                    htfConfidence = ctx.FxHtfConfidence01;
+                    break;
+                case InstrumentClass.CRYPTO:
+                    htfDirection = ctx.CryptoHtfAllowedDirection;
+                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    break;
+                case InstrumentClass.INDEX:
+                    htfDirection = ctx.IndexHtfAllowedDirection;
+                    htfConfidence = ctx.IndexHtfConfidence01;
+                    break;
+                case InstrumentClass.METAL:
+                    htfDirection = ctx.MetalHtfAllowedDirection;
+                    htfConfidence = ctx.MetalHtfConfidence01;
+                    break;
+            }
+        }
+
+        private static bool IsRegimeCompatible(
+            EntryContext ctx,
+            InstrumentClass instrumentClass,
+            TradeDirection direction,
+            bool applyTrendRegimePenalty,
+            bool breakoutConfirmed,
+            bool impulseAligned,
+            bool momentumAligned,
+            bool structureAligned,
+            out string regime)
+        {
+            bool inTrend = ctx.MarketState?.IsTrend == true || (!ctx.IsRange_M5 && ctx.Adx_M5 >= 18.0);
+            bool compressed = ctx.IsRange_M5 || ctx.MarketState?.IsRange == true || ctx.MarketState?.IsLowVol == true;
+
+            if (!applyTrendRegimePenalty)
+            {
+                regime = compressed ? "SoftRange" : "SoftNeutral";
+                return true;
+            }
+
+            bool compatible = instrumentClass switch
+            {
+                InstrumentClass.FX => ctx.Adx_M5 >= 18.0 || breakoutConfirmed || impulseAligned,
+                InstrumentClass.INDEX => ctx.Adx_M5 >= 18.0 && momentumAligned && !compressed,
+                InstrumentClass.METAL => (inTrend && structureAligned) || breakoutConfirmed,
+                InstrumentClass.CRYPTO => momentumAligned && (ctx.IsAtrExpanding_M5 || breakoutConfirmed),
+                _ => true
+            };
+
+            compatible = compatible && !compressed;
+
+            regime = compatible
+                ? "TrendCompatible"
+                : $"{instrumentClass}_RegimeMismatch_{direction}";
+
+            return compatible;
+        }
+
+        private static bool HasDirectionalStructure(EntryContext ctx, TradeDirection direction) =>
+            HasDirectionalBreakout(ctx, direction) ||
+            HasDirectionalFlag(ctx, direction) ||
+            HasDirectionalPullback(ctx, direction) ||
+            HasDirectionalImpulse(ctx, direction);
+
+        private static bool HasDirectionalMomentum(EntryContext ctx, TradeDirection direction)
+        {
+            if (direction == TradeDirection.None)
+                return false;
+
+            if (ctx.BreakoutDirection == direction || ctx.RangeBreakDirection == direction || ctx.ImpulseDirection == direction)
+                return true;
+
+            if (ctx.TrendDirection == direction && ctx.LastClosedBarInTrendDirection)
+                return true;
+
+            if (ctx.HasBreakout_M1 && ctx.BreakoutDirection == direction)
+                return true;
+
+            return false;
+        }
+
+        private static bool HasDirectionalBreakout(EntryContext ctx, TradeDirection direction) =>
+            direction switch
+            {
+                TradeDirection.Long => ctx.FlagBreakoutUpConfirmed || ctx.FlagBreakoutUp || ctx.RangeBreakDirection == TradeDirection.Long || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == TradeDirection.Long),
+                TradeDirection.Short => ctx.FlagBreakoutDownConfirmed || ctx.FlagBreakoutDown || ctx.RangeBreakDirection == TradeDirection.Short || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == TradeDirection.Short),
+                _ => false
+            };
+
+        private static bool HasDirectionalFlag(EntryContext ctx, TradeDirection direction) =>
+            direction switch
+            {
+                TradeDirection.Long => ctx.HasFlagLong_M5,
+                TradeDirection.Short => ctx.HasFlagShort_M5,
+                _ => false
+            };
+
+        private static bool HasDirectionalPullback(EntryContext ctx, TradeDirection direction) =>
+            direction switch
+            {
+                TradeDirection.Long => ctx.HasPullbackLong_M5 || ctx.PullbackDepthRLong_M5 > 0.0,
+                TradeDirection.Short => ctx.HasPullbackShort_M5 || ctx.PullbackDepthRShort_M5 > 0.0,
+                _ => false
+            };
+
+        private static bool HasDirectionalImpulse(EntryContext ctx, TradeDirection direction) =>
+            direction switch
+            {
+                TradeDirection.Long => ctx.HasImpulseLong_M5 || ctx.ImpulseDirection == TradeDirection.Long,
+                TradeDirection.Short => ctx.HasImpulseShort_M5 || ctx.ImpulseDirection == TradeDirection.Short,
+                _ => false
+            };
+
+        private static TradeDirection Opposite(TradeDirection direction) =>
+            direction switch
+            {
+                TradeDirection.Long => TradeDirection.Short,
+                TradeDirection.Short => TradeDirection.Long,
+                _ => TradeDirection.None
+            };
+    }
+}

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -1,4 +1,5 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core;
 using GeminiV26.Instruments.FX;
 
@@ -21,9 +22,14 @@ namespace GeminiV26.EntryTypes.FX
             var shortEval = EvaluateSide(TradeDirection.Short, ctx);
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
+            {
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
                 return Invalid(ctx, "NO_VALID_SIDE");
+            }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)
@@ -150,54 +156,15 @@ namespace GeminiV26.EntryTypes.FX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "FX_FlagContinuationEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -12,6 +12,7 @@ using System;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.FX;
 
@@ -54,21 +55,26 @@ namespace GeminiV26.EntryTypes.FX
 
             if (!buyValid && !sellValid)
             {
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
                 ctx.Log?.Invoke($"[FLAG][REJECT] No valid direction buyValid={buyValid} sellValid={sellValid}");
                 return Invalid(ctx, TradeDirection.None, "FLAG_DIRECTION_INVALID", Math.Max(longEval.Score, shortEval.Score));
             }
 
             // Prefer VALID; if both valid -> higher score wins
             if (buyValid && sellValid)
-                return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            {
+                var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+                return EntryDecisionPolicy.Normalize(selected);
+            }
 
             if (buyValid)
             {
-                EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, longEval.Direction);
                 return longEval;
             }
 
-            EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, shortEval.Direction);
             return shortEval;
         }
 
@@ -1186,54 +1192,15 @@ namespace GeminiV26.EntryTypes.FX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "FX_FlagEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -1,4 +1,5 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core;
 using GeminiV26.Instruments.FX;
 
@@ -28,9 +29,14 @@ namespace GeminiV26.EntryTypes.FX
             var shortEval = EvaluateSide(TradeDirection.Short, ctx);
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
+            {
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
                 return Invalid(ctx, "NO_VALID_SIDE");
+            }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)
@@ -171,54 +177,15 @@ namespace GeminiV26.EntryTypes.FX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "FX_ImpulseContinuationEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -2,6 +2,7 @@ using System;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Instruments.FX;
 using FxTuning = GeminiV26.Instruments.FX.FxFlagSessionTuning;
 
@@ -31,9 +32,14 @@ namespace GeminiV26.EntryTypes.FX
             var shortEval = EvaluateSide(TradeDirection.Short, ctx, tuning);
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
+            {
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
                 return Invalid(ctx, "NO_VALID_SIDE");
+            }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(
@@ -163,54 +169,15 @@ namespace GeminiV26.EntryTypes.FX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "FX_MicroContinuationEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -2,6 +2,7 @@ using System;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Instruments.FX;
 
 namespace GeminiV26.EntryTypes.FX
@@ -29,12 +30,16 @@ namespace GeminiV26.EntryTypes.FX
             var shortEval = EvalForDir(ctx, fx, TradeDirection.Short);
 
             if (longEval.IsValid && shortEval.IsValid)
-                return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+                var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+                return EntryDecisionPolicy.Normalize(selected);
 
             if (longEval.IsValid) return longEval;
             if (shortEval.IsValid) return shortEval;
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private static EntryEvaluation EvalForDir(
@@ -323,54 +328,15 @@ namespace GeminiV26.EntryTypes.FX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "FX_MicroStructureEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -1,6 +1,7 @@
 using System;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.FX;
 
@@ -48,6 +49,7 @@ namespace GeminiV26.EntryTypes.FX
             {
                 int bestScore = Math.Max(longEval.Score, shortEval.Score);
                 ctx?.Log?.Invoke($"[FX_PullbackEntry] BOTH_INVALID long={longEval.Score} short={shortEval.Score}");
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
 
                 return EntryDecisionPolicy.Normalize(new EntryEvaluation
                 {
@@ -69,10 +71,13 @@ namespace GeminiV26.EntryTypes.FX
                     shortEval.Score += 3;
 
                 var winner = longEval.Score >= shortEval.Score ? longEval : shortEval;
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, winner.Direction);
                 return EntryDecisionPolicy.Normalize(winner);
             }
 
-            return EntryDecisionPolicy.Normalize(longValid ? longEval : shortEval);
+            var selected = longValid ? longEval : shortEval;
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(
@@ -419,54 +424,15 @@ namespace GeminiV26.EntryTypes.FX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "FX_PullbackEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/FX/FX_RangeBreakoutEntry.cs
+++ b/EntryTypes/FX/FX_RangeBreakoutEntry.cs
@@ -1,4 +1,5 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.FX;
@@ -69,7 +70,9 @@ namespace GeminiV26.EntryTypes.FX
             var longEval = EvaluateSide(ctx, TradeDirection.Long);
             var shortEval = EvaluateSide(ctx, TradeDirection.Short);
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
@@ -129,54 +132,15 @@ namespace GeminiV26.EntryTypes.FX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "FX_RangeBreakoutEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -1,4 +1,5 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core;
 
@@ -37,7 +38,9 @@ namespace GeminiV26.EntryTypes.FX
             var longEval = EvaluateSide(ctx, TradeDirection.Long);
             var shortEval = EvaluateSide(ctx, TradeDirection.Short);
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
@@ -164,54 +167,15 @@ namespace GeminiV26.EntryTypes.FX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "FX_ReversalEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -1,6 +1,7 @@
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.INDEX;
 using System;
@@ -27,7 +28,9 @@ namespace GeminiV26.EntryTypes.INDEX
             var longEval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
             var shortEval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(
@@ -242,54 +245,15 @@ namespace GeminiV26.EntryTypes.INDEX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "Index_BreakoutEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -1,6 +1,7 @@
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.INDEX;
 using System;
@@ -105,11 +106,14 @@ namespace GeminiV26.EntryTypes.INDEX
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
                 ctx.Log?.Invoke($"[FLAG][REJECT] No hard-tradable direction long={longEval.Score}/{longEval.IsValid} short={shortEval.Score}/{shortEval.IsValid}");
                 return Reject(ctx, "FLAG_DIRECTION_INVALID", Math.Max(longEval.Score, shortEval.Score), TradeDirection.None);
             }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateDir(
@@ -640,54 +644,15 @@ namespace GeminiV26.EntryTypes.INDEX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "Index_FlagEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -1,4 +1,5 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.INDEX;
@@ -33,9 +34,14 @@ namespace GeminiV26.EntryTypes.INDEX
             var shortEval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
+            {
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
                 return Reject(ctx, TradeDirection.None, Math.Max(longEval?.Score ?? 0, shortEval?.Score ?? 0), "IDX_PULLBACK_NO_SIDE");
+            }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(
@@ -340,54 +346,15 @@ namespace GeminiV26.EntryTypes.INDEX
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "Index_PullbackEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Instruments.FX;
 
@@ -82,20 +83,31 @@ namespace GeminiV26.EntryTypes.METAL
             var sell = EvaluateSide(TradeDirection.Short, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
 
             if (EntryDecisionPolicy.IsHardInvalid(buy) && EntryDecisionPolicy.IsHardInvalid(sell))
+            {
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, TradeDirection.None);
                 return Reject(ctx, tag, session, tuning, buy, sell);
+            }
 
             int diff = buy.Score - sell.Score;
 
             if (Math.Abs(diff) <= ScoreDeadband)
             {
                 if (ctx.BreakoutUpBarsSince < ctx.BreakoutDownBarsSince)
+                {
+                    EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, buy.Direction);
                     return buy;
+                }
 
                 if (ctx.BreakoutDownBarsSince < ctx.BreakoutUpBarsSince)
+                {
+                    EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, sell.Direction);
                     return sell;
+                }
             }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, buy, sell));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, buy, sell);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(
@@ -438,54 +450,15 @@ namespace GeminiV26.EntryTypes.METAL
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "XAU_FlagEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -1,4 +1,5 @@
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core;
 using GeminiV26.Core.Matrix;
 
@@ -35,7 +36,9 @@ namespace GeminiV26.EntryTypes.METAL
             var longEval = EvaluateSide(ctx, matrix, TradeDirection.Long);
             var shortEval = EvaluateSide(ctx, matrix, TradeDirection.Short);
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(EntryContext ctx, SessionMatrixConfig matrix, TradeDirection dir)
@@ -214,54 +217,15 @@ namespace GeminiV26.EntryTypes.METAL
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "XAU_ImpulseEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -2,6 +2,7 @@ using System;
 using GeminiV26.Core;
 using System.Collections.Generic;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 using GeminiV26.Core.Matrix;
 
 namespace GeminiV26.EntryTypes.METAL
@@ -32,7 +33,10 @@ namespace GeminiV26.EntryTypes.METAL
             var sell = EvaluateSide(TradeDirection.Short, ctx, matrix);
 
             if (EntryDecisionPolicy.IsHardInvalid(buy) && EntryDecisionPolicy.IsHardInvalid(sell))
+            {
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, TradeDirection.None);
                 return RejectBoth(ctx, buy, sell);
+            }
 
             int diff = buy.Score - sell.Score;
 
@@ -40,13 +44,21 @@ namespace GeminiV26.EntryTypes.METAL
             {
                 // döntés: melyik oldal reagált előbb
                 if (ctx.BarsSinceImpulseLong_M5 < ctx.BarsSinceImpulseShort_M5)
+                {
+                    EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, buy.Direction);
                     return buy;
+                }
 
                 if (ctx.BarsSinceImpulseShort_M5 < ctx.BarsSinceImpulseLong_M5)
+                {
+                    EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, sell.Direction);
                     return sell;
+                }
             }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, buy, sell));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, buy, sell);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(
@@ -335,54 +347,15 @@ namespace GeminiV26.EntryTypes.METAL
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "XAU_PullbackEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -2,6 +2,7 @@ using System;
 using GeminiV26.Core;
 using System.Collections.Generic;
 using GeminiV26.Core.Entry;
+using GeminiV26.EntryTypes;
 
 namespace GeminiV26.EntryTypes.METAL
 {
@@ -23,7 +24,9 @@ namespace GeminiV26.EntryTypes.METAL
             var longEval = EvaluateSide(ctx, TradeDirection.Long);
             var shortEval = EvaluateSide(ctx, TradeDirection.Short);
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
+            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
+            return EntryDecisionPolicy.Normalize(selected);
         }
 
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
@@ -217,54 +220,15 @@ namespace GeminiV26.EntryTypes.METAL
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "XAU_ReversalEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }


### PR DESCRIPTION
### Motivation
- Reduce wrong-direction entries by applying a per-side direction-quality layer at the ENTRYTYPE level for FX/INDEX/METAL/CRYPTO without changing routing, sizing, exits, or concurrency behavior.  
- Capture structural, class-specific, HTF-strong-only, logic-bias and regime compatibility signals to bias scoring (penalty/bonus) rather than invalidating candidates.  
- Produce detailed diagnostics so direction decisions and penalties/bonuses are auditable per candidate side.

### Description
- Add a shared helper `EntryTypes/EntryDirectionQuality.cs` that computes side-specific bonuses/penalties and emits `[DIR QUALITY]` logs and a `[DIR DECISION]` comparison line.  
- Replace in-situ mandatory HTF/logic/regime adjustments in scoped entry evaluators with calls to `EntryDirectionQuality.Apply(...)` and keep `ApplyMandatoryEntryAdjustments` as a thin delegator to the helper.  
- Wire direction-decision logging (`EntryDirectionQuality.LogDecision`) in all touched entry evaluators to log selected/rejected outcomes, including reject/both-invalid and deadband tie-break outcomes.  
- Changes are strictly scoped to files under `EntryTypes/` (19 evaluators modified, 1 new helper file added), and do not alter `TradeCore`, position/session/concurrency, risk sizing, exits, or other forbidden areas.

### Testing
- Ran automated repository validations that confirm only `EntryTypes/` files were modified and that each touched evaluator now contains `EntryDirectionQuality` wiring, and both checks passed.  
- Ran `git diff --check` style static check and repository search validations for injected logging and helper usage; no issues reported by those checks.  
- No project/solution files were present in the snapshot so a full compile/run-backtest was not executed in this change set (none attempted to avoid touching build/configuration outside `EntryTypes/`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc558481f48328967702cbe14b2dcc)