### PR TITLE
Add startup RehydrateService to restore live PositionContext on bot restart

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -341,6 +341,18 @@ namespace GeminiV26.Core
         public bool IsRehydrated { get; set; }
 
         /// <summary>
+        /// Rehydrate meta timestamp UTC-ban.
+        /// Restart audit / debug.
+        /// </summary>
+        public DateTime? RehydratedAtUtc { get; set; }
+
+        /// <summary>
+        /// Rehydrate eredet rövid leírása.
+        /// Pl. LiveOpenPosition.
+        /// </summary>
+        public string RehydrateSource { get; set; } = string.Empty;
+
+        /// <summary>
         /// Utolsó ismert SL ár (pozíció az igazság).
         /// Trailing restore előkészítés.
         /// </summary>

--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -1,0 +1,456 @@
+using System;
+using System.Collections.Generic;
+using cAlgo.API;
+using GeminiV26.Core.Context;
+using GeminiV26.Core.Entry;
+
+namespace GeminiV26.Core.Runtime
+{
+    /// <summary>
+    /// Startup-only recovery layer.
+    /// Rebuilds the minimum safe PositionContext state for still-open Gemini positions.
+    /// No entry, risk, SL/TP, or volume sizing logic belongs here.
+    /// </summary>
+    public sealed class RehydrateService
+    {
+        private readonly Robot _bot;
+        private readonly Dictionary<long, PositionContext> _registry;
+        private readonly ContextRegistry _contextRegistry;
+        private readonly string _botLabel;
+        private readonly Func<PositionContext, bool> _registerExitContext;
+        private readonly string _currentSymbolCanonical;
+
+        public RehydrateService(
+            Robot bot,
+            Dictionary<long, PositionContext> registry,
+            ContextRegistry contextRegistry,
+            string botLabel,
+            Func<PositionContext, bool> registerExitContext)
+        {
+            _bot = bot ?? throw new ArgumentNullException(nameof(bot));
+            _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+            _contextRegistry = contextRegistry ?? throw new ArgumentNullException(nameof(contextRegistry));
+            _botLabel = botLabel ?? string.Empty;
+            _registerExitContext = registerExitContext ?? throw new ArgumentNullException(nameof(registerExitContext));
+            _currentSymbolCanonical = SymbolRouting.NormalizeSymbol(_bot.SymbolName);
+        }
+
+        public RehydrateSummary Run()
+        {
+            var summary = new RehydrateSummary();
+
+            foreach (var position in _bot.Positions)
+            {
+                summary.TotalOpenPositionsSeen++;
+
+                try
+                {
+                    ProcessPosition(position, summary);
+                }
+                catch (Exception ex)
+                {
+                    summary.Failed++;
+                    _bot.Print(
+                        $"[REHYDRATE_WARN] pos={(position == null ? "NULL" : Convert.ToInt64(position.Id).ToString())} " +
+                        $"symbol={position?.SymbolName ?? "UNKNOWN"} error={ex.GetType().Name} message={ex.Message}");
+                    _bot.Print(
+                        $"[REHYDRATE_SKIP] pos={(position == null ? "NULL" : Convert.ToInt64(position.Id).ToString())} " +
+                        $"symbol={position?.SymbolName ?? "UNKNOWN"} reason=exception_during_rebuild unmanaged=true");
+                }
+            }
+
+            if (summary.GeminiManagedCandidates > 0 && summary.SuccessfullyRehydrated == 0)
+            {
+                _bot.Print(
+                    $"[REHYDRATE_WARN] currentSymbol={_currentSymbolCanonical} " +
+                    $"geminiCandidates={summary.GeminiManagedCandidates} reason=zero_successful_rehydrates");
+            }
+
+            _bot.Print(
+                $"[REHYDRATE_SUMMARY] seen={summary.TotalOpenPositionsSeen} " +
+                $"candidates={summary.GeminiManagedCandidates} ok={summary.SuccessfullyRehydrated} " +
+                $"skipped={summary.Skipped} failed={summary.Failed} duplicates={summary.Duplicates} " +
+                $"fallbacks={summary.FallbackReconstructions} ambiguousTp1={summary.AmbiguousTp1Cases} " +
+                $"directionMismatches={summary.DirectionMismatchWarnings}");
+
+            return summary;
+        }
+
+        private void ProcessPosition(Position position, RehydrateSummary summary)
+        {
+            if (position == null)
+            {
+                summary.Skipped++;
+                _bot.Print("[REHYDRATE_SKIP] pos=NULL reason=null_position");
+                return;
+            }
+
+            string normalizedSymbol = SymbolRouting.NormalizeSymbol(position.SymbolName);
+            bool exactOwner = string.Equals(position.Label, _botLabel, StringComparison.Ordinal);
+            bool ambiguousOwner =
+                !exactOwner &&
+                !string.IsNullOrWhiteSpace(position.Label) &&
+                position.Label.IndexOf("gemini", StringComparison.OrdinalIgnoreCase) >= 0;
+
+            if (!exactOwner)
+            {
+                if (ambiguousOwner)
+                {
+                    summary.Skipped++;
+                    _bot.Print(
+                        $"[REHYDRATE_SKIP] pos={Convert.ToInt64(position.Id)} symbol={position.SymbolName} " +
+                        $"label={position.Label} reason=ownership_ambiguous");
+                }
+
+                return;
+            }
+
+            summary.GeminiManagedCandidates++;
+
+            if (!string.Equals(normalizedSymbol, _currentSymbolCanonical, StringComparison.Ordinal))
+            {
+                summary.Skipped++;
+                _bot.Print(
+                    $"[REHYDRATE_SKIP] pos={Convert.ToInt64(position.Id)} symbol={position.SymbolName} " +
+                    $"reason=symbol_scope_mismatch currentSymbol={_currentSymbolCanonical}");
+                return;
+            }
+
+            long positionKey = Convert.ToInt64(position.Id);
+            if (_registry.ContainsKey(positionKey))
+            {
+                summary.Duplicates++;
+                _bot.Print(
+                    $"[REHYDRATE_DUP] pos={positionKey} symbol={position.SymbolName} reason=context_already_exists");
+                return;
+            }
+
+            RebuildResult rebuild = TryRebuild(position, summary);
+            if (rebuild.Context == null)
+            {
+                summary.Failed++;
+                _bot.Print(
+                    $"[REHYDRATE_SKIP] pos={positionKey} symbol={position.SymbolName} reason=rebuild_failed unmanaged=true");
+                return;
+            }
+
+            try
+            {
+                _registry.Add(positionKey, rebuild.Context);
+            }
+            catch (ArgumentException)
+            {
+                summary.Duplicates++;
+                _bot.Print(
+                    $"[REHYDRATE_DUP] pos={positionKey} symbol={position.SymbolName} reason=duplicate_registry_key_attempt");
+                return;
+            }
+
+            _contextRegistry.RegisterPosition(rebuild.Context);
+
+            if (!_registerExitContext(rebuild.Context))
+            {
+                _registry.Remove(positionKey);
+                _contextRegistry.RemovePosition(positionKey);
+                summary.Failed++;
+                _bot.Print(
+                    $"[REHYDRATE_SKIP] pos={positionKey} symbol={position.SymbolName} reason=exit_manager_registration_failed unmanaged=true");
+                return;
+            }
+
+            if (rebuild.UsedFallback)
+                summary.FallbackReconstructions++;
+
+            if (rebuild.AmbiguousTp1)
+                summary.AmbiguousTp1Cases++;
+
+            if (rebuild.DirectionMismatch)
+                summary.DirectionMismatchWarnings++;
+
+            summary.SuccessfullyRehydrated++;
+
+            _bot.Print(
+                $"[REHYDRATE] pos={positionKey} symbol={position.SymbolName} dir={rebuild.Context.FinalDirection} " +
+                $"tp1Hit={rebuild.Context.Tp1Hit} be={rebuild.Context.BeActivated} trailing={rebuild.Context.TrailingActivated} " +
+                $"remainingUnits={rebuild.Context.RemainingVolumeInUnits} source={rebuild.Context.RehydrateSource}");
+
+            if (rebuild.DefaultedLifecycleFields)
+            {
+                _bot.Print(
+                    $"[REHYDRATE_FALLBACK] pos={positionKey} symbol={position.SymbolName} reason=lifecycle_fields_defaulted");
+            }
+        }
+
+        private RebuildResult TryRebuild(Position position, RehydrateSummary summary)
+        {
+            long positionKey = Convert.ToInt64(position.Id);
+            var result = new RebuildResult();
+
+            if (string.IsNullOrWhiteSpace(position.SymbolName))
+            {
+                _bot.Print($"[REHYDRATE_WARN] pos={positionKey} reason=missing_symbol_name");
+                return result;
+            }
+
+            Symbol symbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            if (symbol == null)
+            {
+                _bot.Print($"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=missing_symbol_metadata");
+                return result;
+            }
+
+            double entryPrice = position.EntryPrice;
+            if (!IsFinitePositive(entryPrice))
+            {
+                _bot.Print($"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=invalid_entry_price value={entryPrice}");
+                return result;
+            }
+
+            double currentVolumeInUnits = position.VolumeInUnits;
+            if (!IsFinitePositive(currentVolumeInUnits))
+            {
+                _bot.Print($"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=invalid_volume_units value={currentVolumeInUnits}");
+                return result;
+            }
+
+            if (currentVolumeInUnits < symbol.VolumeInUnitsMin)
+            {
+                _bot.Print(
+                    $"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=volume_below_min " +
+                    $"volume={currentVolumeInUnits} min={symbol.VolumeInUnitsMin}");
+            }
+
+            if (!IsVolumeStepAligned(currentVolumeInUnits, symbol.VolumeInUnitsStep))
+            {
+                _bot.Print(
+                    $"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=volume_step_misaligned " +
+                    $"volume={currentVolumeInUnits} step={symbol.VolumeInUnitsStep}");
+            }
+
+            TradeDirection direction = position.TradeType == TradeType.Buy
+                ? TradeDirection.Long
+                : TradeDirection.Short;
+
+            double? stopLoss = position.StopLoss;
+            double? takeProfit = position.TakeProfit;
+            double riskDistance = 0;
+            bool usedFallback = false;
+            bool defaultedLifecycleFields = false;
+            bool directionMismatch = false;
+            bool ambiguousTp1 = false;
+
+            if (!stopLoss.HasValue)
+            {
+                usedFallback = true;
+                defaultedLifecycleFields = true;
+                _bot.Print(
+                    $"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=missing_stop_loss_exit_manager_expectation");
+            }
+            else if (!IsFinitePositive(stopLoss.Value))
+            {
+                usedFallback = true;
+                defaultedLifecycleFields = true;
+                _bot.Print(
+                    $"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=invalid_stop_loss value={stopLoss.Value}");
+                stopLoss = null;
+            }
+            else
+            {
+                riskDistance = Math.Abs(entryPrice - stopLoss.Value);
+                if (!IsFinitePositive(riskDistance))
+                {
+                    usedFallback = true;
+                    defaultedLifecycleFields = true;
+                    _bot.Print(
+                        $"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=invalid_risk_distance value={riskDistance}");
+                    riskDistance = 0;
+                }
+            }
+
+            if (takeProfit.HasValue && !IsFinitePositive(takeProfit.Value))
+            {
+                usedFallback = true;
+                _bot.Print(
+                    $"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=invalid_take_profit value={takeProfit.Value}");
+                takeProfit = null;
+            }
+
+            bool protectedStop = stopLoss.HasValue && IsProtectedStop(direction, stopLoss.Value, entryPrice, symbol.TickSize);
+            bool trailingEvident = stopLoss.HasValue && IsTrailingBeyondEntry(direction, stopLoss.Value, entryPrice, symbol.TickSize);
+
+            if (stopLoss.HasValue && IsSuspiciousStop(direction, stopLoss.Value, entryPrice, symbol.TickSize))
+            {
+                _bot.Print(
+                    $"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=suspicious_sl_location " +
+                    $"entry={entryPrice} sl={stopLoss.Value} side={position.TradeType}");
+            }
+
+            bool tp1Hit = false;
+            double tp1ClosedVolumeInUnits = 0;
+            double entryVolumeInUnits = currentVolumeInUnits;
+            double initialVolumeInUnits = currentVolumeInUnits;
+
+            if (protectedStop)
+            {
+                tp1Hit = true;
+                usedFallback = true;
+                defaultedLifecycleFields = true;
+                // Ambiguity note:
+                // the live position proves protective-stop phase, but not the original pre-TP1 volume.
+                // We therefore restore the fact of TP1/BE progression, while keeping remaining volume as the only hard volume fact.
+                _bot.Print(
+                    $"[REHYDRATE_TP1] pos={positionKey} symbol={position.SymbolName} reason=protected_stop_infers_tp1 sl={stopLoss.Value} entry={entryPrice}");
+                _bot.Print(
+                    $"[REHYDRATE_FALLBACK] pos={positionKey} symbol={position.SymbolName} reason=original_volume_unknown tp1ClosedUnits=0 remainingUnits={currentVolumeInUnits}");
+            }
+            else
+            {
+                ambiguousTp1 = true;
+                usedFallback = true;
+                defaultedLifecycleFields = true;
+                _bot.Print(
+                    $"[REHYDRATE_TP1] pos={positionKey} symbol={position.SymbolName} reason=tp1_ambiguous default=false " +
+                    $"remainingUnits={currentVolumeInUnits} originalVolumeRecoverable=false");
+            }
+
+            if (tp1Hit && tp1ClosedVolumeInUnits > 0 && entryVolumeInUnits <= currentVolumeInUnits)
+            {
+                _bot.Print(
+                    $"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=invalid_tp1_inference " +
+                    $"entryUnits={entryVolumeInUnits} remainingUnits={currentVolumeInUnits} closedUnits={tp1ClosedVolumeInUnits}");
+            }
+
+            var ctx = new PositionContext
+            {
+                PositionId = positionKey,
+                Symbol = position.SymbolName,
+                EntryType = "REHYDRATED",
+                EntryReason = "Startup rehydrate from live open position",
+                FinalDirection = direction,
+                // Ambiguity note:
+                // original entry evaluation is runtime-only and cannot be recovered safely after restart,
+                // so we restore with neutral placeholders and keep FinalConfidence deterministic via ComputeFinalConfidence().
+                EntryScore = 50,
+                LogicConfidence = 50,
+                EntryTime = _bot.Server.Time,
+                EntryTimeUtc = _bot.Server.Time.ToUniversalTime(),
+                EntryPrice = entryPrice,
+                RiskPriceDistance = riskDistance,
+                Tp1Hit = tp1Hit,
+                Tp1CloseFraction = 0,
+                Tp1ClosedVolumeInUnits = tp1ClosedVolumeInUnits,
+                EntryVolumeInUnits = entryVolumeInUnits,
+                RemainingVolumeInUnits = currentVolumeInUnits,
+                InitialVolumeInUnits = initialVolumeInUnits,
+                BePrice = protectedStop && stopLoss.HasValue ? stopLoss.Value : 0,
+                BeMode = tp1Hit ? BeMode.AfterTp1 : BeMode.None,
+                BeActivated = protectedStop,
+                TrailingMode = tp1Hit ? TrailingMode.Normal : TrailingMode.None,
+                TrailingActivated = tp1Hit && trailingEvident,
+                LastStopLossPrice = stopLoss,
+                LastTrailingStopTarget = tp1Hit && trailingEvident && stopLoss.HasValue ? stopLoss.Value : null,
+                Tp2Price = takeProfit,
+                IsRehydrated = true,
+                RehydratedAtUtc = _bot.Server.Time.ToUniversalTime(),
+                RehydrateSource = "LiveOpenPosition",
+                MarketTrend = direction != TradeDirection.None,
+                Adx_M5 = 0
+            };
+
+            // AGENTS rule: PositionContext létrehozás után azonnal számoljuk a FinalConfidence-t.
+            ctx.ComputeFinalConfidence();
+
+            TradeDirection liveDirection = position.TradeType == TradeType.Buy
+                ? TradeDirection.Long
+                : TradeDirection.Short;
+
+            if (ctx.FinalDirection != liveDirection)
+            {
+                directionMismatch = true;
+                ctx.FinalDirection = liveDirection;
+                _bot.Print(
+                    $"[REHYDRATE_DIR] pos={positionKey} symbol={position.SymbolName} reason=direction_mismatch " +
+                    $"restored={ctx.FinalDirection} live={liveDirection}");
+            }
+
+            if (ctx.FinalDirection == TradeDirection.None)
+            {
+                _bot.Print(
+                    $"[REHYDRATE_DIR] pos={positionKey} symbol={position.SymbolName} reason=direction_missing_after_restore");
+                return result;
+            }
+
+            result.Context = ctx;
+            result.UsedFallback = usedFallback;
+            result.DefaultedLifecycleFields = defaultedLifecycleFields;
+            result.AmbiguousTp1 = ambiguousTp1;
+            result.DirectionMismatch = directionMismatch;
+            return result;
+        }
+
+        private static bool IsFinitePositive(double value)
+        {
+            return value > 0 && !double.IsNaN(value) && !double.IsInfinity(value);
+        }
+
+        private static bool IsProtectedStop(TradeDirection direction, double stopLoss, double entryPrice, double epsilon)
+        {
+            double tolerance = Math.Max(epsilon, 1e-8);
+
+            return direction == TradeDirection.Long
+                ? stopLoss >= entryPrice - tolerance
+                : stopLoss <= entryPrice + tolerance;
+        }
+
+        private static bool IsTrailingBeyondEntry(TradeDirection direction, double stopLoss, double entryPrice, double epsilon)
+        {
+            double tolerance = Math.Max(epsilon * 2.0, 1e-8);
+
+            return direction == TradeDirection.Long
+                ? stopLoss > entryPrice + tolerance
+                : stopLoss < entryPrice - tolerance;
+        }
+
+        private static bool IsSuspiciousStop(TradeDirection direction, double stopLoss, double entryPrice, double epsilon)
+        {
+            double tolerance = Math.Max(epsilon, 1e-8);
+
+            if (direction == TradeDirection.Long)
+                return Math.Abs(stopLoss - entryPrice) < tolerance;
+
+            return Math.Abs(stopLoss - entryPrice) < tolerance;
+        }
+
+        private static bool IsVolumeStepAligned(double volumeInUnits, double step)
+        {
+            if (step <= 0)
+                return true;
+
+            double ratio = volumeInUnits / step;
+            double nearest = Math.Round(ratio);
+            return Math.Abs(ratio - nearest) < 1e-6;
+        }
+
+        private sealed class RebuildResult
+        {
+            public PositionContext Context { get; set; }
+            public bool UsedFallback { get; set; }
+            public bool DefaultedLifecycleFields { get; set; }
+            public bool AmbiguousTp1 { get; set; }
+            public bool DirectionMismatch { get; set; }
+        }
+    }
+
+    public sealed class RehydrateSummary
+    {
+        public int TotalOpenPositionsSeen { get; set; }
+        public int GeminiManagedCandidates { get; set; }
+        public int SuccessfullyRehydrated { get; set; }
+        public int Skipped { get; set; }
+        public int Failed { get; set; }
+        public int Duplicates { get; set; }
+        public int FallbackReconstructions { get; set; }
+        public int AmbiguousTp1Cases { get; set; }
+        public int DirectionMismatchWarnings { get; set; }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -63,6 +63,7 @@ using GeminiV26.Core.HtfBias;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Core.Context;
 using GeminiV26.Core.Analytics;
+using GeminiV26.Core.Runtime;
 using System.Linq;
 
 namespace GeminiV26.Core
@@ -760,6 +761,7 @@ namespace GeminiV26.Core
                 if (!_positionContexts.TryGetValue(pos.Id, out var ctx))
                 {
                     _bot.Print($"[TC] Context missing for position posId={pos.Id}");
+                    _bot.Print($"[REHYDRATE_WARN] pos={Convert.ToInt64(pos.Id)} symbol={pos.SymbolName} reason=exit_pipeline_missing_context");
                     continue;
                 }
 
@@ -2175,12 +2177,131 @@ namespace GeminiV26.Core
             _logWriter?.Dispose();
         }
 
+        public void RehydrateOpenPositions()
+        {
+            var service = new RehydrateService(
+                _bot,
+                _positionContexts,
+                _contextRegistry,
+                BotLabel,
+                RegisterRehydratedContextWithExitManager);
+
+            service.Run();
+        }
+
         // =================================================
         // SYMBOL NORMALIZATION
         // =================================================
         private static string NormalizeSymbol(string symbol)
         {
             return SymbolRouting.NormalizeSymbol(symbol);
+        }
+
+        private bool RegisterRehydratedContextWithExitManager(PositionContext ctx)
+        {
+            if (ctx == null)
+                return false;
+
+            string symbol = NormalizeSymbol(ctx.Symbol);
+
+            if (symbol == "XAUUSD")
+            {
+                _xauExitManager?.RegisterContext(ctx);
+                return _xauExitManager != null;
+            }
+
+            if (symbol == "NAS100")
+            {
+                _nasExitManager?.RegisterContext(ctx);
+                return _nasExitManager != null;
+            }
+
+            if (symbol == "US30")
+            {
+                _us30ExitManager?.RegisterContext(ctx);
+                return _us30ExitManager != null;
+            }
+
+            if (symbol == "GER40")
+            {
+                _ger40ExitManager?.RegisterContext(ctx);
+                return _ger40ExitManager != null;
+            }
+
+            if (symbol == "EURUSD")
+            {
+                _eurUsdExitManager?.RegisterContext(ctx);
+                return _eurUsdExitManager != null;
+            }
+
+            if (symbol == "USDJPY")
+            {
+                _usdJpyExitManager?.RegisterContext(ctx);
+                return _usdJpyExitManager != null;
+            }
+
+            if (symbol == "GBPUSD")
+            {
+                _gbpUsdExitManager?.RegisterContext(ctx);
+                return _gbpUsdExitManager != null;
+            }
+
+            if (symbol == "AUDUSD")
+            {
+                _audUsdExitManager?.RegisterContext(ctx);
+                return _audUsdExitManager != null;
+            }
+
+            if (symbol == "AUDNZD")
+            {
+                _audNzdExitManager?.RegisterContext(ctx);
+                return _audNzdExitManager != null;
+            }
+
+            if (symbol == "EURJPY")
+            {
+                _eurJpyExitManager?.RegisterContext(ctx);
+                return _eurJpyExitManager != null;
+            }
+
+            if (symbol == "GBPJPY")
+            {
+                _gbpJpyExitManager?.RegisterContext(ctx);
+                return _gbpJpyExitManager != null;
+            }
+
+            if (symbol == "NZDUSD")
+            {
+                _nzdUsdExitManager?.RegisterContext(ctx);
+                return _nzdUsdExitManager != null;
+            }
+
+            if (symbol == "USDCAD")
+            {
+                _usdCadExitManager?.RegisterContext(ctx);
+                return _usdCadExitManager != null;
+            }
+
+            if (symbol == "USDCHF")
+            {
+                _usdChfExitManager?.RegisterContext(ctx);
+                return _usdChfExitManager != null;
+            }
+
+            if (symbol == "BTCUSD")
+            {
+                _btcUsdExitManager?.RegisterContext(ctx);
+                return _btcUsdExitManager != null;
+            }
+
+            if (symbol == "ETHUSD")
+            {
+                _ethUsdExitManager?.RegisterContext(ctx);
+                return _ethUsdExitManager != null;
+            }
+
+            _bot.Print($"[REHYDRATE_WARN] pos={ctx.PositionId} symbol={ctx.Symbol} reason=no_exit_manager_for_symbol");
+            return false;
         }
 
         // =================================================

--- a/GeminiV26Bot.cs
+++ b/GeminiV26Bot.cs
@@ -63,12 +63,9 @@ namespace GeminiV26
             });
 
             // =========================
-            // 🔹 REHYDRATE (XAU)
+            // 🔹 STARTUP REHYDRATE
             // =========================
-            if (SymbolRouting.ResolveInstrumentClass(SymbolName) == InstrumentClass.METAL)
-            {
-                _core.XauExitManager.RehydrateFromLivePositions(this);
-            }
+            _core.RehydrateOpenPositions();
         }
 
         protected override void OnBar()


### PR DESCRIPTION
### Motivation
- Ensure every Gemini-managed live position regains a valid `PositionContext` after a bot restart so ExitManagers can continue TP1/BE/trailing lifecycle safely. 
- Provide an instrument-agnostic, startup-only recovery layer that conservatively reconstructs runtime-only state without changing entry/risk/volume/SL–TP logic. 
- Surface restart-related inconsistencies explicitly via structured debug logs so hidden state bugs are visible during startup. 

### Description
- Added a global startup recovery engine `Core/Runtime/RehydrateService.cs` that scans `_bot.Positions`, filters for exact Gemini ownership and current symbol scope, rebuilds conservative `PositionContext` objects, prevents duplicate registry keys, registers them into the `TradeCore` long-key registry, and registers contexts with the existing instrument `ExitManager`s via a callback. 
- Wired startup recovery into the lifecycle by calling `TradeCore.RehydrateOpenPositions()` from `GeminiV26Bot.OnStart()` and implemented `RehydrateOpenPositions()` plus a `RegisterRehydratedContextWithExitManager` helper in `Core/TradeCore.cs`. 
- Restored minimal safe fields in rehydrated `PositionContext` (e.g. `PositionId`, `Symbol`, `EntryPrice`, `FinalDirection`, `EntryVolumeInUnits`, `RemainingVolumeInUnits`, `InitialVolumeInUnits`, `LastStopLossPrice`, `Tp2Price`, `RiskPriceDistance`, TP1/BE/trailing flags) and added audit metadata `RehydratedAtUtc` and `RehydrateSource` to `Core/PositionContext.cs`. 
- Conservative reconstruction policy and defensive guards: do not invent original entry scoring/volume or recalculate SL/TP/risk/volume sizing, infer `Tp1Hit` only with protective-stop evidence, keep remaining units as the single hard volume fact when original volume is unknown, call `ctx.ComputeFinalConfidence()` immediately after `PositionContext` creation, and emit detailed `[REHYDRATE]`/`[REHYDRATE_WARN]`/`[REHYDRATE_SUMMARY]` logs for ambiguous or fallback cases. 

### Testing
- Ran `git diff --check` and verified no whitespace/git-diff issues (passed). 
- Ran targeted static checks (`rg`) to ensure no legacy `Position.Volume` or legacy `Symbol.VolumeMin/Step/Max` usage was introduced in the rehydrate code (passed). 
- Performed repository-level sanity checks (`git status`, commit) to ensure changes were committed (passed). 
- Confirmed that `PositionContext.ComputeFinalConfidence()` is called after every rehydrated context creation as required (inspection). 
- Could not run a full C# compile or runtime tests because `dotnet`/`csc`/`mcs` are not available in this environment, so runtime compilation/tests were not executed here (manual/static checks only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bea2cc755c8328ab4513326b36c6fb)