### PR TITLE
Fix USDJPY entry logic compile error (restore missing `low` variable)

### DIFF
--- a/Instruments/USDJPY/UsdJpyEntryLogic.cs
+++ b/Instruments/USDJPY/UsdJpyEntryLogic.cs
@@ -50,6 +50,7 @@ namespace GeminiV26.Instruments.USDJPY
             double close = m5.ClosePrices[i];
             double open = m5.OpenPrices[i];
             double high = m5.HighPrices[i];
+            double low = m5.LowPrices[i];
 
             double ema8Now = ema8[i];
             double ema21Now = ema21[i];


### PR DESCRIPTION
### Motivation
- Restore the missing local `low` variable in `UsdJpyEntryLogic` to fix the `CS0103` compile error introduced by the previous edit.

### Description
- Add `double low = m5.LowPrices[i];` next to the other price locals in `Instruments/USDJPY/UsdJpyEntryLogic.cs` so subsequent references to `low` are valid.

### Testing
- Verified the source change with `git diff` and committed the fix (`git commit` completed successfully). 
- No solution/project files were present in the repository snapshot, so `dotnet build` / compile could not be executed and no automated build/tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd2ed24ac08328899c9daadb4d44a1)