### PR TITLE
FX: Soften HTF mismatch, rebalance FX confidence, and stabilize AUDNZD bias

### DIFF
--- a/EntryTypes/DirectionDebug.cs
+++ b/EntryTypes/DirectionDebug.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 
@@ -15,7 +16,13 @@ namespace GeminiV26.EntryTypes
 
             if (SymbolRouting.NormalizeSymbol(ctx.Symbol) == "AUDNZD")
             {
-                ctx.Print($"[AUDNZD TRACE] step3_entry={ctx.LogicBiasDirection} conf={ctx.LogicBiasConfidence}");
+                var entryBias = ctx.LogicBiasDirection;
+                if (ctx.SymbolName == "AUDNZD")
+                {
+                    Debug.Assert(ctx.LogicBias == entryBias);
+                }
+
+                ctx.Print($"[AUDNZD TRACE] step3_entry={entryBias} conf={ctx.LogicBiasConfidence}");
             }
         }
     }

--- a/EntryTypes/FX/FxDirectionValidation.cs
+++ b/EntryTypes/FX/FxDirectionValidation.cs
@@ -16,6 +16,10 @@ namespace GeminiV26.EntryTypes.FX
             if (ctx == null)
                 return false;
 
+            string symbol = Normalize(ctx.Symbol);
+            if (symbol == "GBPUSD")
+                return LegacyShouldBlockHtfMismatch(ctx, symbol);
+
             var logicBias = ctx.LogicBiasDirection;
             if (logicBias == TradeDirection.None)
                 return false;
@@ -26,7 +30,50 @@ namespace GeminiV26.EntryTypes.FX
             if (htfDirection == TradeDirection.None || htfDirection == logicBias || htfConfidence < 0.60)
                 return false;
 
-            string symbol = Normalize(ctx.Symbol);
+            bool targetedFx = IsTargetedFx(symbol);
+            bool localStructure = HasDirectionalStructure(ctx, logicBias);
+            bool trendAligned = IsTrendAligned(ctx, logicBias);
+            bool strongLocalAlignment = localStructure && trendAligned;
+            int strongLogicConfidence = targetedFx ? 68 : 70;
+            double hardBlockConfidence = targetedFx ? 0.78 : 0.76;
+
+            bool strongOpposingHtf = htfDirection != logicBias && htfConfidence >= hardBlockConfidence;
+            bool highLogicConfidence = ctx.LogicBiasConfidence >= strongLogicConfidence;
+
+            if (!strongOpposingHtf)
+            {
+                ctx.Log?.Invoke(
+                    $"[FX HTF][SOFTEN] sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
+                    $"htf={htfDirection}/{htfConfidence:F2} reason=weak_htf_conflict structure={localStructure} trendAligned={trendAligned}");
+                return false;
+            }
+
+            if (strongLocalAlignment || highLogicConfidence)
+            {
+                ctx.Log?.Invoke(
+                    $"[FX HTF][SOFTEN] sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
+                    $"htf={htfDirection}/{htfConfidence:F2} reason=local_logic_override structure={localStructure} trendAligned={trendAligned}");
+                return false;
+            }
+
+            ctx.Log?.Invoke(
+                $"[FX HTF][BLOCK] sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
+                $"htf={htfDirection}/{htfConfidence:F2} structure={localStructure} trendAligned={trendAligned}");
+            return true;
+        }
+
+        private static bool LegacyShouldBlockHtfMismatch(EntryContext ctx, string symbol)
+        {
+            var logicBias = ctx.LogicBiasDirection;
+            if (logicBias == TradeDirection.None)
+                return false;
+
+            var htfDirection = ctx.FxHtfAllowedDirection;
+            var htfConfidence = ctx.FxHtfConfidence01;
+
+            if (htfDirection == TradeDirection.None || htfDirection == logicBias || htfConfidence < 0.60)
+                return false;
+
             bool targetedFx = IsTargetedFx(symbol);
             bool localStructure = HasDirectionalStructure(ctx, logicBias);
             bool trendAligned = IsTrendAligned(ctx, logicBias);

--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -117,8 +117,14 @@ namespace GeminiV26.Instruments.AUDNZD
             // =========================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (AUDNZD)
             // =========================================================
-            _entryLogic.Evaluate();
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+            int logicConfidence = entryContext.LogicBiasConfidence;
+            if (logicConfidence <= 0)
+            {
+                _entryLogic.Evaluate();
+                logicConfidence = _entryLogic.LastLogicConfidence;
+                _bot.Print($"[AUDNZD EXEC] logicConfidence fallback={logicConfidence}");
+            }
+
             int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
             int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
 

--- a/Instruments/FX/FxBiasTuningHelper.cs
+++ b/Instruments/FX/FxBiasTuningHelper.cs
@@ -8,9 +8,9 @@ namespace GeminiV26.Instruments.FX
     {
         private const double TrendDeadzoneAtr = 0.08;
         private const double StructureLookbackAtr = 2.20;
-        private const double StructuredConfidence = 62.0;
-        private const double StrongTrendFallbackConfidence = 56.0;
-        private const double TrendOnlyConfidence = 42.0;
+        private const double StructuredConfidence = 68.0;
+        private const double StrongTrendFallbackConfidence = 52.0;
+        private const double TrendOnlyConfidence = 34.0;
 
         internal struct FxBiasResult
         {
@@ -137,24 +137,47 @@ namespace GeminiV26.Instruments.FX
                 }
             }
 
+            bool structureAligned = (trendLong && structureLong) || (trendShort && structureShort);
+            bool continuationAligned = continuationLong || continuationShort;
+            bool clearStructure = structureAligned && !choppy && !oppositeSignal;
+            bool strongSetup =
+                clearStructure &&
+                continuationAligned &&
+                adxValue >= 23.0 &&
+                atrValue > 0 &&
+                emaAbs >= atrValue * 0.22;
+
             if (trendLong || trendShort)
-                confidence += 5;
-            if (adxValue >= 16.0)
-                confidence += 5;
-            if (adxValue >= 23.0)
-                confidence += 5;
-            if (atrValue > 0 && emaAbs > atrValue * 0.22)
-                confidence += 5;
-            if (htfAligned)
-                confidence += 5;
-            if (continuationLong || continuationShort)
                 confidence += 4;
+            if (adxValue >= 16.0)
+                confidence += 4;
+            if (adxValue >= 23.0)
+                confidence += structureAligned ? 6 : 4;
+            if (atrValue > 0 && emaAbs > atrValue * 0.22)
+                confidence += structureAligned ? 6 : 4;
+            if (htfAligned)
+                confidence += structureAligned ? 5 : 3;
+            if (continuationAligned)
+                confidence += structureAligned ? 6 : 3;
             if (choppy)
-                confidence -= 15;
+                confidence -= structureAligned ? 14 : 18;
             if (oppositeSignal)
-                confidence -= 15;
+                confidence -= structureAligned ? 14 : 18;
             if ((state == "STRUCTURED_BIAS") && ((trendLong && (flagLong || pullbackLong)) || (trendShort && (flagShort || pullbackShort))))
-                confidence += 5;
+                confidence += 4;
+            if (strongSetup)
+                confidence += 6;
+            else if (clearStructure && continuationAligned)
+                confidence += 3;
+
+            if (state == "TREND_ONLY")
+            {
+                confidence -= strongTrendContext && htfAligned && !choppy && !oppositeSignal ? 2 : 6;
+            }
+            else if (state == "NO_TREND")
+            {
+                confidence -= 6;
+            }
 
             confidence = Math.Max(0, Math.Min(100, confidence));
 


### PR DESCRIPTION
### Motivation
- Reduce spurious FX rejections caused by overly strict HTF mismatch checks while keeping strong HTF vetoes in place.
- Ensure `AUDNZD` uses the same propagated logic bias/confidence end-to-end to eliminate occasional step mismatches.
- Improve FX confidence dispersion so clear strong setups map to 70+ and weak setups fall below 50, reducing mid-range clustering.

### Description
- Softened HTF mismatch blocking in `FxDirectionValidation.ShouldBlockHtfMismatch` so FX-only blocking occurs only when the HTF is strongly opposing (higher `FxHtfConfidence01`) and local structure/logic confidence do not clearly support the bias, while preserving legacy behavior for `GBPUSD` via a `LegacyShouldBlockHtfMismatch` fallback; logging updated to indicate soften/block reasons (`EntryTypes/FX/FxDirectionValidation.cs`).
- Rebalanced FX bias/confidence mapping in `FxBiasTuningHelper.Evaluate` by raising `StructuredConfidence`, lowering trend-only baseline, and weighting structure/continuation/ADX/EMA contributions to push strong structured continuations into higher confidence bands and suppress weak/no-trend cases (`Instruments/FX/FxBiasTuningHelper.cs`).
- Enforced AUDNZD final-stage consistency by adding a debug-only assertion comparing propagated context bias and the entry-stage bias in `DirectionDebug.LogOnce` and by making the `AudNzdInstrumentExecutor` prefer `entryContext.LogicBiasConfidence` (with a safe fallback to re-evaluate only if missing) so the same propagated value is used for execution (`EntryTypes/DirectionDebug.cs`, `Instruments/AUDNZD/AudNzdInstrumentExecutor.cs`).

### Testing
- Ran `git diff --check` to validate whitespace/patch integrity and found no issues (success).
- Attempted `dotnet --version` to run a full build in this environment but `dotnet` is not available, so no full compile/test run was executed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd34e728308328ad62c5e080330638)