### PR TITLE
Stabilize FX direction propagation and HTF gating

### DIFF
--- a/Core/Entry/FlagBreakoutDetector.cs
+++ b/Core/Entry/FlagBreakoutDetector.cs
@@ -29,7 +29,6 @@ namespace GeminiV26.Core.Entry
 
         public void Evaluate(EntryContext ctx)
         {
-            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null)
                 return;
 

--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -22,7 +22,6 @@ namespace GeminiV26.Core.Entry
 
         public TransitionEvaluation Evaluate(EntryContext ctx)
         {
-            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
             if (ctx == null || ctx.M5 == null || ctx.M5.Count < 12 || ctx.AtrM5 <= 0)
             {
                 ResetContext(ctx);

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -968,8 +968,10 @@ namespace GeminiV26.Core
             if (IsSymbol("USDJPY"))
             {
                 _usdJpyEntryLogic?.Evaluate();
-                logicBias = FromTradeType(_usdJpyEntryLogic.LastBias);
                 logicConfidence = _usdJpyEntryLogic.LastLogicConfidence;
+                logicBias = logicConfidence > 0
+                    ? FromTradeType(_usdJpyEntryLogic.LastBias)
+                    : TradeDirection.None;
             }
 
             if (IsSymbol("AUDUSD"))
@@ -1073,6 +1075,9 @@ namespace GeminiV26.Core
                 _ctx.LogicBiasConfidence = 50;
                 _ctx.Print("[BIAS FALLBACK] using TrendDirection");
             }
+
+            if (IsSymbol("AUDNZD"))
+                _ctx.Print($"[AUDNZD FIX] finalBias={_ctx.LogicBias} finalConf={_ctx.LogicConfidence}");
 
             _bot.Print($"[CTX PROPAGATION] symbol={_bot.SymbolName} bias={_ctx.LogicBias} conf={_ctx.LogicConfidence}");
             _bot.Print($"[DIR][LOGIC] sym={_bot.SymbolName} logicBias={_ctx.LogicBiasDirection} logicConf={_ctx.LogicBiasConfidence}");

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -15,14 +15,14 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
+            FxDirectionValidation.LogDirectionDebug(ctx);
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
             if (ctx.LogicBias == TradeDirection.None)
                 return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
                 return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -26,7 +26,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
+            FxDirectionValidation.LogDirectionDebug(ctx);
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 30)
                 return Invalid(ctx, TradeDirection.None, "CTX_NOT_READY", 0);
 
@@ -47,7 +47,7 @@ namespace GeminiV26.EntryTypes.FX
             if (fx.FlagTuning == null || !fx.FlagTuning.TryGetValue(ctx.Session, out var tuning))
                 return Invalid(ctx, TradeDirection.None, "NO_FLAG_TUNING", 0);
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
                 return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -22,14 +22,14 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
+            FxDirectionValidation.LogDirectionDebug(ctx);
             if (!ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
             if (ctx.LogicBias == TradeDirection.None)
                 return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
                 return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -17,7 +17,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
+            FxDirectionValidation.LogDirectionDebug(ctx);
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
@@ -32,7 +32,7 @@ namespace GeminiV26.EntryTypes.FX
             if (!fx.FlagTuning.TryGetValue(ctx.Session, out var tuning))
                 return Invalid(ctx, "NO_SESSION_TUNING");
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
                 return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -15,7 +15,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
+            FxDirectionValidation.LogDirectionDebug(ctx);
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 30)
                 return Invalid(ctx, TradeDirection.None, "CTX_NOT_READY", 0);
 
@@ -29,7 +29,7 @@ namespace GeminiV26.EntryTypes.FX
             if (fx == null)
                 return Invalid(ctx, TradeDirection.None, "NO_FX_PROFILE", 0);
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
                 return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -22,7 +22,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
+            FxDirectionValidation.LogDirectionDebug(ctx);
             if (ctx == null || !ctx.IsReady)
                 return Block(ctx, TradeDirection.None, "CTX_NOT_READY", 0);
 
@@ -43,7 +43,7 @@ namespace GeminiV26.EntryTypes.FX
             if (!matrix.AllowPullback)
                 return Block(ctx, TradeDirection.None, "SESSION_MATRIX_PULLBACK_DISABLED", 0);
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
                 return Block(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/FX/FX_RangeBreakoutEntry.cs
+++ b/EntryTypes/FX/FX_RangeBreakoutEntry.cs
@@ -19,7 +19,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
+            FxDirectionValidation.LogDirectionDebug(ctx);
             var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
             if (!matrix.AllowBreakout)
             {
@@ -81,7 +81,7 @@ namespace GeminiV26.EntryTypes.FX
                 };
             }
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
             {
                 return new EntryEvaluation
                 {

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -15,7 +15,7 @@ namespace GeminiV26.EntryTypes.FX
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            ctx?.Print($"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBias ?? TradeDirection.None} conf={ctx?.LogicConfidence ?? 0}");
+            FxDirectionValidation.LogDirectionDebug(ctx);
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
@@ -39,7 +39,7 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx.ReversalEvidenceScore < MIN_EVIDENCE)
                 return Invalid(ctx, "WEAK_EVIDENCE");
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
                 return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/FX/FxDirectionValidation.cs
+++ b/EntryTypes/FX/FxDirectionValidation.cs
@@ -1,0 +1,127 @@
+using System;
+using GeminiV26.Core;
+using GeminiV26.Core.Entry;
+
+namespace GeminiV26.EntryTypes.FX
+{
+    internal static class FxDirectionValidation
+    {
+        public static void LogDirectionDebug(EntryContext ctx)
+        {
+            ctx?.Print(
+                $"[DIR DEBUG] symbol={ctx?.SymbolName} bias={ctx?.LogicBiasDirection ?? TradeDirection.None} conf={ctx?.LogicBiasConfidence ?? 0}");
+        }
+
+        public static bool ShouldBlockHtfMismatch(EntryContext ctx)
+        {
+            if (ctx == null)
+                return false;
+
+            var logicBias = ctx.LogicBiasDirection;
+            if (logicBias == TradeDirection.None)
+                return false;
+
+            var htfDirection = ctx.FxHtfAllowedDirection;
+            var htfConfidence = ctx.FxHtfConfidence01;
+
+            if (htfDirection == TradeDirection.None || htfDirection == logicBias || htfConfidence < 0.60)
+                return false;
+
+            string symbol = Normalize(ctx.Symbol);
+            bool targetedFx = IsTargetedFx(symbol);
+            bool localStructure = HasDirectionalStructure(ctx, logicBias);
+            bool trendAligned = IsTrendAligned(ctx, logicBias);
+            int minLogicConfidence = targetedFx ? 60 : 64;
+            double hardBlockConfidence = targetedFx ? 0.72 : 0.70;
+
+            if (htfConfidence < hardBlockConfidence &&
+                ctx.LogicBiasConfidence >= minLogicConfidence &&
+                localStructure &&
+                trendAligned)
+            {
+                ctx.Log?.Invoke(
+                    $"[FX HTF][SOFTEN] sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
+                    $"htf={htfDirection}/{htfConfidence:F2} structure={localStructure} trendAligned={trendAligned}");
+                return false;
+            }
+
+            ctx.Log?.Invoke(
+                $"[FX HTF][BLOCK] sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
+                $"htf={htfDirection}/{htfConfidence:F2} structure={localStructure} trendAligned={trendAligned}");
+            return true;
+        }
+
+        private static bool HasDirectionalStructure(EntryContext ctx, TradeDirection direction)
+        {
+            if (direction == TradeDirection.Long)
+            {
+                return ctx.HasImpulseLong_M5 ||
+                       ctx.HasPullbackLong_M5 ||
+                       ctx.HasFlagLong_M5 ||
+                       ctx.FlagBreakoutUp ||
+                       ctx.FlagBreakoutUpConfirmed ||
+                       ctx.BrokeLastSwingHigh_M5 ||
+                       ctx.BreakoutDirection == TradeDirection.Long ||
+                       ctx.RangeBreakDirection == TradeDirection.Long;
+            }
+
+            if (direction == TradeDirection.Short)
+            {
+                return ctx.HasImpulseShort_M5 ||
+                       ctx.HasPullbackShort_M5 ||
+                       ctx.HasFlagShort_M5 ||
+                       ctx.FlagBreakoutDown ||
+                       ctx.FlagBreakoutDownConfirmed ||
+                       ctx.BrokeLastSwingLow_M5 ||
+                       ctx.BreakoutDirection == TradeDirection.Short ||
+                       ctx.RangeBreakDirection == TradeDirection.Short;
+            }
+
+            return false;
+        }
+
+        private static bool IsTrendAligned(EntryContext ctx, TradeDirection direction)
+        {
+            int lastClosed = ctx?.M5 == null || ctx.M5.Count < 2
+                ? -1
+                : ctx.M5.Count - 2;
+
+            double lastClose = lastClosed >= 0 ? ctx.M5.ClosePrices[lastClosed] : 0.0;
+
+            if (direction == TradeDirection.Long)
+            {
+                return ctx.Ema50_M5 >= ctx.Ema200_M5 &&
+                       ctx.Ema21Slope_M5 >= 0 &&
+                       ctx.Ema21Slope_M15 >= -0.00001 &&
+                       (lastClosed < 0 || lastClose >= ctx.Ema21_M5);
+            }
+
+            if (direction == TradeDirection.Short)
+            {
+                return ctx.Ema50_M5 <= ctx.Ema200_M5 &&
+                       ctx.Ema21Slope_M5 <= 0 &&
+                       ctx.Ema21Slope_M15 <= 0.00001 &&
+                       (lastClosed < 0 || lastClose <= ctx.Ema21_M5);
+            }
+
+            return false;
+        }
+
+        private static bool IsTargetedFx(string symbol)
+        {
+            return symbol == "AUDNZD" ||
+                   symbol == "USDJPY" ||
+                   symbol == "USDCHF" ||
+                   symbol == "USDCAD" ||
+                   symbol == "NZDUSD" ||
+                   symbol == "EURJPY";
+        }
+
+        private static string Normalize(string symbol)
+        {
+            return string.IsNullOrWhiteSpace(symbol)
+                ? string.Empty
+                : symbol.Trim().ToUpperInvariant();
+        }
+    }
+}

--- a/Instruments/FX/FxBiasTuningHelper.cs
+++ b/Instruments/FX/FxBiasTuningHelper.cs
@@ -8,8 +8,9 @@ namespace GeminiV26.Instruments.FX
     {
         private const double TrendDeadzoneAtr = 0.08;
         private const double StructureLookbackAtr = 2.20;
-        private const double MinPatternConfidence = 60.0;
-        private const double FallbackConfidence = 50.0;
+        private const double StructuredConfidence = 62.0;
+        private const double StrongTrendFallbackConfidence = 56.0;
+        private const double TrendOnlyConfidence = 42.0;
 
         internal struct FxBiasResult
         {
@@ -98,32 +99,39 @@ namespace GeminiV26.Instruments.FX
 
             double recentStructureRange = atrValue > 0 ? (GetRecentHigh(m5, i, 6) - GetRecentLow(m5, i, 6)) / atrValue : 0;
             bool choppy = (adxValue < 14 && emaAbs <= deadzone * 1.25) || recentStructureRange < 0.90 || recentStructureRange > StructureLookbackAtr;
+            bool strongTrendContext =
+                !choppy &&
+                adxValue >= 18.0 &&
+                atrValue > 0 &&
+                emaAbs >= atrValue * 0.18;
 
             double htfEmaValue = emaHtf.LastValue;
             double htfPrice = m15.ClosePrices.LastValue;
             bool htfBull = htfPrice >= htfEmaValue;
             bool htfAligned = (trendLong && htfBull) || (trendShort && !htfBull);
+            bool continuationLong = trendLong && (hhhlLong || breakoutLong || (pullbackLong && bullishClose));
+            bool continuationShort = trendShort && (lhllShort || breakoutShort || (pullbackShort && bearishClose));
 
-            int confidence = 45;
+            int confidence = 35;
             string state = "NO_TREND";
             string pattern = "none";
 
             if (trendLong || trendShort)
             {
-                confidence = 50;
+                confidence = (int)TrendOnlyConfidence;
                 state = "TREND_ONLY";
 
                 if ((trendLong && structureLong) || (trendShort && structureShort))
                 {
-                    confidence = (int)MinPatternConfidence;
+                    confidence = (int)StructuredConfidence;
                     state = "STRUCTURED_BIAS";
                     pattern = trendLong
                         ? flagLong ? "flag" : pullbackLong ? "pullback" : breakoutLong ? "breakout" : "hhhl"
                         : flagShort ? "flag" : pullbackShort ? "pullback" : breakoutShort ? "breakout" : "lhll";
                 }
-                else if (!choppy && !oppositeSignal)
+                else if (strongTrendContext && !oppositeSignal && htfAligned)
                 {
-                    confidence = (int)FallbackConfidence;
+                    confidence = (int)StrongTrendFallbackConfidence;
                     state = "FX_FALLBACK";
                     pattern = "trend";
                 }
@@ -139,6 +147,8 @@ namespace GeminiV26.Instruments.FX
                 confidence += 5;
             if (htfAligned)
                 confidence += 5;
+            if (continuationLong || continuationShort)
+                confidence += 4;
             if (choppy)
                 confidence -= 15;
             if (oppositeSignal)

--- a/Instruments/USDJPY/UsdJpyEntryLogic.cs
+++ b/Instruments/USDJPY/UsdJpyEntryLogic.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using cAlgo.API;
 using cAlgo.API.Indicators;
-using GeminiV26.Core.Entry;
 using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.USDJPY
 {
     /// <summary>
-    /// USDJPY Entry Logic – Phase 3.7
-    /// STRUKTÚRA: US30 klón (csak irány + confidence)
-    /// LOGIKA: USDJPY trend/pullback jelleghez igazítva (FX noise kezelés)
+    /// USDJPY Entry Logic – stricter long continuation, earlier weakening shorts.
     /// </summary>
     public class UsdJpyEntryLogic : IEntryLogic
     {
@@ -21,7 +18,7 @@ namespace GeminiV26.Instruments.USDJPY
         public UsdJpyEntryLogic(Robot bot)
         {
             _bot = bot;
-            LastBias = TradeType.Buy;   // default, de confidence = 0 → nincs trade
+            LastBias = TradeType.Buy;
             LastLogicConfidence = 0;
         }
 
@@ -30,34 +27,174 @@ namespace GeminiV26.Instruments.USDJPY
             LastLogicConfidence = 0;
 
             var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5);
-            if (m5 == null || m5.Count < 250)
+            var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15);
+            if (m5 == null || m15 == null || m5.Count < 260 || m15.Count < 80)
                 return;
 
-            var ema50 = _bot.Indicators
-                .ExponentialMovingAverage(m5.ClosePrices, 50)
-                .Result.LastValue;
+            int i = m5.Count - 2;
+            if (i < 12)
+                return;
 
-            var ema200 = _bot.Indicators
-                .ExponentialMovingAverage(m5.ClosePrices, 200)
-                .Result.LastValue;
+            var ema8 = _bot.Indicators.ExponentialMovingAverage(m5.ClosePrices, 8).Result;
+            var ema21 = _bot.Indicators.ExponentialMovingAverage(m5.ClosePrices, 21).Result;
+            var ema50 = _bot.Indicators.ExponentialMovingAverage(m5.ClosePrices, 50).Result;
+            var ema200 = _bot.Indicators.ExponentialMovingAverage(m5.ClosePrices, 200).Result;
+            var ema21M15 = _bot.Indicators.ExponentialMovingAverage(m15.ClosePrices, 21).Result;
+            var atr = _bot.Indicators.AverageTrueRange(m5, 14, MovingAverageType.Exponential);
+            var adx = _bot.Indicators.AverageDirectionalMovementIndexRating(14);
 
-            if (ema50 > ema200)
+            double atrValue = atr.Result[i];
+            if (atrValue <= 0)
+                return;
+
+            double close = m5.ClosePrices[i];
+            double open = m5.OpenPrices[i];
+            double high = m5.HighPrices[i];
+
+            double ema8Now = ema8[i];
+            double ema21Now = ema21[i];
+            double ema50Now = ema50[i];
+            double ema200Now = ema200[i];
+            double ema21SlopeM5 = ema21[i] - ema21[i - 3];
+            double ema21SlopeM15 = ema21M15.LastValue - ema21M15[Math.Max(0, m15.Count - 4)];
+            double adxNow = adx.ADX[i];
+            double adxSlope = adx.ADX[i] - adx.ADX[i - 3];
+
+            double recentHigh4 = GetRecentHigh(m5, i - 1, 4);
+            double recentLow4 = GetRecentLow(m5, i - 1, 4);
+            double recentLow8 = GetRecentLow(m5, i, 8);
+
+            bool bullishClose = close > open;
+            bool bearishClose = close < open;
+            bool bullishReclaim = bullishClose && close > ema8Now && close > ema21Now;
+            bool bearishReclaim = bearishClose && close < ema8Now && close < ema21Now;
+
+            bool trendLong =
+                ema50Now > ema200Now &&
+                ema21Now >= ema50Now &&
+                ema21SlopeM5 > atrValue * 0.04 &&
+                ema21SlopeM15 >= -atrValue * 0.02 &&
+                close >= ema21Now;
+
+            bool trendShort =
+                ema50Now < ema200Now &&
+                ema21Now <= ema50Now &&
+                ema21SlopeM5 < -atrValue * 0.04 &&
+                ema21SlopeM15 <= atrValue * 0.02 &&
+                close <= ema21Now;
+
+            bool higherLowConfirmed =
+                low > GetRecentLow(m5, i - 3, 3) &&
+                m5.LowPrices[i - 1] >= m5.LowPrices[i - 3] &&
+                m5.HighPrices[i] >= m5.HighPrices[i - 2];
+
+            bool lowerHighLowerLow =
+                high < GetRecentHigh(m5, i - 3, 3) &&
+                m5.HighPrices[i - 1] <= m5.HighPrices[i - 3] &&
+                m5.LowPrices[i] <= m5.LowPrices[i - 2];
+
+            double pullbackDepthLong = (ema21Now - GetRecentLow(m5, i, 5)) / atrValue;
+            double pullbackDepthShort = (GetRecentHigh(m5, i, 5) - ema21Now) / atrValue;
+
+            bool pullbackCompleteLong =
+                pullbackDepthLong >= 0.18 &&
+                pullbackDepthLong <= 1.10 &&
+                GetRecentLow(m5, i, 4) <= ema21Now + atrValue * 0.08 &&
+                bullishReclaim;
+
+            bool continuationLong =
+                higherLowConfirmed &&
+                (close > recentHigh4 || (bullishReclaim && m5.ClosePrices[i - 1] >= ema21[i - 1]));
+
+            bool extendedLong =
+                (close - recentLow8) / atrValue >= 2.45 ||
+                (close - ema21Now) / atrValue >= 1.20;
+
+            bool exhaustionLong =
+                adxNow >= 34.0 &&
+                adxSlope <= 0 &&
+                !pullbackCompleteLong;
+
+            bool incompleteLongStructure = !higherLowConfirmed || !continuationLong || !pullbackCompleteLong;
+
+            bool shortBreakdown = bearishClose && close < recentLow4;
+            bool rejectionFailure =
+                bearishClose &&
+                high >= recentHigh4 - atrValue * 0.10 &&
+                close < ema21Now;
+
+            bool weakeningShort =
+                lowerHighLowerLow ||
+                shortBreakdown ||
+                rejectionFailure ||
+                (ema21SlopeM5 <= 0 && bearishReclaim && close < recentLow4 + atrValue * 0.15);
+
+            bool earlyShortAllowed =
+                bearishReclaim &&
+                pullbackDepthShort >= 0.15 &&
+                pullbackDepthShort <= 1.15 &&
+                (lowerHighLowerLow || shortBreakdown || rejectionFailure);
+
+            if (trendLong && continuationLong && pullbackCompleteLong && !extendedLong && !exhaustionLong && adxNow >= 18.0)
+            {
+                int confidence = 62;
+                if (adxNow >= 22.0) confidence += 6;
+                if (adxNow >= 28.0) confidence += 4;
+                if (close > recentHigh4) confidence += 5;
+                if (ema21SlopeM15 > 0) confidence += 4;
+                if (higherLowConfirmed) confidence += 4;
+
                 LastBias = TradeType.Buy;
-            else if (ema50 < ema200)
+                LastLogicConfidence = Math.Min(confidence, 92);
+            }
+            else if (weakeningShort && earlyShortAllowed)
+            {
+                int confidence = trendShort ? 63 : 58;
+                if (shortBreakdown) confidence += 5;
+                if (lowerHighLowerLow) confidence += 4;
+                if (adxNow >= 18.0) confidence += 4;
+                if (adxSlope >= 0) confidence += 2;
+
                 LastBias = TradeType.Sell;
-            else
-                return;
+                LastLogicConfidence = Math.Min(confidence, 90);
+            }
+            else if (trendShort && bearishReclaim && !pullbackCompleteLong && !continuationLong)
+            {
+                int confidence = 55;
+                if (lowerHighLowerLow) confidence += 4;
+                if (shortBreakdown) confidence += 4;
 
-            var adx = _bot.Indicators
-                .AverageDirectionalMovementIndexRating(14)
-                .ADX.LastValue;
+                LastBias = TradeType.Sell;
+                LastLogicConfidence = Math.Min(confidence, 84);
+            }
+            else if (trendLong && incompleteLongStructure)
+            {
+                LastBias = TradeType.Buy;
+                LastLogicConfidence = 0;
+            }
 
-            int conf = 60;
-            if (adx > 25) conf += 10;
-            if (adx > 30) conf += 5;
+            _bot.Print(
+                $"[USDJPY LOGIC] trend={(trendLong ? "Long" : trendShort ? "Short" : "None")} " +
+                $"longCont={continuationLong} longPb={pullbackCompleteLong} ext={extendedLong} exh={exhaustionLong} " +
+                $"shortWeak={weakeningShort} shortBreak={shortBreakdown} bias={LastBias} logicConf={LastLogicConfidence}");
+        }
 
-            LastLogicConfidence = Math.Min(conf, 95);
+        private static double GetRecentHigh(Bars bars, int endIndex, int length)
+        {
+            int start = Math.Max(0, endIndex - length + 1);
+            double value = double.MinValue;
+            for (int idx = start; idx <= endIndex; idx++)
+                value = Math.Max(value, bars.HighPrices[idx]);
+            return value;
+        }
+
+        private static double GetRecentLow(Bars bars, int endIndex, int length)
+        {
+            int start = Math.Max(0, endIndex - length + 1);
+            double value = double.MaxValue;
+            for (int idx = start; idx <= endIndex; idx++)
+                value = Math.Min(value, bars.LowPrices[idx]);
+            return value;
         }
     }
-
 }


### PR DESCRIPTION
### Motivation

- Fix AUDNZD propagation mismatch so instrument bias and confidence reliably reach the shared `EntryContext`/`PositionContext` used by evaluators. 
- Reduce USDJPY premature/weak Long bias generation by tightening continuation qualification and surfacing Short earlier when weakening is visible. 
- Remove misleading early `[DIR DEBUG]` prints and apply instrument-aware softening of `HTF_MISMATCH` for FX instead of unconditional hard-blocking, while preserving HTF protection for strong opposite HTF signals.

### Description

- Added `EntryTypes/FX/FxDirectionValidation.cs` to centralize FX direction debug logging and instrument-aware HTF mismatch logic; FX entries now call `FxDirectionValidation.LogDirectionDebug()` and `FxDirectionValidation.ShouldBlockHtfMismatch()`. 
- Replaced many early `[DIR DEBUG]` calls in detector layers by removing those prints and moved direction debug to FX entry layer so direction logging occurs only after final propagation. 
- Implemented a stricter `UsdJpyEntryLogic` that requires clearer continuation structure for Longs, allows earlier Shorts on visible weakening, and prevents zero-confidence USDJPY bias from propagating into shared context (file `Instruments/USDJPY/UsdJpyEntryLogic.cs`). 
- Tuned FX bias confidence calculation in `Instruments/FX/FxBiasTuningHelper.cs` to boost structured/continuation setups and keep weak trend-only cases lower quality. 
- Inserted the mandatory AUDNZD propagation audit log immediately after propagation in `Core/TradeCore.cs`: `ctx.Print("[AUDNZD FIX] finalBias={_ctx.LogicBias} finalConf={_ctx.LogicConfidence}")`. 
- Updated FX entry types under `EntryTypes/FX/` (Flag, Pullback, RangeBreakout, Micro*, ImpulseContinuation, Reversal, etc.) to use the shared validation helper and to avoid printing pre-propagation debug lines. 
- Removed pre-propagation `[DIR DEBUG]` from `Core/Entry/TransitionDetector.cs` and `Core/Entry/FlagBreakoutDetector.cs` to eliminate misleading early logs. 

### Testing

- Ran targeted repository searches with `rg` to verify debug-log removal and new `AUDNZD` propagation line (checks passed). 
- Executed Python assertions that confirm detector-layer `[DIR DEBUG]` occurrences were removed and that no `GBPUSD`/`GER40` files were modified (passed). 
- Performed code inspection to confirm FX entry types now call the new helper and that `AUDNZD` debug is printed after propagation (verified). 
- Attempted `dotnet build /workspace/GeminiV26/GeminiV26.csproj` but `dotnet` is not installed in the environment so a full compile was not executed (build not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd2bad69d48328a1be0b6ac0b5d8ab)