### PR TITLE
Fix LogicBias propagation and remove legacy direction-selection artifacts

### DIFF
--- a/Core/Entry/EntryDecisionPolicy.cs
+++ b/Core/Entry/EntryDecisionPolicy.cs
@@ -135,55 +135,6 @@ namespace GeminiV26.Core.Entry
             return MinScoreThreshold - 5;
         }
 
-        public static EntryEvaluation SelectBalancedEvaluation(
-            EntryContext ctx,
-            EntryType type,
-            EntryEvaluation longEval,
-            EntryEvaluation shortEval)
-        {
-            double longScore = Math.Max(0, longEval?.Score ?? 0);
-            double shortScore = Math.Max(0, shortEval?.Score ?? 0);
-            bool longHardInvalid = IsHardInvalid(longEval);
-            bool shortHardInvalid = IsHardInvalid(shortEval);
-
-            EntryEvaluation selectedEval;
-            if (!longHardInvalid && !shortHardInvalid && Math.Abs(longScore - shortScore) < 1.0)
-            {
-                selectedEval = new EntryEvaluation
-                {
-                    Symbol = ctx?.Symbol,
-                    Type = type,
-                    Direction = TradeDirection.None,
-                    Score = (int)Math.Round(Math.Max(longScore, shortScore)),
-                    IsValid = false,
-                    Reason = "SCORE_BALANCE_TIE"
-                };
-            }
-            else if (longHardInvalid && shortHardInvalid)
-            {
-                selectedEval = longScore > shortScore ? longEval : shortEval;
-            }
-            else if (longHardInvalid)
-            {
-                selectedEval = shortEval;
-            }
-            else if (shortHardInvalid)
-            {
-                selectedEval = longEval;
-            }
-            else
-            {
-                selectedEval = longScore > shortScore ? longEval : shortEval;
-            }
-
-            var selectedDirection = selectedEval?.Direction ?? TradeDirection.None;
-            string balanceLog = $"[SCORE BALANCE] type={type} longScore={longScore:0.##} shortScore={shortScore:0.##} selected={selectedDirection}";
-            ctx?.Log?.Invoke(balanceLog);
-            Console.WriteLine(balanceLog);
-
-            return Normalize(selectedEval);
-        }
-
         private static EntryState ResolveState(EntryEvaluation eval)
         {
             if (eval == null)

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -934,33 +934,25 @@ namespace GeminiV26.Core
             _ctx.Session = SessionResolver.FromBucket(sessionDecision.Bucket);
             _bot.Print("[CTX_SESSION_ASSIGN] sessionFromGate={0} sessionAssigned={1}", sessionDecision.Bucket, _ctx.Session);
 
-            bool hasValidLogic =
-                _ctx.LogicBiasDirection != TradeDirection.None &&
-                _ctx.LogicBiasConfidence > 0;
-
-            if (!isIndexSymbol || !hasValidLogic)
-            {
-                _ctx.LogicBiasDirection = TradeDirection.None;
-                _ctx.LogicBiasConfidence = 0;
-            }
-
             TradeType xauBias = TradeType.Buy;
             int xauBiasConfidence = 0;
             TradeDirection cryptoBias = TradeDirection.None;
             int cryptoLogicConfidence = 0;
+            TradeDirection logicBias = TradeDirection.None;
+            int logicConfidence = 0;
 
             if (IsSymbol("XAUUSD"))
             {
                 _xauEntryLogic?.Evaluate(out xauBias, out xauBiasConfidence);
-                _ctx.LogicBiasDirection = FromTradeType(xauBias);
-                _ctx.LogicBiasConfidence = xauBiasConfidence;
+                logicBias = FromTradeType(xauBias);
+                logicConfidence = xauBiasConfidence;
             }
 
             if (IsSymbol("EURUSD"))
             {
                 _eurUsdEntryLogic?.Evaluate();
-                _ctx.LogicBiasDirection = FromTradeType(_eurUsdEntryLogic.LastBias);
-                _ctx.LogicBiasConfidence = _eurUsdEntryLogic.LastLogicConfidence;
+                logicBias = FromTradeType(_eurUsdEntryLogic.LastBias);
+                logicConfidence = _eurUsdEntryLogic.LastLogicConfidence;
             }
 
             if (IsSymbol("GBPUSD"))
@@ -968,46 +960,74 @@ namespace GeminiV26.Core
                 _gbpUsdEntryLogic?.Evaluate();
                 if (_gbpUsdEntryLogic != null && _gbpUsdEntryLogic.CheckEntry(out var gbpBias, out var gbpLogicConfidence))
                 {
-                    _ctx.LogicBiasDirection = gbpBias;
-                    _ctx.LogicBiasConfidence = gbpLogicConfidence;
+                    logicBias = gbpBias;
+                    logicConfidence = gbpLogicConfidence;
                 }
             }
 
             if (IsSymbol("USDJPY"))
             {
                 _usdJpyEntryLogic?.Evaluate();
-                _ctx.LogicBiasDirection = FromTradeType(_usdJpyEntryLogic.LastBias);
-                _ctx.LogicBiasConfidence = _usdJpyEntryLogic.LastLogicConfidence;
+                logicBias = FromTradeType(_usdJpyEntryLogic.LastBias);
+                logicConfidence = _usdJpyEntryLogic.LastLogicConfidence;
             }
 
             if (IsSymbol("AUDUSD"))
+            {
                 _audUsdEntryLogic?.Evaluate();
+                logicBias = FromTradeType(_audUsdEntryLogic.LastBias);
+                logicConfidence = _audUsdEntryLogic.LastLogicConfidence;
+            }
 
             if (IsSymbol("AUDNZD"))
+            {
                 _audNzdEntryLogic?.Evaluate();
+                logicBias = FromTradeType(_audNzdEntryLogic.LastBias);
+                logicConfidence = _audNzdEntryLogic.LastLogicConfidence;
+            }
 
             if (IsSymbol("EURJPY"))
+            {
                 _eurJpyEntryLogic?.Evaluate();
+                logicBias = FromTradeType(_eurJpyEntryLogic.LastBias);
+                logicConfidence = _eurJpyEntryLogic.LastLogicConfidence;
+            }
 
             if (IsSymbol("GBPJPY"))
+            {
                 _gbpJpyEntryLogic?.Evaluate();
+                logicBias = FromTradeType(_gbpJpyEntryLogic.LastBias);
+                logicConfidence = _gbpJpyEntryLogic.LastLogicConfidence;
+            }
 
             if (IsSymbol("NZDUSD"))
+            {
                 _nzdUsdEntryLogic?.Evaluate();
+                logicBias = FromTradeType(_nzdUsdEntryLogic.LastBias);
+                logicConfidence = _nzdUsdEntryLogic.LastLogicConfidence;
+            }
 
             if (IsSymbol("USDCAD"))
+            {
                 _usdCadEntryLogic?.Evaluate();
+                logicBias = FromTradeType(_usdCadEntryLogic.LastBias);
+                logicConfidence = _usdCadEntryLogic.LastLogicConfidence;
+            }
 
             if (IsSymbol("USDCHF"))
+            {
                 _usdChfEntryLogic?.Evaluate();
+                logicBias = FromTradeType(_usdChfEntryLogic.LastBias);
+                logicConfidence = _usdChfEntryLogic.LastLogicConfidence;
+            }
 
             if (IsNasSymbol(_bot.SymbolName))
             {
                 _nasEntryLogic?.Evaluate();
                 if (_nasEntryLogic != null)
                 {
-                    _ctx.LogicBiasDirection = FromTradeType(_nasEntryLogic.LastBias);
-                    _ctx.LogicBiasConfidence = _nasEntryLogic.LastLogicConfidence;
+                    logicBias = FromTradeType(_nasEntryLogic.LastBias);
+                    logicConfidence = _nasEntryLogic.LastLogicConfidence;
                 }
             }
 
@@ -1016,35 +1036,37 @@ namespace GeminiV26.Core
                 _ger40EntryLogic?.Evaluate();
                 if (_ger40EntryLogic != null)
                 {
-                    _ctx.LogicBiasDirection = FromTradeType(_ger40EntryLogic.LastBias);
-                    _ctx.LogicBiasConfidence = _ger40EntryLogic.LastLogicConfidence;
+                    logicBias = FromTradeType(_ger40EntryLogic.LastBias);
+                    logicConfidence = _ger40EntryLogic.LastLogicConfidence;
                 }
             }
 
             if (IsSymbol("US30"))
             {
-                _us30EntryLogic?.Evaluate();
-                if (_us30EntryLogic != null)
+                if (_us30EntryLogic != null && _us30EntryLogic.CheckEntry(out var us30Bias, out var us30LogicConfidence))
                 {
-                    _ctx.LogicBiasDirection = FromTradeType(_us30EntryLogic.LastBias);
-                    _ctx.LogicBiasConfidence = _us30EntryLogic.LastLogicConfidence;
+                    logicBias = us30Bias;
+                    logicConfidence = us30LogicConfidence;
                 }
             }
 
             if (IsSymbol("BTCUSD"))
             {
                 _btcUsdEntryLogic?.Evaluate(out cryptoBias, out cryptoLogicConfidence);
-                _ctx.LogicBiasDirection = cryptoBias;
-                _ctx.LogicBiasConfidence = cryptoLogicConfidence;
+                logicBias = cryptoBias;
+                logicConfidence = cryptoLogicConfidence;
             }
 
             if (IsSymbol("ETHUSD"))
             {
                 _ethUsdEntryLogic?.Evaluate(out cryptoBias, out cryptoLogicConfidence);
-                _ctx.LogicBiasDirection = cryptoBias;
-                _ctx.LogicBiasConfidence = cryptoLogicConfidence;
+                logicBias = cryptoBias;
+                logicConfidence = cryptoLogicConfidence;
             }
 
+            _ctx.LogicBiasDirection = logicBias;
+            _ctx.LogicBiasConfidence = logicConfidence;
+            _bot.Print($"[CTX PROPAGATION] bias={_ctx.LogicBias} conf={_ctx.LogicConfidence}");
             _bot.Print($"[DIR][LOGIC] sym={_bot.SymbolName} logicBias={_ctx.LogicBiasDirection} logicConf={_ctx.LogicBiasConfidence}");
 
             _bot.Print($"[DEBUG] HasOpenGeminiPosition={HasOpenGeminiPosition()}");

--- a/EntryTypes/EntryDirectionQuality.cs
+++ b/EntryTypes/EntryDirectionQuality.cs
@@ -130,8 +130,9 @@ namespace GeminiV26.EntryTypes
 
         public static void LogDecision(EntryContext ctx, string typeTag, EntryEvaluation longEval, EntryEvaluation shortEval, TradeDirection selected)
         {
+            var eval = longEval ?? shortEval;
             ctx?.Log?.Invoke(
-                $"[DIR DECISION] type={typeTag} longScore={longEval?.Score ?? 0} shortScore={shortEval?.Score ?? 0} selected={selected}");
+                $"[DIR FLOW] type={typeTag} logicBias={ctx?.LogicBiasDirection ?? TradeDirection.None} evalDir={eval?.Direction ?? TradeDirection.None} score={eval?.Score ?? 0}");
         }
 
         private static void ResolveHtf(


### PR DESCRIPTION
### Motivation

- Ensure `EntryContext` receives the instrument `LogicBias` and `LogicConfidence` reliably so evaluators never see `ctx.LogicBias == None` when logic produced a bias.
- Remove leftover dual-direction selection and diagnostic artifacts (long/short score comparisons and `DIR DECISION` logs) now that flow is single-direction.

### Description

- Centralized instrument logic evaluation in `Core/TradeCore.cs`, collecting `logicBias`/`logicConfidence` into local variables and assigning them to the single `EntryContext` instance exactly once via ` _ctx.LogicBiasDirection = logicBias; _ctx.LogicBiasConfidence = logicConfidence;` immediately before entry evaluation.
- Added the required debug safety log ` _bot.Print($"[CTX PROPAGATION] bias={_ctx.LogicBias} conf={_ctx.LogicConfidence}");` right after the single assignment and before routing/evaluators run.
- Removed the legacy balanced dual-direction selector `SelectBalancedEvaluation` from `Core/Entry/EntryDecisionPolicy.cs`, eliminating `longScore`/`shortScore` comparison and score-balance tie handling.
- Replaced legacy `[DIR DECISION]` score logs in `EntryTypes/EntryDirectionQuality.cs` with a single-direction flow log (`[DIR FLOW]`) that reports `logicBias` and the chosen evaluation direction/score.

### Testing

- Searched repository for legacy artifacts with `rg -n "DIR DECISION|longScore|shortScore|bestDirection|selectedDirection|SCORE BALANCE" .` and confirmed no remaining legacy score/decision artifacts were reported in source paths after the change.
- Ran `git diff --check` to validate there are no whitespace/merge errors and it completed cleanly.
- Attempted `dotnet build -v minimal` but `dotnet` was not available in the environment, so full compile verification could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd1444bcc48328aefd16f81e0b4b8f)