### PR TITLE
Harden entry evaluators to single LogicBias-driven direction

### DIFF
--- a/EntryTypes/BR_RangeBreakoutEntry.cs
+++ b/EntryTypes/BR_RangeBreakoutEntry.cs
@@ -45,6 +45,19 @@ namespace GeminiV26.EntryTypes
                 };
             }
 
+            if (ctx.LogicBias == TradeDirection.None)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NO_LOGIC_BIAS"
+                };
+            }
+
             if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MinRangeBars)
             {
                 return new EntryEvaluation
@@ -58,12 +71,42 @@ namespace GeminiV26.EntryTypes
                 };
             }
 
-            var longEval = EvaluateSide(ctx, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "HTF_MISMATCH"
+                };
+            }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            if (ctx.LogicBias == TradeDirection.Long)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+
+            return new EntryEvaluation
+            {
+                Symbol = ctx.Symbol,
+                Type = Type,
+                Direction = TradeDirection.None,
+                Score = 0,
+                IsValid = false,
+                Reason = "NO_LOGIC_BIAS"
+            };
         }
-
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
         {
             var eval = new EntryEvaluation

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -25,6 +25,9 @@ namespace GeminiV26.EntryTypes.Crypto
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 20)
                 return Invalid(ctx, "CTX_NOT_READY");
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
+
             if (ctx.AtrM5 <= 0)
                 return Invalid(ctx, "ATR_ZERO");
 
@@ -92,49 +95,24 @@ namespace GeminiV26.EntryTypes.Crypto
 
             var profile = CryptoInstrumentMatrix.Get(ctx.Symbol);
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(ctx, TradeDirection.Long, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Short, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(ctx, TradeDirection.Long, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
-            else
-                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
-
-            if (allowShort)
-                shortEval = EvaluateSide(ctx, TradeDirection.Short, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
-            else
-                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
-
-            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
-            {
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
-                ctx.Log?.Invoke($"[FLAG][REJECT] No hard-tradable direction long={longEval.Score}/{longEval.IsValid} short={shortEval.Score}/{shortEval.IsValid}");
-                return Invalid(ctx, "FLAG_DIRECTION_INVALID");
-            }
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
         }
-
         private EntryEvaluation EvaluateSide(
             EntryContext ctx,
             TradeDirection dir,

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -20,47 +20,32 @@ namespace GeminiV26.EntryTypes.Crypto
             var originalTrendDirection = ctx.TrendDirection;
             try
             {
-                bool allowLong = true;
-                bool allowShort = true;
+                if (ctx.LogicBias == TradeDirection.None)
+                    return Block(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
 
-                if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+                if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                    return Block(ctx, "HTF_MISMATCH", 0, TradeDirection.None);
+
+                if (ctx.LogicBias == TradeDirection.Long)
                 {
-                    allowLong = ctx.LogicBias == TradeDirection.Long;
-                    allowShort = ctx.LogicBias == TradeDirection.Short;
+                    var eval = EvaluateDirectional(ctx, TradeDirection.Long);
+                    EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                    return EntryDecisionPolicy.Normalize(eval);
+                }
+                else if (ctx.LogicBias == TradeDirection.Short)
+                {
+                    var eval = EvaluateDirectional(ctx, TradeDirection.Short);
+                    EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                    return EntryDecisionPolicy.Normalize(eval);
                 }
 
-                if (ctx.HtfConfidence >= 0.6)
-                {
-                    allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                    allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-                }
-
-                if (!allowLong && !allowShort)
-                    return Block(ctx, "NO_DIRECTIONAL_EDGE", 0, TradeDirection.None);
-
-                EntryEvaluation longEval;
-                EntryEvaluation shortEval;
-
-                if (allowLong)
-                    longEval = EvaluateDirectional(ctx, TradeDirection.Long);
-                else
-                    longEval = Block(ctx, "DIR_BLOCKED", 0, TradeDirection.Long);
-
-                if (allowShort)
-                    shortEval = EvaluateDirectional(ctx, TradeDirection.Short);
-                else
-                    shortEval = Block(ctx, "DIR_BLOCKED", 0, TradeDirection.Short);
-
-                var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-                return EntryDecisionPolicy.Normalize(selected);
+                return Block(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
             }
             finally
             {
                 ctx.TrendDirection = originalTrendDirection;
             }
         }
-
         private EntryEvaluation EvaluateDirectional(EntryContext ctx, TradeDirection forcedDirection)
         {
             int score = 36;

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -15,6 +15,9 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Invalid(ctx, "NO_LOGIC_BIAS", TradeDirection.None, 0);
+
             var crypto = CryptoInstrumentMatrix.Get(ctx.Symbol);
 
             if (!crypto.AllowRangeBreakout)
@@ -23,66 +26,24 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MIN_RANGE_BARS)
                 return Invalid(ctx, "NO_RANGE");
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Invalid(ctx, "HTF_MISMATCH", TradeDirection.None, 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(ctx, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return new EntryEvaluation
-                {
-                    Symbol = ctx?.Symbol,
-                    Type = EntryType.Crypto_RangeBreakout,
-                    Direction = TradeDirection.None,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "NO_DIRECTIONAL_EDGE;"
-                };
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(ctx, TradeDirection.Long);
-            else
-                longEval = new EntryEvaluation
-                {
-                    Symbol = ctx?.Symbol,
-                    Type = EntryType.Crypto_RangeBreakout,
-                    Direction = TradeDirection.Long,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "DIR_BLOCKED;"
-                };
-
-            if (allowShort)
-                shortEval = EvaluateSide(ctx, TradeDirection.Short);
-            else
-                shortEval = new EntryEvaluation
-                {
-                    Symbol = ctx?.Symbol,
-                    Type = EntryType.Crypto_RangeBreakout,
-                    Direction = TradeDirection.Short,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "DIR_BLOCKED;"
-                };
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Invalid(ctx, "NO_LOGIC_BIAS", TradeDirection.None, 0);
         }
-
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
         {
             int score = 25;

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -15,45 +15,30 @@ namespace GeminiV26.EntryTypes.Crypto
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Invalid(ctx, "NO_LOGIC_BIAS", TradeDirection.None, 0);
+
             if (!ctx.IsVolatilityAcceptable_Crypto)
                 return Invalid(ctx, "CRYPTO_VOL_DISABLED");
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Invalid(ctx, "HTF_MISMATCH", TradeDirection.None, 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(ctx, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Invalid(ctx, "NO_DIRECTIONAL_EDGE", TradeDirection.None, 0);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(ctx, TradeDirection.Long);
-            else
-                longEval = Invalid(ctx, "DIR_BLOCKED", TradeDirection.Long, 0);
-
-            if (allowShort)
-                shortEval = EvaluateSide(ctx, TradeDirection.Short);
-            else
-                shortEval = Invalid(ctx, "DIR_BLOCKED", TradeDirection.Short, 0);
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Invalid(ctx, "NO_LOGIC_BIAS", TradeDirection.None, 0);
         }
-
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
         {
             int score = 60;

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -18,46 +18,26 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.LogicBias == TradeDirection.None)
+                return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
+
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(TradeDirection.Long, ctx);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(TradeDirection.Short, ctx);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(TradeDirection.Long, ctx);
-            else
-                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
-
-            if (allowShort)
-                shortEval = EvaluateSide(TradeDirection.Short, ctx);
-            else
-                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
-
-            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
-            {
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
-                return Invalid(ctx, "NO_VALID_SIDE");
-            }
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
         }
 
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -29,6 +29,9 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 30)
                 return Invalid(ctx, TradeDirection.None, "CTX_NOT_READY", 0);
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
+
             if (ctx.AtrM5 <= 0)
                 return Invalid(ctx, TradeDirection.None, "ATR_NOT_READY", 0);
 
@@ -43,69 +46,25 @@ namespace GeminiV26.EntryTypes.FX
             if (fx.FlagTuning == null || !fx.FlagTuning.TryGetValue(ctx.Session, out var tuning))
                 return Invalid(ctx, TradeDirection.None, "NO_FLAG_TUNING", 0);
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvalForDir(ctx, fx, tuning, TradeDirection.Long);
+                ApplyScoreModifier(eval, matrix);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvalForDir(ctx, fx, tuning, TradeDirection.Short);
+                ApplyScoreModifier(eval, matrix);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvalForDir(ctx, fx, tuning, TradeDirection.Long);
-            else
-                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
-
-            if (allowShort)
-                shortEval = EvalForDir(ctx, fx, tuning, TradeDirection.Short);
-            else
-                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
-
-            if (allowLong)
-                ApplyScoreModifier(longEval, matrix);
-
-            if (allowShort)
-                ApplyScoreModifier(shortEval, matrix);
-
-            bool buyValid = longEval.IsValid;
-            bool sellValid = shortEval.IsValid;
-
-            if (!buyValid && !sellValid)
-            {
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
-                ctx.Log?.Invoke($"[FLAG][REJECT] No valid direction buyValid={buyValid} sellValid={sellValid}");
-                return Invalid(ctx, TradeDirection.None, "FLAG_DIRECTION_INVALID", Math.Max(longEval.Score, shortEval.Score));
-            }
-
-            // Prefer VALID; if both valid -> higher score wins
-            if (buyValid && sellValid)
-            {
-                var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-                return EntryDecisionPolicy.Normalize(selected);
-            }
-
-            if (buyValid)
-            {
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, longEval.Direction);
-                return longEval;
-            }
-
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, shortEval.Direction);
-            return shortEval;
+            return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
         }
 
         // =====================================================

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -25,46 +25,26 @@ namespace GeminiV26.EntryTypes.FX
             if (!ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.LogicBias == TradeDirection.None)
+                return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
+
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(TradeDirection.Long, ctx);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(TradeDirection.Short, ctx);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(TradeDirection.Long, ctx);
-            else
-                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
-
-            if (allowShort)
-                shortEval = EvaluateSide(TradeDirection.Short, ctx);
-            else
-                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
-
-            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
-            {
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
-                return Invalid(ctx, "NO_VALID_SIDE");
-            }
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
         }
 
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -20,6 +20,9 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
+
             var fx = FxInstrumentMatrix.Get(ctx.Symbol);
 
             if (fx == null)
@@ -28,46 +31,23 @@ namespace GeminiV26.EntryTypes.FX
             if (!fx.FlagTuning.TryGetValue(ctx.Session, out var tuning))
                 return Invalid(ctx, "NO_SESSION_TUNING");
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(TradeDirection.Long, ctx, tuning);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(TradeDirection.Short, ctx, tuning);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(TradeDirection.Long, ctx, tuning);
-            else
-                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
-
-            if (allowShort)
-                shortEval = EvaluateSide(TradeDirection.Short, ctx, tuning);
-            else
-                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
-
-            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
-            {
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
-                return Invalid(ctx, "NO_VALID_SIDE");
-            }
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
         }
 
         private EntryEvaluation EvaluateSide(

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -18,6 +18,9 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 30)
                 return Invalid(ctx, TradeDirection.None, "CTX_NOT_READY", 0);
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
+
             if (ctx.AtrM5 <= 0)
                 return Invalid(ctx, TradeDirection.None, "ATR_NOT_READY", 0);
 
@@ -25,52 +28,23 @@ namespace GeminiV26.EntryTypes.FX
             if (fx == null)
                 return Invalid(ctx, TradeDirection.None, "NO_FX_PROFILE", 0);
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvalForDir(ctx, fx, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvalForDir(ctx, fx, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Invalid(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvalForDir(ctx, fx, TradeDirection.Long);
-            else
-                longEval = Invalid(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
-
-            if (allowShort)
-                shortEval = EvalForDir(ctx, fx, TradeDirection.Short);
-            else
-                shortEval = Invalid(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
-
-            EntryEvaluation selected; // ✅ egyszer deklarálva
-
-            if (longEval.IsValid && shortEval.IsValid)
-            {
-                selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-                return EntryDecisionPolicy.Normalize(selected);
-            }
-
-            if (longEval.IsValid) return longEval;
-            if (shortEval.IsValid) return shortEval;
-
-            selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
         }
 
         private static EntryEvaluation EvalForDir(

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -25,6 +25,9 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx == null || !ctx.IsReady)
                 return Block(ctx, TradeDirection.None, "CTX_NOT_READY", 0);
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Block(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
+
             var fx = FxInstrumentMatrix.Get(ctx.Symbol);
             if (fx == null)
                 return Block(ctx, TradeDirection.None, "NO_FX_PROFILE", 0);
@@ -39,73 +42,23 @@ namespace GeminiV26.EntryTypes.FX
             if (!matrix.AllowPullback)
                 return Block(ctx, TradeDirection.None, "SESSION_MATRIX_PULLBACK_DISABLED", 0);
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Block(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(ctx, fx, matrix, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, fx, matrix, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Block(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(ctx, fx, matrix, TradeDirection.Long);
-            else
-                longEval = Block(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
-
-            if (allowShort)
-                shortEval = EvaluateSide(ctx, fx, matrix, TradeDirection.Short);
-            else
-                shortEval = Block(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
-
-            bool longValid = longEval.IsValid;
-            bool shortValid = shortEval.IsValid;
-
-            if (!longValid && !shortValid)
-            {
-                int bestScore = Math.Max(longEval.Score, shortEval.Score);
-                ctx?.Log?.Invoke($"[FX_PullbackEntry] BOTH_INVALID long={longEval.Score} short={shortEval.Score}");
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
-
-                return EntryDecisionPolicy.Normalize(new EntryEvaluation
-                {
-                    Symbol = ctx?.Symbol,
-                    Type = EntryType.FX_Pullback,
-                    Direction = TradeDirection.None,
-                    Score = bestScore,
-                    IsValid = false,
-                    Reason = "PB_BOTH_INVALID"
-                });
-            }
-
-            if (longValid && shortValid)
-            {
-                if (ctx.FxHtfAllowedDirection == TradeDirection.Long)
-                    longEval.Score += 3;
-
-                if (ctx.FxHtfAllowedDirection == TradeDirection.Short)
-                    shortEval.Score += 3;
-
-                var winner = longEval.Score >= shortEval.Score ? longEval : shortEval;
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, winner.Direction);
-                return EntryDecisionPolicy.Normalize(winner);
-            }
-
-            var selected = longValid ? longEval : shortEval;
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Block(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
         }
 
         private EntryEvaluation EvaluateSide(

--- a/EntryTypes/FX/FX_RangeBreakoutEntry.cs
+++ b/EntryTypes/FX/FX_RangeBreakoutEntry.cs
@@ -41,6 +41,19 @@ namespace GeminiV26.EntryTypes.FX
                 };
             }
 
+            if (ctx.LogicBias == TradeDirection.None)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NO_LOGIC_BIAS"
+                };
+            }
+
             if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MinRangeBars)
             {
                 return new EntryEvaluation
@@ -67,22 +80,7 @@ namespace GeminiV26.EntryTypes.FX
                 };
             }
 
-            bool allowLong = true;
-            bool allowShort = true;
-
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
-            {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
-            }
-
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
             {
                 return new EntryEvaluation
                 {
@@ -91,42 +89,32 @@ namespace GeminiV26.EntryTypes.FX
                     Direction = TradeDirection.None,
                     Score = 0,
                     IsValid = false,
-                    Reason = "NO_DIRECTIONAL_EDGE"
+                    Reason = "HTF_MISMATCH"
                 };
             }
 
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
+            if (ctx.LogicBias == TradeDirection.Long)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
 
-            if (allowLong)
-                longEval = EvaluateSide(ctx, TradeDirection.Long);
-            else
-                longEval = new EntryEvaluation
-                {
-                    Symbol = ctx.Symbol,
-                    Type = Type,
-                    Direction = TradeDirection.Long,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "DIR_BLOCKED"
-                };
-
-            if (allowShort)
-                shortEval = EvaluateSide(ctx, TradeDirection.Short);
-            else
-                shortEval = new EntryEvaluation
-                {
-                    Symbol = ctx.Symbol,
-                    Type = Type,
-                    Direction = TradeDirection.Short,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "DIR_BLOCKED"
-                };
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return new EntryEvaluation
+            {
+                Symbol = ctx.Symbol,
+                Type = Type,
+                Direction = TradeDirection.None,
+                Score = 0,
+                IsValid = false,
+                Reason = "NO_LOGIC_BIAS"
+            };
         }
 
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -18,6 +18,9 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
+
             // =========================================================
             // FX REVERSAL – ASIA SESSION HARD BLOCK (Phase 3.8)
             // =========================================================
@@ -35,66 +38,24 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx.ReversalEvidenceScore < MIN_EVIDENCE)
                 return Invalid(ctx, "WEAK_EVIDENCE");
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(ctx, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return new EntryEvaluation
-                {
-                    Symbol = ctx?.Symbol,
-                    Type = Type,
-                    Direction = TradeDirection.None,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "NO_DIRECTIONAL_EDGE"
-                };
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(ctx, TradeDirection.Long);
-            else
-                longEval = new EntryEvaluation
-                {
-                    Symbol = ctx?.Symbol,
-                    Type = Type,
-                    Direction = TradeDirection.Long,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "DIR_BLOCKED"
-                };
-
-            if (allowShort)
-                shortEval = EvaluateSide(ctx, TradeDirection.Short);
-            else
-                shortEval = new EntryEvaluation
-                {
-                    Symbol = ctx?.Symbol,
-                    Type = Type,
-                    Direction = TradeDirection.Short,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "DIR_BLOCKED"
-                };
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
         }
-
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
         {
             int score = 0;

--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -24,44 +24,29 @@ namespace GeminiV26.EntryTypes.INDEX
             if (ctx == null || !ctx.IsReady)
                 return Reject(ctx, "CTX_NOT_READY", 0, TradeDirection.None);
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Reject(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
+
             var p = IndexInstrumentMatrix.Get(ctx.Symbol);
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Reject(ctx, "HTF_MISMATCH", 0, TradeDirection.None);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Reject(ctx, "NO_DIRECTIONAL_EDGE", 0, TradeDirection.None);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
-            else
-                longEval = Reject(ctx, "DIR_BLOCKED", 0, TradeDirection.Long);
-
-            if (allowShort)
-                shortEval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
-            else
-                shortEval = Reject(ctx, "DIR_BLOCKED", 0, TradeDirection.Short);
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Reject(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
         }
-
         private EntryEvaluation EvaluateSide(
             EntryContext ctx,
             dynamic p,

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -40,6 +40,9 @@ namespace GeminiV26.EntryTypes.INDEX
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 40)
                 return Reject(ctx, "CTX_NOT_READY", 0, TradeDirection.None);
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Reject(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
+
             if (ctx.AtrM5 <= 0)
                 return Reject(ctx, "ATR_NOT_READY", 0, TradeDirection.None);
 
@@ -69,29 +72,12 @@ namespace GeminiV26.EntryTypes.INDEX
                 $"minAdx={minAdxTrend:F1} chopAdx={chopAdxThreshold:F1} fatigueTh={fatigueThreshold} scoreMult={scoreMultiplier:F2}"
             );
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Reject(ctx, "HTF_MISMATCH", 0, TradeDirection.None);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
-            }
-
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Reject(ctx, "NO_DIRECTIONAL_EDGE", 0, TradeDirection.None);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateDir(
+                var eval = EvaluateDir(
                     ctx,
                     TradeDirection.Long,
                     flagBars,
@@ -106,11 +92,13 @@ namespace GeminiV26.EntryTypes.INDEX
                     fatigueThreshold,
                     fatigueAdxLevel,
                     scoreMultiplier);
-            else
-                longEval = Reject(ctx, "DIR_BLOCKED", 0, TradeDirection.Long);
-
-            if (allowShort)
-                shortEval = EvaluateDir(
+                eval.Score += (int)Math.Round(matrix.EntryScoreModifier);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateDir(
                     ctx,
                     TradeDirection.Short,
                     flagBars,
@@ -125,27 +113,13 @@ namespace GeminiV26.EntryTypes.INDEX
                     fatigueThreshold,
                     fatigueAdxLevel,
                     scoreMultiplier);
-            else
-                shortEval = Reject(ctx, "DIR_BLOCKED", 0, TradeDirection.Short);
-
-            if (allowLong)
-                longEval.Score += (int)Math.Round(matrix.EntryScoreModifier);
-
-            if (allowShort)
-                shortEval.Score += (int)Math.Round(matrix.EntryScoreModifier);
-
-            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
-            {
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
-                ctx.Log?.Invoke($"[FLAG][REJECT] No hard-tradable direction long={longEval.Score}/{longEval.IsValid} short={shortEval.Score}/{shortEval.IsValid}");
-                return Reject(ctx, "FLAG_DIRECTION_INVALID", Math.Max(longEval.Score, shortEval.Score), TradeDirection.None);
+                eval.Score += (int)Math.Round(matrix.EntryScoreModifier);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Reject(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
         }
-
         private EntryEvaluation EvaluateDir(
             EntryContext ctx,
             TradeDirection dir,

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -26,52 +26,31 @@ namespace GeminiV26.EntryTypes.INDEX
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 10)
                 return Reject(ctx, TradeDirection.None, 0, "CTX_NOT_READY");
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Reject(ctx, TradeDirection.None, 0, "NO_LOGIC_BIAS");
+
             var p = IndexInstrumentMatrix.Get(ctx.Symbol);
             if (p == null)
                 return Reject(ctx, TradeDirection.None, 0, "NO_INDEX_PROFILE");
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Reject(ctx, TradeDirection.None, 0, "HTF_MISMATCH");
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Reject(ctx, TradeDirection.None, 0, "NO_DIRECTIONAL_EDGE");
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(ctx, p, matrix, TradeDirection.Long);
-            else
-                longEval = Reject(ctx, TradeDirection.Long, 0, "DIR_BLOCKED");
-
-            if (allowShort)
-                shortEval = EvaluateSide(ctx, p, matrix, TradeDirection.Short);
-            else
-                shortEval = Reject(ctx, TradeDirection.Short, 0, "DIR_BLOCKED");
-
-            if (EntryDecisionPolicy.IsHardInvalid(longEval) && EntryDecisionPolicy.IsHardInvalid(shortEval))
-            {
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, TradeDirection.None);
-                return Reject(ctx, TradeDirection.None, Math.Max(longEval?.Score ?? 0, shortEval?.Score ?? 0), "IDX_PULLBACK_NO_SIDE");
-            }
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Reject(ctx, TradeDirection.None, 0, "NO_LOGIC_BIAS");
         }
-
         private EntryEvaluation EvaluateSide(
             EntryContext ctx,
             dynamic p,

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -29,6 +29,9 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < BarsNotReadyMin)
                 return Invalid(ctx, "CTX_NOT_READY");
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return InvalidDir(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
+
             var matrix = ctx.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowFlag)
                 return Invalid(ctx, "SESSION_DISABLED");
@@ -61,7 +64,7 @@ namespace GeminiV26.EntryTypes.METAL
 
             if (!ctx.HasFlagLong_M5 && !ctx.HasFlagShort_M5)
                 return Invalid(ctx, "NO_FLAG_STRUCTURE");
-                
+
             double rangeAtr = hasValidRange && ctx.AtrM5 > 0
                 ? (hi - lo) / ctx.AtrM5
                 : 0;
@@ -79,65 +82,24 @@ namespace GeminiV26.EntryTypes.METAL
                     return Invalid(ctx, "AMBIGUOUS_SPIKE");
             }
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return InvalidDir(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(TradeDirection.Long, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(TradeDirection.Short, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return InvalidDir(ctx, TradeDirection.None, "NO_DIRECTIONAL_EDGE", 0);
-
-            EntryEvaluation buy;
-            EntryEvaluation sell;
-
-            if (allowLong)
-                buy = EvaluateSide(TradeDirection.Long, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
-            else
-                buy = InvalidDir(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
-
-            if (allowShort)
-                sell = EvaluateSide(TradeDirection.Short, ctx, tuning, hi, lo, hasValidRange, rangeAtr, bar, last);
-            else
-                sell = InvalidDir(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
-
-            if (EntryDecisionPolicy.IsHardInvalid(buy) && EntryDecisionPolicy.IsHardInvalid(sell))
-            {
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, TradeDirection.None);
-                return Reject(ctx, tag, session, tuning, buy, sell);
-            }
-
-            int diff = buy.Score - sell.Score;
-
-            if (Math.Abs(diff) <= ScoreDeadband)
-            {
-                if (ctx.BreakoutUpBarsSince < ctx.BreakoutDownBarsSince)
-                {
-                    EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, buy.Direction);
-                    return buy;
-                }
-
-                if (ctx.BreakoutDownBarsSince < ctx.BreakoutUpBarsSince)
-                {
-                    EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, sell.Direction);
-                    return sell;
-                }
-            }
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, buy, sell);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return InvalidDir(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
         }
-
         private EntryEvaluation EvaluateSide(
             TradeDirection dir,
             EntryContext ctx,

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -33,22 +33,7 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null)
                 return Reject(ctx, "CTX_NOT_READY");
 
-            bool allowLong = true;
-            bool allowShort = true;
-
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
-            {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
-            }
-
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
+            if (ctx.LogicBias == TradeDirection.None)
                 return new EntryEvaluation
                 {
                     Symbol = ctx?.Symbol,
@@ -56,43 +41,43 @@ namespace GeminiV26.EntryTypes.METAL
                     Direction = TradeDirection.None,
                     Score = 0,
                     IsValid = false,
-                    Reason = "NO_DIRECTIONAL_EDGE"
+                    Reason = "NO_LOGIC_BIAS"
                 };
 
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(ctx, matrix, TradeDirection.Long);
-            else
-                longEval = new EntryEvaluation
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return new EntryEvaluation
                 {
                     Symbol = ctx?.Symbol,
                     Type = Type,
-                    Direction = TradeDirection.Long,
+                    Direction = TradeDirection.None,
                     Score = 0,
                     IsValid = false,
-                    Reason = "DIR_BLOCKED"
+                    Reason = "HTF_MISMATCH"
                 };
 
-            if (allowShort)
-                shortEval = EvaluateSide(ctx, matrix, TradeDirection.Short);
-            else
-                shortEval = new EntryEvaluation
-                {
-                    Symbol = ctx?.Symbol,
-                    Type = Type,
-                    Direction = TradeDirection.Short,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "DIR_BLOCKED"
-                };
+            if (ctx.LogicBias == TradeDirection.Long)
+            {
+                var eval = EvaluateSide(ctx, matrix, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, matrix, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
 
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return new EntryEvaluation
+            {
+                Symbol = ctx?.Symbol,
+                Type = Type,
+                Direction = TradeDirection.None,
+                Score = 0,
+                IsValid = false,
+                Reason = "NO_LOGIC_BIAS"
+            };
         }
-
         private EntryEvaluation EvaluateSide(EntryContext ctx, SessionMatrixConfig matrix, TradeDirection dir)
         {
             int score = 60;

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -26,69 +26,30 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < BarsNotReadyMin)
                 return Reject(ctx, "CTX_NOT_READY");
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return Reject(ctx, "NO_LOGIC_BIAS");
+
             if (ctx.MarketState?.IsTrend != true)
                 return Reject(ctx, "NO_TREND_STATE");
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return Reject(ctx, "HTF_MISMATCH");
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(TradeDirection.Long, ctx, matrix);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(TradeDirection.Short, ctx, matrix);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return Reject(ctx, "NO_DIRECTIONAL_EDGE");
-
-            EntryEvaluation buy;
-            EntryEvaluation sell;
-
-            if (allowLong)
-                buy = EvaluateSide(TradeDirection.Long, ctx, matrix);
-            else
-                buy = InvalidDir(ctx, TradeDirection.Long, "DIR_BLOCKED", 0);
-
-            if (allowShort)
-                sell = EvaluateSide(TradeDirection.Short, ctx, matrix);
-            else
-                sell = InvalidDir(ctx, TradeDirection.Short, "DIR_BLOCKED", 0);
-
-            if (EntryDecisionPolicy.IsHardInvalid(buy) && EntryDecisionPolicy.IsHardInvalid(sell))
-            {
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, TradeDirection.None);
-                return RejectBoth(ctx, buy, sell);
-            }
-
-            int diff = buy.Score - sell.Score;
-
-            if (Math.Abs(diff) <= ScoreDeadband)
-            {
-                // döntés: melyik oldal reagált előbb
-                if (ctx.BarsSinceImpulseLong_M5 < ctx.BarsSinceImpulseShort_M5)
-                {
-                    EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, buy.Direction);
-                    return buy;
-                }
-
-                if (ctx.BarsSinceImpulseShort_M5 < ctx.BarsSinceImpulseLong_M5)
-                {
-                    EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, sell.Direction);
-                    return sell;
-                }
-            }
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, buy, sell);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), buy, sell, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return Reject(ctx, "NO_LOGIC_BIAS");
         }
-
         private EntryEvaluation EvaluateSide(
             TradeDirection dir,
             EntryContext ctx,

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -21,42 +21,27 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null)
                 return Reject(ctx, "CTX_NOT_READY");
 
-            bool allowLong = true;
-            bool allowShort = true;
+            if (ctx.LogicBias == TradeDirection.None)
+                return RejectDecision(ctx, TradeDirection.None, 0, "NO_LOGIC_BIAS", null);
 
-            if (ctx.LogicBias != TradeDirection.None && ctx.LogicConfidence >= 60)
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return RejectDecision(ctx, TradeDirection.None, 0, "HTF_MISMATCH", null);
+
+            if (ctx.LogicBias == TradeDirection.Long)
             {
-                allowLong = ctx.LogicBias == TradeDirection.Long;
-                allowShort = ctx.LogicBias == TradeDirection.Short;
+                var eval = EvaluateSide(ctx, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
             }
 
-            if (ctx.HtfConfidence >= 0.6)
-            {
-                allowLong = allowLong && ctx.HtfDirection == TradeDirection.Long;
-                allowShort = allowShort && ctx.HtfDirection == TradeDirection.Short;
-            }
-
-            if (!allowLong && !allowShort)
-                return RejectDecision(ctx, TradeDirection.None, 0, "NO_DIRECTIONAL_EDGE", null);
-
-            EntryEvaluation longEval;
-            EntryEvaluation shortEval;
-
-            if (allowLong)
-                longEval = EvaluateSide(ctx, TradeDirection.Long);
-            else
-                longEval = RejectDecision(ctx, TradeDirection.Long, 0, "DIR_BLOCKED", null);
-
-            if (allowShort)
-                shortEval = EvaluateSide(ctx, TradeDirection.Short);
-            else
-                shortEval = RejectDecision(ctx, TradeDirection.Short, 0, "DIR_BLOCKED", null);
-
-            var selected = EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval);
-            EntryDirectionQuality.LogDecision(ctx, Type.ToString(), longEval, shortEval, selected.Direction);
-            return EntryDecisionPolicy.Normalize(selected);
+            return RejectDecision(ctx, TradeDirection.None, 0, "NO_LOGIC_BIAS", null);
         }
-
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
         {
             var reasons = new List<string>(8);

--- a/EntryTypes/TC_FlagEntry.cs
+++ b/EntryTypes/TC_FlagEntry.cs
@@ -40,6 +40,19 @@ namespace GeminiV26.EntryTypes
                 };
             }
 
+            if (ctx.LogicBias == TradeDirection.None)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NO_LOGIC_BIAS"
+                };
+            }
+
             if (!ctx.HasImpulse_M5)
             {
                 return new EntryEvaluation
@@ -84,12 +97,42 @@ namespace GeminiV26.EntryTypes
                 };
             }
 
-            var longEval = EvaluateSide(ctx, impulseMove, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, impulseMove, TradeDirection.Short);
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "HTF_MISMATCH"
+                };
+            }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            if (ctx.LogicBias == TradeDirection.Long)
+            {
+                var eval = EvaluateSide(ctx, impulseMove, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, impulseMove, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+
+            return new EntryEvaluation
+            {
+                Symbol = ctx.Symbol,
+                Type = Type,
+                Direction = TradeDirection.None,
+                Score = 0,
+                IsValid = false,
+                Reason = "NO_LOGIC_BIAS"
+            };
         }
-
         private EntryEvaluation EvaluateSide(EntryContext ctx, double impulseMove, TradeDirection dir)
         {
             var eval = new EntryEvaluation

--- a/EntryTypes/TC_PullbackEntry.cs
+++ b/EntryTypes/TC_PullbackEntry.cs
@@ -41,12 +41,55 @@ namespace GeminiV26.EntryTypes
                 };
             }
 
-            var longEval = EvaluateDirectional(ctx, TradeDirection.Long);
-            var shortEval = EvaluateDirectional(ctx, TradeDirection.Short);
+            if (ctx.LogicBias == TradeDirection.None)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NO_LOGIC_BIAS"
+                };
+            }
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            {
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "HTF_MISMATCH"
+                };
+            }
+
+            if (ctx.LogicBias == TradeDirection.Long)
+            {
+                var eval = EvaluateDirectional(ctx, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateDirectional(ctx, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+
+            return new EntryEvaluation
+            {
+                Symbol = ctx.Symbol,
+                Type = Type,
+                Direction = TradeDirection.None,
+                Score = 0,
+                IsValid = false,
+                Reason = "NO_LOGIC_BIAS"
+            };
         }
-
         private EntryEvaluation EvaluateDirectional(EntryContext ctx, TradeDirection forcedDirection)
         {
             var eval = new EntryEvaluation

--- a/EntryTypes/TR_ReversalEntry.cs
+++ b/EntryTypes/TR_ReversalEntry.cs
@@ -45,6 +45,17 @@ namespace GeminiV26.EntryTypes
                 };
             }
 
+            if (ctx.LogicBias == TradeDirection.None)
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "NO_LOGIC_BIAS"
+                };
+
             if (ctx.ReversalEvidenceScore < MIN_EVIDENCE)
             {
                 return new EntryEvaluation
@@ -58,12 +69,40 @@ namespace GeminiV26.EntryTypes
                 };
             }
 
-            var longEval = EvaluateSide(ctx, TradeDirection.Long);
-            var shortEval = EvaluateSide(ctx, TradeDirection.Short);
+            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                return new EntryEvaluation
+                {
+                    Symbol = ctx.Symbol,
+                    Type = Type,
+                    Direction = TradeDirection.None,
+                    Score = 0,
+                    IsValid = false,
+                    Reason = "HTF_MISMATCH"
+                };
 
-            return EntryDecisionPolicy.Normalize(EntryDecisionPolicy.SelectBalancedEvaluation(ctx, Type, longEval, shortEval));
+            if (ctx.LogicBias == TradeDirection.Long)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Long);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+            else if (ctx.LogicBias == TradeDirection.Short)
+            {
+                var eval = EvaluateSide(ctx, TradeDirection.Short);
+                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
+                return EntryDecisionPolicy.Normalize(eval);
+            }
+
+            return new EntryEvaluation
+            {
+                Symbol = ctx.Symbol,
+                Type = Type,
+                Direction = TradeDirection.None,
+                Score = 0,
+                IsValid = false,
+                Reason = "NO_LOGIC_BIAS"
+            };
         }
-
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
         {
             var eval = new EntryEvaluation


### PR DESCRIPTION
### Motivation
- Remove dual-direction evaluation in all active entry evaluators and ensure exactly one directional evaluation path driven by the `LogicBias` gate.
- Enforce an early hard gate that requires `LogicBias` to be set and validate HTF only as a blocking condition (no direction modification).
- Eliminate legacy two-side selection artifacts (`allowLong`/`allowShort`, `longEval`/`shortEval`, balanced selection) to prevent random direction selection and architectural leaks.

### Description
- Insert an early `NO_LOGIC_BIAS` gate at the start of every `Evaluate(EntryContext ctx)` for active entry types and return a blocking/invalid evaluation when `ctx.LogicBias == TradeDirection.None`.
- Replace previous dual-side flows with a single `if (ctx.LogicBias == TradeDirection.Long) { EvaluateSide(..., Long) } else if (ctx.LogicBias == TradeDirection.Short) { EvaluateSide(..., Short) }` pattern so each execution path makes exactly one `EvaluateSide`/directional call.
- Convert HTF handling at evaluator entry points into a validation-only gate that returns `HTF_MISMATCH` when `ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias` and do not modify or infer direction from HTF anywhere.
- Remove dual-direction helper variables and blocks across all modified files so no `allowLong`/`allowShort`, `longEval`/`shortEval`, or balanced `SelectBalancedEvaluation(...)` selection remain in active evaluators.

### Testing
- Ran static diff/consistency checks and whitespace/format validations which completed without errors.
- Executed a targeted Python validation that inspected the 23 active entry evaluators to confirm presence of `NO_LOGIC_BIAS`, `HTF_MISMATCH`, removal of `allowLong`/`allowShort`/`longEval`/`shortEval` artifacts, and exactly one directional call per execution path, and the script reported success.
- Performed ripgrep-based searches to verify dual-direction selection patterns were removed from the active entry evaluators and found no remaining dual-evaluation artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd0cba6b0883289d1de58dbdf2a2b7)