### PR TITLE
US30: Add EMA-based fallback logic bias

### DIFF
--- a/Instruments/US30/Us30EntryLogic.cs
+++ b/Instruments/US30/Us30EntryLogic.cs
@@ -54,10 +54,8 @@ namespace GeminiV26.Instruments.US30
 
             if (ema50 > ema200)
                 direction = TradeDirection.Long;
-            else if (ema50 < ema200)
-                direction = TradeDirection.Short;
             else
-                return false;
+                direction = TradeDirection.Short;
 
             // =========================
             // ADX – trend erő
@@ -65,8 +63,10 @@ namespace GeminiV26.Instruments.US30
             var adxInd = _bot.Indicators.AverageDirectionalMovementIndexRating(14);
             double adx = adxInd.ADX.LastValue;
 
+            bool fallbackBias = false;
+
             if (adx < 18)
-                return false;
+                fallbackBias = true;
 
             // =========================
             // ATR – skálázás
@@ -99,7 +99,13 @@ namespace GeminiV26.Instruments.US30
                 impulseSoft;
 
             if (!valid)
-                return false;
+                fallbackBias = true;
+
+            if (fallbackBias)
+            {
+                confidence = 50;
+                _bot.Print("[US30][FALLBACK] EMA-based bias applied");
+            }
 
             LastDirection = direction;
             LastBias = direction == TradeDirection.Long ? TradeType.Buy : TradeType.Sell;


### PR DESCRIPTION
### Motivation
- When US30 entry logic produced no clean setup it returned no bias, which stopped the entry pipeline and prevented candidate generation, so a low-confidence fallback direction is needed when no valid logic is found.

### Description
- Ensure direction is always derived from `EMA50` vs `EMA200` (Long if `ema50 > ema200`, otherwise Short) and avoid the previous early-return that left no bias set.
- Add a US30-only `fallbackBias` path that triggers only when `ADX < 18` or the existing `valid` checks fail, sets `confidence = 50`, and logs `[US30][FALLBACK] EMA-based bias applied`; the original valid-setup path and confidence calculations are unchanged.
- The change is strictly limited to `Instruments/US30/Us30EntryLogic.cs` and does not alter routing, scoring, thresholds, or any other instrument logic.

### Testing
- Inspected the file and diff with `git diff -- Instruments/US30/Us30EntryLogic.cs` to verify the change is scoped to the US30 entry logic and the fallback insertions are minimal and local, which succeeded.
- Verified working tree state with `git status --short`, which showed the modified file staged/committed locally.
- Attempted `dotnet build GeminiV26.sln` to perform a build verification but the `dotnet` CLI is not available in this execution environment, so a local build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd4804a36c8328869932993a7d4b8a)