### PR TITLE
Fix legacy EntryContext compatibility aliases

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -267,6 +267,53 @@ namespace GeminiV26.Core.Entry
         // =========================
         // TEMP BACKWARD COMPAT
         // =========================
+        [Obsolete("LEGACY – use LogicBiasDirection")]
+        public TradeDirection LogicBias => LogicBiasDirection;
+
+        [Obsolete("LEGACY – use LogicBiasConfidence")]
+        public int LogicConfidence => LogicBiasConfidence;
+
+        [Obsolete("LEGACY – use the instrument-specific *HtfAllowedDirection property")]
+        public TradeDirection HtfDirection
+        {
+            get
+            {
+                if (FxHtfAllowedDirection != TradeDirection.None)
+                    return FxHtfAllowedDirection;
+
+                if (CryptoHtfAllowedDirection != TradeDirection.None)
+                    return CryptoHtfAllowedDirection;
+
+                if (IndexHtfAllowedDirection != TradeDirection.None)
+                    return IndexHtfAllowedDirection;
+
+                if (MetalHtfAllowedDirection != TradeDirection.None)
+                    return MetalHtfAllowedDirection;
+
+                return TradeDirection.None;
+            }
+        }
+
+        [Obsolete("LEGACY – use the instrument-specific *HtfConfidence01 property")]
+        public double HtfConfidence
+        {
+            get
+            {
+                double maxConfidence = FxHtfConfidence01;
+
+                if (CryptoHtfConfidence01 > maxConfidence)
+                    maxConfidence = CryptoHtfConfidence01;
+
+                if (IndexHtfConfidence01 > maxConfidence)
+                    maxConfidence = IndexHtfConfidence01;
+
+                if (MetalHtfConfidence01 > maxConfidence)
+                    maxConfidence = MetalHtfConfidence01;
+
+                return maxConfidence;
+            }
+        }
+
         public bool IsValidFlagStructure_M5 =>
             HasFlagLong_M5 || HasFlagShort_M5;
     }


### PR DESCRIPTION
### Motivation
- A recent confidence/SSOT refactor renamed or centralized several entry-context properties and caused legacy entry code to reference removed names, producing widespread errors. 
- Provide a compatibility bridge so older entry types and analytics code keep working without changing business logic.

### Description
- Added obsolete alias `LogicBias` that returns `LogicBiasDirection` in `Core/Entry/EntryContext.cs` to restore legacy references. 
- Added obsolete alias `LogicConfidence` that returns `LogicBiasConfidence` in `Core/Entry/EntryContext.cs` to restore legacy references. 
- Added obsolete computed `HtfDirection` and `HtfConfidence` accessors in `Core/Entry/EntryContext.cs` that aggregate instrument-specific HTF fields (`FxHtfAllowedDirection`, `CryptoHtfAllowedDirection`, `IndexHtfAllowedDirection`, `MetalHtfAllowedDirection` and the corresponding `*HtfConfidence01`).

### Testing
- Located and inspected all usages of the legacy symbols via `rg` to confirm the aliases cover the referenced sites. 
- Verified the modified file `Core/Entry/EntryContext.cs` was saved into the repository. 
- A full build/test run could not be performed in this environment because no `.csproj` or `.sln` files were available, so compilation was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd0a5cb524832897b8c4cdd130cae3)