### PR TITLE
Add logic bias propagation diagnostics and safe bias-fallback

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -314,6 +314,22 @@ namespace GeminiV26.Core.Entry
             }
         }
 
+        public string SymbolName => Symbol;
+
+        public void Print(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+                return;
+
+            if (Log != null)
+            {
+                Log(message);
+                return;
+            }
+
+            Bot?.Print(message);
+        }
+
         public bool IsValidFlagStructure_M5 =>
             HasFlagLong_M5 || HasFlagShort_M5;
     }

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -59,7 +59,8 @@ namespace GeminiV26.Core.Entry
             {
                 Symbol = symbol,
                 IsReady = false,
-                TrendDirection = TradeDirection.None
+                TrendDirection = TradeDirection.None,
+                Log = message => _bot.Print(message)
             };
 
             // -------------------------

--- a/Core/Entry/FlagBreakoutDetector.cs
+++ b/Core/Entry/FlagBreakoutDetector.cs
@@ -29,6 +29,7 @@ namespace GeminiV26.Core.Entry
 
         public void Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null)
                 return;
 

--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -22,6 +22,7 @@ namespace GeminiV26.Core.Entry
 
         public TransitionEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || ctx.M5 == null || ctx.M5.Count < 12 || ctx.AtrM5 <= 0)
             {
                 ResetContext(ctx);

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1066,7 +1066,15 @@ namespace GeminiV26.Core
 
             _ctx.LogicBiasDirection = logicBias;
             _ctx.LogicBiasConfidence = logicConfidence;
-            _bot.Print($"[CTX PROPAGATION] bias={_ctx.LogicBias} conf={_ctx.LogicConfidence}");
+
+            if (_ctx.LogicBiasDirection == TradeDirection.None && _ctx.TrendDirection != TradeDirection.None)
+            {
+                _ctx.LogicBiasDirection = _ctx.TrendDirection;
+                _ctx.LogicBiasConfidence = 50;
+                _ctx.Print("[BIAS FALLBACK] using TrendDirection");
+            }
+
+            _bot.Print($"[CTX PROPAGATION] symbol={_bot.SymbolName} bias={_ctx.LogicBias} conf={_ctx.LogicConfidence}");
             _bot.Print($"[DIR][LOGIC] sym={_bot.SymbolName} logicBias={_ctx.LogicBiasDirection} logicConf={_ctx.LogicBiasConfidence}");
 
             _bot.Print($"[DEBUG] HasOpenGeminiPosition={HasOpenGeminiPosition()}");
@@ -1077,6 +1085,7 @@ namespace GeminiV26.Core
 
             _entryRouterPassCounter++;
             _bot.Print($"[PIPE][ENTRY_ROUTER_PASS] pass={_entryRouterPassCounter} symbol={_bot.SymbolName} bar={_bot.Server.Time:O}");
+            _bot.Print($"[ENTRY START] symbol={_bot.SymbolName} bias={_ctx.LogicBias}");
 
             var signals = _entryRouter.Evaluate(new[] { _ctx });
 

--- a/EntryTypes/BR_RangeBreakoutEntry.cs
+++ b/EntryTypes/BR_RangeBreakoutEntry.cs
@@ -32,6 +32,7 @@ namespace GeminiV26.EntryTypes
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady)
             {
                 return new EntryEvaluation

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -22,6 +22,7 @@ namespace GeminiV26.EntryTypes.Crypto
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 20)
                 return Invalid(ctx, "CTX_NOT_READY");
 

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -14,6 +14,7 @@ namespace GeminiV26.EntryTypes.Crypto
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady)
                 return Block(ctx, "CTX_NOT_READY", 36);
 

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -12,6 +12,7 @@ namespace GeminiV26.EntryTypes.Crypto
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (!ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -12,6 +12,7 @@ namespace GeminiV26.EntryTypes.Crypto
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -15,6 +15,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -26,6 +26,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 30)
                 return Invalid(ctx, TradeDirection.None, "CTX_NOT_READY", 0);
 

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -22,6 +22,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (!ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -17,6 +17,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -15,6 +15,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 30)
                 return Invalid(ctx, TradeDirection.None, "CTX_NOT_READY", 0);
 

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -22,6 +22,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady)
                 return Block(ctx, TradeDirection.None, "CTX_NOT_READY", 0);
 

--- a/EntryTypes/FX/FX_RangeBreakoutEntry.cs
+++ b/EntryTypes/FX/FX_RangeBreakoutEntry.cs
@@ -19,6 +19,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowBreakout)
             {

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -15,6 +15,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 

--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -17,6 +17,7 @@ namespace GeminiV26.EntryTypes.INDEX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowBreakout)
                 return Reject(ctx, "SESSION_MATRIX_ALLOWBREAKOUT_DISABLED", 0, TradeDirection.None);

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -33,6 +33,7 @@ namespace GeminiV26.EntryTypes.INDEX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowFlag)
                 return Reject(ctx, "SESSION_MATRIX_ALLOWFLAG_DISABLED", 0, TradeDirection.None);

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -19,6 +19,7 @@ namespace GeminiV26.EntryTypes.INDEX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowPullback)
                 return Reject(ctx, TradeDirection.None, 0, "SESSION_MATRIX_ALLOWPULLBACK_DISABLED");

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -26,6 +26,7 @@ namespace GeminiV26.EntryTypes.METAL
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < BarsNotReadyMin)
                 return Invalid(ctx, "CTX_NOT_READY");
 

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -26,6 +26,7 @@ namespace GeminiV26.EntryTypes.METAL
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowBreakout)
                 return Reject(ctx, "SESSION_MATRIX_BREAKOUT_DISABLED");

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -19,6 +19,7 @@ namespace GeminiV26.EntryTypes.METAL
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowPullback)
                 return Reject(ctx, "SESSION_DISABLED");

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -18,6 +18,7 @@ namespace GeminiV26.EntryTypes.METAL
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady || ctx.M5 == null)
                 return Reject(ctx, "CTX_NOT_READY");
 

--- a/EntryTypes/TC_FlagEntry.cs
+++ b/EntryTypes/TC_FlagEntry.cs
@@ -27,6 +27,7 @@ namespace GeminiV26.EntryTypes
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady)
             {
                 return new EntryEvaluation

--- a/EntryTypes/TC_PullbackEntry.cs
+++ b/EntryTypes/TC_PullbackEntry.cs
@@ -28,6 +28,7 @@ namespace GeminiV26.EntryTypes
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady)
             {
                 return new EntryEvaluation

--- a/EntryTypes/TR_ReversalEntry.cs
+++ b/EntryTypes/TR_ReversalEntry.cs
@@ -32,6 +32,7 @@ namespace GeminiV26.EntryTypes
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
+            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || !ctx.IsReady)
             {
                 return new EntryEvaluation


### PR DESCRIPTION
### Motivation

- Make `LogicBias` and its confidence fully observable throughout the entry pipeline so bias flow can be traced end-to-end. 
- Surface entry-start and per-evaluator diagnostics to locate propagation gaps and inconsistent bias generation. 
- Provide a conservative, controlled fallback bias only when no logic bias is produced but a clear `TrendDirection` exists, without changing core entry/evaluate scoring or direction pipeline.

### Description

- Added `SymbolName` and `Print(string)` helper to `EntryContext` and wired `Log` during `EntryContext` creation so evaluators can emit diagnostics via the same `ctx` instance. 
- In `TradeCore` emitted `[CTX PROPAGATION]` and `[ENTRY START]` logs and added a safe fallback that sets `ctx.LogicBiasDirection = ctx.TrendDirection` and `ctx.LogicBiasConfidence = 50` only when `LogicBiasDirection` is `None` and `TrendDirection` is not `None`. 
- Injected `ctx?.Print("[DIR DEBUG] symbol=... bias=... conf=...")` at the very start of evaluator `Evaluate(...)` entry points (transition/flag detectors and entry types) to record per-evaluator bias/context visibility while preserving existing logic and gates. 

### Testing

- Ran `git diff --check` to validate no whitespace/patch errors and it passed. 
- Verified instrumentation presence with searches such as `rg "\[DIR DEBUG\]"` and `rg "\[CTX PROPAGATION\]|\[ENTRY START\]|\[BIAS FALLBACK\]"` which confirmed the new logs are present. 
- Confirmed the `EntryContext` print wiring and that evaluator patches include `ctx?.Print(...)`, and no changes were made to `EvaluateSide`, scoring formulas, matrix/risk/exit logic, or direction pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd18d6558483289a6ac6689720aa21)