### PR TITLE
FX HTF: replace hard HTF-mismatch block with penalty and strict-block rule

### DIFF
--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -100,6 +100,8 @@ namespace GeminiV26.Core
 
         private bool ApplyFxAcceptanceFilters(EntryEvaluation eval, EntryContext entryContext)
         {
+            const int HtfMismatchPenalty = 10;
+
             if (eval == null || !eval.IsValid)
                 return false;
 
@@ -116,10 +118,21 @@ namespace GeminiV26.Core
                 && eval.Direction != entryContext.FxHtfAllowedDirection;
 
             int decisionScore = eval.Score;
-            if (eval.HtfConfidence01 < 0.5 && eval.IsHTFMisaligned)
+            if (eval.IsHTFMisaligned)
             {
-                eval.IgnoreHTFForDecision = true;
-                decisionScore = Math.Max(0, Math.Min(100, decisionScore + 10));
+                if (eval.HtfConfidence01 >= 0.80 && entryContext?.LogicBiasConfidence < 60)
+                {
+                    _bot.Print(
+                        $"[HTF][BLOCK] strong opposite HTF + weak LTF type={eval.Type} dir={eval.Direction} " +
+                        $"score={eval.Score} htfConf={eval.HtfConfidence01:F2} logicConf={entryContext?.LogicBiasConfidence ?? 0}");
+                    return RejectFxCandidate(eval, decisionScore, "HTF_STRONG_OPPOSITE_LTF_WEAK");
+                }
+
+                int originalScore = eval.Score;
+                eval.Score = Math.Max(0, eval.Score - HtfMismatchPenalty);
+                _bot.Print(
+                    $"[HTF][PENALTY] mismatch applied type={eval.Type} dir={eval.Direction} " +
+                    $"score={originalScore}->{eval.Score} htfConf={eval.HtfConfidence01:F2} logicConf={entryContext?.LogicBiasConfidence ?? 0}");
             }
 
             if (decisionScore < EntryDecisionPolicy.MinScoreThreshold)

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -23,7 +23,7 @@ namespace GeminiV26.EntryTypes.FX
                 return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
 
             if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
-                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
+                return Invalid(ctx, TradeDirection.None, "HTF_STRONG_OPPOSITE_LTF_WEAK", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)
             {

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -48,7 +48,7 @@ namespace GeminiV26.EntryTypes.FX
                 return Invalid(ctx, TradeDirection.None, "NO_FLAG_TUNING", 0);
 
             if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
-                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
+                return Invalid(ctx, TradeDirection.None, "HTF_STRONG_OPPOSITE_LTF_WEAK", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)
             {

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -30,7 +30,7 @@ namespace GeminiV26.EntryTypes.FX
                 return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
 
             if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
-                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
+                return Invalid(ctx, TradeDirection.None, "HTF_STRONG_OPPOSITE_LTF_WEAK", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)
             {

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -33,7 +33,7 @@ namespace GeminiV26.EntryTypes.FX
                 return Invalid(ctx, "NO_SESSION_TUNING");
 
             if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
-                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
+                return Invalid(ctx, TradeDirection.None, "HTF_STRONG_OPPOSITE_LTF_WEAK", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)
             {

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -30,7 +30,7 @@ namespace GeminiV26.EntryTypes.FX
                 return Invalid(ctx, TradeDirection.None, "NO_FX_PROFILE", 0);
 
             if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
-                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
+                return Invalid(ctx, TradeDirection.None, "HTF_STRONG_OPPOSITE_LTF_WEAK", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)
             {

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -44,7 +44,7 @@ namespace GeminiV26.EntryTypes.FX
                 return Block(ctx, TradeDirection.None, "SESSION_MATRIX_PULLBACK_DISABLED", 0);
 
             if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
-                return Block(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
+                return Block(ctx, TradeDirection.None, "HTF_STRONG_OPPOSITE_LTF_WEAK", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)
             {

--- a/EntryTypes/FX/FX_RangeBreakoutEntry.cs
+++ b/EntryTypes/FX/FX_RangeBreakoutEntry.cs
@@ -90,7 +90,7 @@ namespace GeminiV26.EntryTypes.FX
                     Direction = TradeDirection.None,
                     Score = 0,
                     IsValid = false,
-                    Reason = "HTF_MISMATCH"
+                    Reason = "HTF_STRONG_OPPOSITE_LTF_WEAK"
                 };
             }
 

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -40,7 +40,7 @@ namespace GeminiV26.EntryTypes.FX
                 return Invalid(ctx, "WEAK_EVIDENCE");
 
             if (FxDirectionValidation.ShouldBlockHtfMismatch(ctx))
-                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
+                return Invalid(ctx, TradeDirection.None, "HTF_STRONG_OPPOSITE_LTF_WEAK", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)
             {

--- a/EntryTypes/FX/FxDirectionValidation.cs
+++ b/EntryTypes/FX/FxDirectionValidation.cs
@@ -27,38 +27,20 @@ namespace GeminiV26.EntryTypes.FX
             var htfDirection = ctx.FxHtfAllowedDirection;
             var htfConfidence = ctx.FxHtfConfidence01;
 
-            if (htfDirection == TradeDirection.None || htfDirection == logicBias || htfConfidence < 0.60)
+            if (htfDirection == TradeDirection.None || htfDirection == logicBias)
                 return false;
 
-            bool targetedFx = IsTargetedFx(symbol);
-            bool localStructure = HasDirectionalStructure(ctx, logicBias);
-            bool trendAligned = IsTrendAligned(ctx, logicBias);
-            bool strongLocalAlignment = localStructure && trendAligned;
-            int strongLogicConfidence = targetedFx ? 68 : 70;
-            double hardBlockConfidence = targetedFx ? 0.78 : 0.76;
-
-            bool strongOpposingHtf = htfDirection != logicBias && htfConfidence >= hardBlockConfidence;
-            bool highLogicConfidence = ctx.LogicBiasConfidence >= strongLogicConfidence;
-
-            if (!strongOpposingHtf)
+            if (htfConfidence < 0.80 || ctx.LogicBiasConfidence >= 60)
             {
                 ctx.Log?.Invoke(
-                    $"[FX HTF][SOFTEN] sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
-                    $"htf={htfDirection}/{htfConfidence:F2} reason=weak_htf_conflict structure={localStructure} trendAligned={trendAligned}");
-                return false;
-            }
-
-            if (strongLocalAlignment || highLogicConfidence)
-            {
-                ctx.Log?.Invoke(
-                    $"[FX HTF][SOFTEN] sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
-                    $"htf={htfDirection}/{htfConfidence:F2} reason=local_logic_override structure={localStructure} trendAligned={trendAligned}");
+                    $"[HTF][PENALTY] mismatch applied sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
+                    $"htf={htfDirection}/{htfConfidence:F2}");
                 return false;
             }
 
             ctx.Log?.Invoke(
-                $"[FX HTF][BLOCK] sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
-                $"htf={htfDirection}/{htfConfidence:F2} structure={localStructure} trendAligned={trendAligned}");
+                $"[HTF][BLOCK] strong opposite HTF + weak LTF sym={symbol} logicBias={logicBias} " +
+                $"logicConf={ctx.LogicBiasConfidence} htf={htfDirection}/{htfConfidence:F2}");
             return true;
         }
 
@@ -71,29 +53,20 @@ namespace GeminiV26.EntryTypes.FX
             var htfDirection = ctx.FxHtfAllowedDirection;
             var htfConfidence = ctx.FxHtfConfidence01;
 
-            if (htfDirection == TradeDirection.None || htfDirection == logicBias || htfConfidence < 0.60)
+            if (htfDirection == TradeDirection.None || htfDirection == logicBias)
                 return false;
 
-            bool targetedFx = IsTargetedFx(symbol);
-            bool localStructure = HasDirectionalStructure(ctx, logicBias);
-            bool trendAligned = IsTrendAligned(ctx, logicBias);
-            int minLogicConfidence = targetedFx ? 60 : 64;
-            double hardBlockConfidence = targetedFx ? 0.72 : 0.70;
-
-            if (htfConfidence < hardBlockConfidence &&
-                ctx.LogicBiasConfidence >= minLogicConfidence &&
-                localStructure &&
-                trendAligned)
+            if (htfConfidence < 0.80 || ctx.LogicBiasConfidence >= 60)
             {
                 ctx.Log?.Invoke(
-                    $"[FX HTF][SOFTEN] sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
-                    $"htf={htfDirection}/{htfConfidence:F2} structure={localStructure} trendAligned={trendAligned}");
+                    $"[HTF][PENALTY] mismatch applied sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
+                    $"htf={htfDirection}/{htfConfidence:F2}");
                 return false;
             }
 
             ctx.Log?.Invoke(
-                $"[FX HTF][BLOCK] sym={symbol} logicBias={logicBias} logicConf={ctx.LogicBiasConfidence} " +
-                $"htf={htfDirection}/{htfConfidence:F2} structure={localStructure} trendAligned={trendAligned}");
+                $"[HTF][BLOCK] strong opposite HTF + weak LTF sym={symbol} logicBias={logicBias} " +
+                $"logicConf={ctx.LogicBiasConfidence} htf={htfDirection}/{htfConfidence:F2}");
             return true;
         }
 


### PR DESCRIPTION
### Motivation

- HTF mismatches for FX were force-invalidating candidates everywhere, preventing weak but salvageable LTF setups from being ranked by the router.  
- The intent is to convert those hard blocks into survivable score penalties while keeping a strict block only when HTF is strongly opposite and local logic is weak.  

### Description

- Router: in `Core/TradeRouter.cs` `ApplyFxAcceptanceFilters` an FX-only guard now applies a fixed penalty (10 points) to `eval.Score` when HTF opposes LTF, and does not mark the candidate invalid or stop pipeline traversal; a strict block now fires only when `htfConf >= 0.80` AND `logicConf < 60`, using the reason token `HTF_STRONG_OPPOSITE_LTF_WEAK`.  
- Validation/logging: `EntryTypes/FX/FxDirectionValidation.cs` was simplified to return `true` only for the strict block condition and to emit `[HTF][PENALTY] mismatch applied` for the non-block case and `[HTF][BLOCK] strong opposite HTF + weak LTF` for the strict block case.  
- FX entry files: FX entry evaluators that previously returned generic `HTF_MISMATCH` hard-reasons were updated to use the new `HTF_STRONG_OPPOSITE_LTF_WEAK` block token where they still need to hard-block; no change was made to scoring formulas outside HTF mismatch handling or to non-FX code paths.  
- Scope: changes are limited to FX HTF handling and the FX entry types plus the FX-specific router acceptance flow; non-FX logic and thresholds were left untouched.  

### Testing

- Ran repository checks including `git diff --check` which passed without whitespace errors.  
- Performed targeted source searches (`rg`) for `HTF_MISMATCH`, `ShouldBlockHtfMismatch(` and new log tokens to verify replacements and that only FX files and `Core/TradeRouter.cs` were modified, and the searches returned the expected hits.  
- Ran lightweight Python checks to confirm the modified files set is limited to `Core/TradeRouter.cs` and `EntryTypes/FX/*.cs` and that there are no unexpected changed files.  
- Note: there is no solution/project file in the workspace so no build/compile test was available to run; all automated textual/code checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd3d92893483288366a5ea484ce414)