### PR TITLE
Add missing Invalid overloads to FX_ReversalEntry and BTC_RangeBreakoutEntry

### DIFF
--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -158,6 +158,17 @@ namespace GeminiV26.EntryTypes.Crypto
                 Reason = reason + ";"
             };
 
+        private static EntryEvaluation Invalid(EntryContext ctx, string reason, TradeDirection dir, int score)
+            => new EntryEvaluation
+            {
+                Symbol = ctx?.Symbol,
+                Type = EntryType.Crypto_RangeBreakout,
+                Direction = dir,
+                Score = score,
+                IsValid = false,
+                Reason = reason + ";"
+            };
+
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
             return EntryDirectionQuality.Apply(

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -178,6 +178,17 @@ namespace GeminiV26.EntryTypes.FX
                 Reason = reason
             };
 
+        private EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason, int score) =>
+            new EntryEvaluation
+            {
+                Symbol = ctx?.Symbol,
+                Type = Type,
+                Direction = dir,
+                Score = score,
+                IsValid = false,
+                Reason = reason
+            };
+
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
             return EntryDirectionQuality.Apply(


### PR DESCRIPTION
### Motivation
- Recent edits removed/omitted the directional `Invalid` overloads used by several entry call sites, causing compile errors where `Invalid` was invoked with `direction` and `score` parameters.

### Description
- Add `Invalid(EntryContext ctx, TradeDirection dir, string reason, int score)` to `EntryTypes/FX/FX_ReversalEntry.cs` to restore the directional invalid-return path. 
- Add `Invalid(EntryContext ctx, string reason, TradeDirection dir, int score)` to `EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs` to restore the directional invalid-return path.
- Changes are minimal (two small helper overloads) and match the shapes expected by existing callers.

### Testing
- Verified the new overloads are present with a file scan and `git diff` showing the inserted methods, and committed the changes with message `Fix missing Invalid overloads for entry types`.
- Ran repository searches (`rg`) to confirm the overloaded signature is used by call sites and is now defined in both files.
- Attempted a full build with `dotnet build` but the environment lacks the `dotnet` CLI, so a complete compilation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd105ccd388328908307b8cd12da89)