### PR TITLE
Fix scope for `selected` in FX_MicroStructureEntry (add braces)

### DIFF
--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -30,9 +30,11 @@ namespace GeminiV26.EntryTypes.FX
             var shortEval = EvalForDir(ctx, fx, TradeDirection.Short);
 
             if (longEval.IsValid && shortEval.IsValid)
+            {
                 var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
                 EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
                 return EntryDecisionPolicy.Normalize(selected);
+            }
 
             if (longEval.IsValid) return longEval;
             if (shortEval.IsValid) return shortEval;


### PR DESCRIPTION
### Motivation
- Resolve C# compile errors caused by a local variable declaration placed under an `if` without braces which led to invalid embedded-statement, duplicate `selected` declarations, and use-before-declaration diagnostics. 

### Description
- Add braces around `if (longEval.IsValid && shortEval.IsValid)` in `EntryTypes/FX/FX_MicroStructureEntry.cs` by inserting `{` after the `if` line and `}` after the `return EntryDecisionPolicy.Normalize(selected);` so `selected` is declared exactly once in the intended block while leaving the fallback `selected` declaration and all strategy logic unchanged. 

### Testing
- Inspected the updated snippet with `nl -ba EntryTypes/FX/FX_MicroStructureEntry.cs | sed -n '28,44p'`, reviewed the `git diff` showing the two brace insertions, and committed the change; attempted `dotnet/csc/mcs` but no C# toolchain or `.csproj` exists in the repository so a full compile could not be run locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc589b6cf48328bfe207429b76aa50)