### PR TITLE
Add strict directional pre-filters to entry Evaluate methods

### DIFF
--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -92,8 +92,36 @@ namespace GeminiV26.EntryTypes.Crypto
 
             var profile = CryptoInstrumentMatrix.Get(ctx.Symbol);
 
-            var longEval = EvaluateSide(ctx, TradeDirection.Long, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
-            var shortEval = EvaluateSide(ctx, TradeDirection.Short, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(ctx, TradeDirection.Long, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
+            else
+                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
+
+            if (allowShort)
+                shortEval = EvaluateSide(ctx, TradeDirection.Short, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
+            else
+                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -20,8 +20,36 @@ namespace GeminiV26.EntryTypes.Crypto
             var originalTrendDirection = ctx.TrendDirection;
             try
             {
-                var longEval = EvaluateDirectional(ctx, TradeDirection.Long);
-                var shortEval = EvaluateDirectional(ctx, TradeDirection.Short);
+                bool allowLong = true;
+                bool allowShort = true;
+
+                if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+                {
+                    allowLong = ctx.LogicBias == TradeDirection.Long;
+                    allowShort = ctx.LogicBias == TradeDirection.Short;
+                }
+
+                if (ctx.HtfConfidence >= 0.6)
+                {
+                    allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                    allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+                }
+
+                if (!allowLong && !allowShort)
+                    return Block(ctx, "NO_DIRECTIONAL_EDGE", 0, TradeDirection.None);
+
+                EntryEvaluation longEval;
+                EntryEvaluation shortEval;
+
+                if (allowLong)
+                    longEval = EvaluateDirectional(ctx, TradeDirection.Long);
+                else
+                    longEval = Block(ctx, "DIR_BLOCKED", 0, TradeDirection.Long);
+
+                if (allowShort)
+                    shortEval = EvaluateDirectional(ctx, TradeDirection.Short);
+                else
+                    shortEval = Block(ctx, "DIR_BLOCKED", 0, TradeDirection.Short);
 
                 var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
                 EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -23,8 +23,60 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MIN_RANGE_BARS)
                 return Invalid(ctx, "NO_RANGE");
 
-            var longEval = EvaluateSide(ctx, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = EntryType.Crypto_RangeBreakout,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NO_DIRECTIONAL_EDGE;"
+                };
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(ctx, TradeDirection.Long);
+            else
+                longEval = new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = EntryType.Crypto_RangeBreakout,
+                    Direction = TradeDirection.Long,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "DIR_BLOCKED;"
+                };
+
+            if (allowShort)
+                shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            else
+                shortEval = new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = EntryType.Crypto_RangeBreakout,
+                    Direction = TradeDirection.Short,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "DIR_BLOCKED;"
+                };
 
             var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
             EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -18,8 +18,36 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsVolatilityAcceptable_Crypto)
                 return Invalid(ctx, "CRYPTO_VOL_DISABLED");
 
-            var longEval = EvaluateSide(ctx, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Invalid(ctx, "NO_DIRECTIONAL_EDGE", TradeDirection.None, 0);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(ctx, TradeDirection.Long);
+            else
+                longEval = Invalid(ctx, "DIR_BLOCKED", TradeDirection.Long, 0);
+
+            if (allowShort)
+                shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            else
+                shortEval = Invalid(ctx, "DIR_BLOCKED", TradeDirection.Short, 0);
 
             var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
             EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -18,8 +18,36 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
-            var longEval = EvaluateSide(TradeDirection.Long, ctx);
-            var shortEval = EvaluateSide(TradeDirection.Short, ctx);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(TradeDirection.Long, ctx);
+            else
+                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
+
+            if (allowShort)
+                shortEval = EvaluateSide(TradeDirection.Short, ctx);
+            else
+                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -43,12 +43,42 @@ namespace GeminiV26.EntryTypes.FX
             if (fx.FlagTuning == null || !fx.FlagTuning.TryGetValue(ctx.Session, out var tuning))
                 return Invalid(ctx, TradeDirection.None, "NO_FLAG_TUNING", 0);
 
-            // === Evaluate BOTH directions ===
-            var longEval = EvalForDir(ctx, fx, tuning, TradeDirection.Long);
-            var shortEval = EvalForDir(ctx, fx, tuning, TradeDirection.Short);
+            bool allowLong = true;
+            bool allowShort = true;
 
-            ApplyScoreModifier(longEval, matrix);
-            ApplyScoreModifier(shortEval, matrix);
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvalForDir(ctx, fx, tuning, TradeDirection.Long);
+            else
+                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
+
+            if (allowShort)
+                shortEval = EvalForDir(ctx, fx, tuning, TradeDirection.Short);
+            else
+                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
+
+            if (allowLong)
+                ApplyScoreModifier(longEval, matrix);
+
+            if (allowShort)
+                ApplyScoreModifier(shortEval, matrix);
 
             bool buyValid = longEval.IsValid;
             bool sellValid = shortEval.IsValid;

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -25,8 +25,36 @@ namespace GeminiV26.EntryTypes.FX
             if (!ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
-            var longEval = EvaluateSide(TradeDirection.Long, ctx);
-            var shortEval = EvaluateSide(TradeDirection.Short, ctx);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(TradeDirection.Long, ctx);
+            else
+                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
+
+            if (allowShort)
+                shortEval = EvaluateSide(TradeDirection.Short, ctx);
+            else
+                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -28,8 +28,36 @@ namespace GeminiV26.EntryTypes.FX
             if (!fx.FlagTuning.TryGetValue(ctx.Session, out var tuning))
                 return Invalid(ctx, "NO_SESSION_TUNING");
 
-            var longEval = EvaluateSide(TradeDirection.Long, ctx, tuning);
-            var shortEval = EvaluateSide(TradeDirection.Short, ctx, tuning);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(TradeDirection.Long, ctx, tuning);
+            else
+                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
+
+            if (allowShort)
+                shortEval = EvaluateSide(TradeDirection.Short, ctx, tuning);
+            else
+                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -25,9 +25,36 @@ namespace GeminiV26.EntryTypes.FX
             if (fx == null)
                 return Invalid(ctx, TradeDirection.None, "NO_FX_PROFILE", 0);
 
-            // evaluate both directions
-            var longEval = EvalForDir(ctx, fx, TradeDirection.Long);
-            var shortEval = EvalForDir(ctx, fx, TradeDirection.Short);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvalForDir(ctx, fx, TradeDirection.Long);
+            else
+                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
+
+            if (allowShort)
+                shortEval = EvalForDir(ctx, fx, TradeDirection.Short);
+            else
+                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
 
             EntryEvaluation selected; // ✅ egyszer deklarálva
 

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -39,8 +39,36 @@ namespace GeminiV26.EntryTypes.FX
             if (!matrix.AllowPullback)
                 return Block(ctx, TradeDirection.None, "SESSION_MATRIX_PULLBACK_DISABLED", 0);
 
-            var longEval = EvaluateSide(ctx, fx, matrix, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, fx, matrix, TradeDirection.Short);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Block(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(ctx, fx, matrix, TradeDirection.Long);
+            else
+                longEval = Block(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
+
+            if (allowShort)
+                shortEval = EvaluateSide(ctx, fx, matrix, TradeDirection.Short);
+            else
+                shortEval = Block(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
 
             bool longValid = longEval.IsValid;
             bool shortValid = shortEval.IsValid;

--- a/EntryTypes/FX/FX_RangeBreakoutEntry.cs
+++ b/EntryTypes/FX/FX_RangeBreakoutEntry.cs
@@ -67,8 +67,62 @@ namespace GeminiV26.EntryTypes.FX
                 };
             }
 
-            var longEval = EvaluateSide(ctx, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NO_DIRECTIONAL_EDGE"
+                };
+            }
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(ctx, TradeDirection.Long);
+            else
+                longEval = new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.Long,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "DIR_BLOCKED"
+                };
+
+            if (allowShort)
+                shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            else
+                shortEval = new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.Short,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "DIR_BLOCKED"
+                };
 
             var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
             EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -35,8 +35,60 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx.ReversalEvidenceScore < MIN_EVIDENCE)
                 return Invalid(ctx, "WEAK_EVIDENCE");
 
-            var longEval = EvaluateSide(ctx, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NO_DIRECTIONAL_EDGE"
+                };
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(ctx, TradeDirection.Long);
+            else
+                longEval = new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.Long,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "DIR_BLOCKED"
+                };
+
+            if (allowShort)
+                shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            else
+                shortEval = new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.Short,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "DIR_BLOCKED"
+                };
 
             var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
             EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);

--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -25,8 +25,37 @@ namespace GeminiV26.EntryTypes.INDEX
                 return Reject(ctx, "CTX_NOT_READY", 0, TradeDirection.None);
 
             var p = IndexInstrumentMatrix.Get(ctx.Symbol);
-            var longEval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
+
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Reject(ctx, "NO_DIRECTIONAL_EDGE", 0, TradeDirection.None);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
+            else
+                longEval = Reject(ctx, "DIR_BLOCKED", 0, TradeDirection.Long);
+
+            if (allowShort)
+                shortEval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
+            else
+                shortEval = Reject(ctx, "DIR_BLOCKED", 0, TradeDirection.Short);
 
             var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
             EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -69,40 +69,70 @@ namespace GeminiV26.EntryTypes.INDEX
                 $"minAdx={minAdxTrend:F1} chopAdx={chopAdxThreshold:F1} fatigueTh={fatigueThreshold} scoreMult={scoreMultiplier:F2}"
             );
 
-            var longEval = EvaluateDir(
-                ctx,
-                TradeDirection.Long,
-                flagBars,
-                maxBarsSinceImpulse,
-                maxFlagRangeAtr,
-                breakoutBufferAtr,
-                maxDistFromEmaAtr,
-                requireStructure,
-                minAdxTrend,
-                chopAdxThreshold,
-                chopDiDiff,
-                fatigueThreshold,
-                fatigueAdxLevel,
-                scoreMultiplier);
+            bool allowLong = true;
+            bool allowShort = true;
 
-            var shortEval = EvaluateDir(
-                ctx,
-                TradeDirection.Short,
-                flagBars,
-                maxBarsSinceImpulse,
-                maxFlagRangeAtr,
-                breakoutBufferAtr,
-                maxDistFromEmaAtr,
-                requireStructure,
-                minAdxTrend,
-                chopAdxThreshold,
-                chopDiDiff,
-                fatigueThreshold,
-                fatigueAdxLevel,
-                scoreMultiplier);
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
 
-            longEval.Score += (int)Math.Round(matrix.EntryScoreModifier);
-            shortEval.Score += (int)Math.Round(matrix.EntryScoreModifier);
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Reject(ctx, "NO_DIRECTIONAL_EDGE", 0, TradeDirection.None);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateDir(
+                    ctx,
+                    TradeDirection.Long,
+                    flagBars,
+                    maxBarsSinceImpulse,
+                    maxFlagRangeAtr,
+                    breakoutBufferAtr,
+                    maxDistFromEmaAtr,
+                    requireStructure,
+                    minAdxTrend,
+                    chopAdxThreshold,
+                    chopDiDiff,
+                    fatigueThreshold,
+                    fatigueAdxLevel,
+                    scoreMultiplier);
+            else
+                longEval = Reject(ctx, "DIR_BLOCKED", 0, TradeDirection.Long);
+
+            if (allowShort)
+                shortEval = EvaluateDir(
+                    ctx,
+                    TradeDirection.Short,
+                    flagBars,
+                    maxBarsSinceImpulse,
+                    maxFlagRangeAtr,
+                    breakoutBufferAtr,
+                    maxDistFromEmaAtr,
+                    requireStructure,
+                    minAdxTrend,
+                    chopAdxThreshold,
+                    chopDiDiff,
+                    fatigueThreshold,
+                    fatigueAdxLevel,
+                    scoreMultiplier);
+            else
+                shortEval = Reject(ctx, "DIR_BLOCKED", 0, TradeDirection.Short);
+
+            if (allowLong)
+                longEval.Score += (int)Math.Round(matrix.EntryScoreModifier);
+
+            if (allowShort)
+                shortEval.Score += (int)Math.Round(matrix.EntryScoreModifier);
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -30,8 +30,36 @@ namespace GeminiV26.EntryTypes.INDEX
             if (p == null)
                 return Reject(ctx, TradeDirection.None, 0, "NO_INDEX_PROFILE");
 
-            var longEval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Reject(ctx, TradeDirection.None, 0, "NO_DIRECTIONAL_EDGE");
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
+            else
+                longEval = Reject(ctx, TradeDirection.Long, 0, "DIR_BLOCKED");
+
+            if (allowShort)
+                shortEval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
+            else
+                shortEval = Reject(ctx, TradeDirection.Short, 0, "DIR_BLOCKED");
 
             if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
             {

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -79,8 +79,36 @@ namespace GeminiV26.EntryTypes.METAL
                     return Invalid(ctx, "AMBIGUOUS_SPIKE");
             }
 
-            var buy = EvaluateSide(TradeDirection.Long, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
-            var sell = EvaluateSide(TradeDirection.Short, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return InvalidDir(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
+
+            EntryEvaluation buy;
+            EntryEvaluation sell;
+
+            if (allowLong)
+                buy = EvaluateSide(TradeDirection.Long, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
+            else
+                buy = InvalidDir(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
+
+            if (allowShort)
+                sell = EvaluateSide(TradeDirection.Short, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
+            else
+                sell = InvalidDir(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
 
             if (EntryDecisionPolicy.IsHardInvalid(buy) && EntryDecisionPolicy.IsHardInvalid(sell))
             {

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -33,8 +33,60 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null)
                 return Reject(ctx, "CTX_NOT_READY");
 
-            var longEval = EvaluateSide(ctx, matrix, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, matrix, TradeDirection.Short);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NO_DIRECTIONAL_EDGE"
+                };
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(ctx, matrix, TradeDirection.Long);
+            else
+                longEval = new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.Long,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "DIR_BLOCKED"
+                };
+
+            if (allowShort)
+                shortEval = EvaluateSide(ctx, matrix, TradeDirection.Short);
+            else
+                shortEval = new EntryEvaluation
+                {
+                    Symbol = ctx?.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.Short,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "DIR_BLOCKED"
+                };
 
             var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
             EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -29,8 +29,36 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx.MarketState?.IsTrend != true)
                 return Reject(ctx, "NO_TREND_STATE");
 
-            var buy = EvaluateSide(TradeDirection.Long, ctx, matrix);
-            var sell = EvaluateSide(TradeDirection.Short, ctx, matrix);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return Reject(ctx, "NO_DIRECTIONAL_EDGE");
+
+            EntryEvaluation buy;
+            EntryEvaluation sell;
+
+            if (allowLong)
+                buy = EvaluateSide(TradeDirection.Long, ctx, matrix);
+            else
+                buy = InvalidDir(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
+
+            if (allowShort)
+                sell = EvaluateSide(TradeDirection.Short, ctx, matrix);
+            else
+                sell = InvalidDir(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
 
             if (EntryDecisionPolicy.IsHardInvalid(buy) && EntryDecisionPolicy.IsHardInvalid(sell))
             {

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -21,8 +21,36 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null)
                 return Reject(ctx, "CTX_NOT_READY");
 
-            var longEval = EvaluateSide(ctx, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            bool allowLong = true;
+            bool allowShort = true;
+
+            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            {
+                allowLong = ctx.LogicBias == TradeDirection.Long;
+                allowShort = ctx.LogicBias == TradeDirection.Short;
+            }
+
+            if (ctx.HtfConfidence >= 0.6)
+            {
+                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
+                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
+            }
+
+            if (!allowLong && !allowShort)
+                return RejectDecision(ctx, TradeDirection.None, 0, "NO_DIRECTIONAL_EDGE", null);
+
+            EntryEvaluation longEval;
+            EntryEvaluation shortEval;
+
+            if (allowLong)
+                longEval = EvaluateSide(ctx, TradeDirection.Long);
+            else
+                longEval = RejectDecision(ctx, TradeDirection.Long, 0, "DIR_BLOCKED", null);
+
+            if (allowShort)
+                shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            else
+                shortEval = RejectDecision(ctx, TradeDirection.Short, 0, "DIR_BLOCKED", null);
 
             var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
             EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);


### PR DESCRIPTION
### Motivation
- Prevent wrong-direction and random-direction trades by ensuring only allowed directions are evaluated in entry evaluators as a control-layer fix, without changing scoring, selection, routing, or sizing behavior.
- Apply a uniform pre-filter to all targeted FX/INDEX/METAL/CRYPTO `Evaluate(...)` methods to enforce alignment with `LogicBias` and HTF signals before any per-direction scoring runs.

### Description
- Added `bool allowLong = true; bool allowShort = true;` at the top of each targeted `Evaluate(...)` and gated evaluation with a `LogicBias` filter using `ctx.LogicConfidence >= 60` to restrict directions accordingly.
- Added a secondary HTF check using `ctx.HtfConfidence >= 0.6` (per spec) that further constrains `allowLong`/`allowShort`, and return an immediate `NO_DIRECTIONAL_EDGE` result when neither direction is allowed.
- Replaced unconditional dual-direction calls with conditional evaluation: allowed sides call the existing `EvalForDir`/`EvaluateSide`/`EvaluateDir` logic, blocked sides produce an invalid result using existing helpers (reason `DIR_BLOCKED`), while preserving downstream selection and normalization unchanged.
- Changes applied to 19 entry files under EntryTypes/FX, EntryTypes/INDEX, EntryTypes/METAL and EntryTypes/CRYPTO and do not modify `EvalForDir(...)`, scoring formulas, weights, penalties, thresholds (other than the explicit HTF 0.6), or method signatures.

### Testing
- Ran a repository marker validation (`python` script) that confirmed all 19 targeted files contain the expected pre-filter markers (`allowLong`, `allowShort`, `LogicConfidence >= 60`, `HtfConfidence >= 0.6`, `NO_DIRECTIONAL_EDGE`, `DIR_BLOCKED`) and it succeeded.
- Attempted to run a C# build/compile but the container lacks a C# toolchain (`dotnet`, `csc`, `mcs` not available), so compilation could not be executed in this environment.
- No solution/project (`.sln`/`.csproj`) entrypoint was available in the environment for automated build tooling to run, so no further automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd06c72a608328abe667bc8dd5230e)