### PR TITLE
Add tempId/posId tracing to trade logs

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -3,6 +3,7 @@ using cAlgo.API.Internals;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Instruments.INDEX;
 using GeminiV26.Core.Matrix;
+using GeminiV26.Core.Logging;
 using System;
 
 namespace GeminiV26.Core.Entry
@@ -14,6 +15,7 @@ namespace GeminiV26.Core.Entry
         // =========================
         public bool IsReady { get; set; }
         public string Symbol;
+        public string TempId { get; set; }
         public Action<string> Log { get; set; }
 
         public DateTime LastUpdateUtc { get; set; } = DateTime.UtcNow;
@@ -324,11 +326,11 @@ namespace GeminiV26.Core.Entry
 
             if (Log != null)
             {
-                Log(message);
+                Log(TradeLogIdentity.WithTempId(message, this));
                 return;
             }
 
-            Bot?.Print(message);
+            Bot?.Print(TradeLogIdentity.WithTempId(message, this));
         }
 
         public bool IsValidFlagStructure_M5 =>

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -58,6 +58,7 @@ namespace GeminiV26.Core.Entry
             var ctx = new EntryContext
             {
                 Symbol = symbol,
+                TempId = $"{symbol}_{_bot.Server.Time:yyyyMMdd_HHmmss_fff}",
                 IsReady = false,
                 TrendDirection = TradeDirection.None,
                 Log = message => _bot.Print(message)

--- a/Core/Logging/TradeLogIdentity.cs
+++ b/Core/Logging/TradeLogIdentity.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using cAlgo.API;
+using GeminiV26.Core.Entry;
+
+namespace GeminiV26.Core.Logging
+{
+    internal static class TradeLogIdentity
+    {
+        public static string WithTempId(string message, EntryContext ctx)
+        {
+            if (ctx == null)
+                return message;
+
+            return WithTempId(message, ctx.TempId);
+        }
+
+        public static string WithTempId(string message, string tempId)
+        {
+            if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(tempId) || message.Contains("tempId=", StringComparison.Ordinal))
+                return message;
+
+            return InsertFields(message, $"tempId={tempId}");
+        }
+
+        public static string WithPositionIds(string message, PositionContext ctx, Position pos = null)
+        {
+            long posId = 0;
+            if (pos != null && pos.Id > 0)
+                posId = pos.Id;
+            else if (ctx != null && ctx.PositionId > 0)
+                posId = ctx.PositionId;
+
+            return WithPositionIds(message, posId > 0 ? posId : (long?)null, ctx?.TempId);
+        }
+
+        public static string WithPositionIds(string message, long? posId, string tempId = null)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+                return message;
+
+            var fields = new List<string>();
+            if (!string.IsNullOrWhiteSpace(tempId) && !message.Contains("tempId=", StringComparison.Ordinal))
+                fields.Add($"tempId={tempId}");
+
+            if (posId.HasValue && posId.Value > 0 && !message.Contains("posId=", StringComparison.Ordinal))
+                fields.Add($"posId={posId.Value}");
+
+            if (fields.Count == 0)
+                return message;
+
+            return InsertFields(message, string.Join(" ", fields));
+        }
+
+        private static string InsertFields(string message, string fields)
+        {
+            if (string.IsNullOrWhiteSpace(fields))
+                return message;
+
+            if (message.StartsWith("[", StringComparison.Ordinal))
+            {
+                int closing = message.IndexOf(']');
+                if (closing >= 0)
+                    return message.Insert(closing + 1, $" {fields}");
+            }
+
+            return $"{fields} {message}";
+        }
+    }
+}

--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -44,6 +44,8 @@ namespace GeminiV26.Core
 
         public string Symbol { get; set; } = string.Empty;
 
+        public string TempId { get; set; } = string.Empty;
+
         public string EntryType { get; set; } = string.Empty;
 
         public string EntryReason { get; set; } = string.Empty;

--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -324,6 +324,7 @@ namespace GeminiV26.Core.Runtime
             {
                 PositionId = positionKey,
                 Symbol = position.SymbolName,
+                TempId = position.Comment ?? string.Empty,
                 EntryType = "REHYDRATED",
                 EntryReason = "Startup rehydrate from live open position",
                 FinalDirection = direction,

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -904,7 +904,7 @@ namespace GeminiV26.Core
             _ctx.TransitionValid = transition.IsValid;
             _ctx.TransitionScoreBonus = transition.BonusScore;
             _flagBreakoutDetector.Evaluate(_ctx);
-            _bot.Print($"[DIR][CTX_BUILD] sym={_bot.SymbolName} trend={_ctx.TrendDirection} impulse={_ctx.ImpulseDirection} breakout={_ctx.BreakoutDirection} reversal={_ctx.ReversalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][CTX_BUILD] sym={_bot.SymbolName} trend={_ctx.TrendDirection} impulse={_ctx.ImpulseDirection} breakout={_ctx.BreakoutDirection} reversal={_ctx.ReversalDirection}", _ctx));
 
             // =========================
             // GLOBAL SESSION GATE + SESSION MATRIX
@@ -1078,8 +1078,8 @@ namespace GeminiV26.Core
                 _ctx.Print("[BIAS FALLBACK] using TrendDirection");
             }
 
-            _bot.Print($"[DIR][LOGIC] sym={_bot.SymbolName} logicBias={_ctx.LogicBiasDirection} logicConf={_ctx.LogicBiasConfidence}");
-            _bot.Print($"[CTX PROPAGATION] symbol={_bot.SymbolName} bias={_ctx.LogicBias} conf={_ctx.LogicConfidence}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][LOGIC] sym={_bot.SymbolName} logicBias={_ctx.LogicBiasDirection} logicConf={_ctx.LogicBiasConfidence}", _ctx));
+            _bot.Print(TradeLogIdentity.WithTempId($"[CTX PROPAGATION] symbol={_bot.SymbolName} bias={_ctx.LogicBias} conf={_ctx.LogicConfidence}", _ctx));
 
             if (IsSymbol("AUDNZD"))
                 _ctx.Print($"[AUDNZD TRACE] step2_ctx={_ctx.LogicBiasDirection} conf={_ctx.LogicBiasConfidence}");
@@ -1092,8 +1092,8 @@ namespace GeminiV26.Core
 
             _entryRouterPassCounter++;
             _ctx.DirectionDebugLogged = false;
-            _bot.Print($"[PIPE][ENTRY_ROUTER_PASS] pass={_entryRouterPassCounter} symbol={_bot.SymbolName} bar={_bot.Server.Time:O}");
-            _bot.Print($"[ENTRY START] symbol={_bot.SymbolName} bias={_ctx.LogicBias}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[PIPE][ENTRY_ROUTER_PASS] pass={_entryRouterPassCounter} symbol={_bot.SymbolName} bar={_bot.Server.Time:O}", _ctx));
+            _bot.Print(TradeLogIdentity.WithTempId($"[ENTRY START] symbol={_bot.SymbolName} bias={_ctx.LogicBias}", _ctx));
 
             var signals = _entryRouter.Evaluate(new[] { _ctx });
 
@@ -1113,11 +1113,11 @@ namespace GeminiV26.Core
 
             ApplyTransitionScoreBoost(_ctx, symbolSignals);
 
-            _bot.Print($"[DBG ENTRY] total candidates={symbolSignals.Count}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DBG ENTRY] total candidates={symbolSignals.Count}", _ctx));
 
             foreach (var e in symbolSignals)
             {
-                _bot.Print($"[DIR][ROUTER_CAND] sym={_bot.SymbolName} type={e?.Type} valid={e?.IsValid} score={e?.Score} dir={e?.Direction} reason={e?.Reason}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][ROUTER_CAND] sym={_bot.SymbolName} type={e?.Type} valid={e?.IsValid} score={e?.Score} dir={e?.Direction} reason={e?.Reason}", _ctx));
             }
 
         // =====================================================
@@ -1133,7 +1133,7 @@ namespace GeminiV26.Core
             _ctx.FxHtfConfidence01 = bias.Confidence01;
             _ctx.FxHtfReason = bias.Reason;
 
-            _bot.Print($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}", _ctx));
             ApplyHtfBiasScoreOnly(symbolSignals, bias, "FX");
         }
         else if (isCryptoSymbol && _cryptoBias != null)
@@ -1143,7 +1143,7 @@ namespace GeminiV26.Core
             _ctx.CryptoHtfConfidence01 = bias.Confidence01;
             _ctx.CryptoHtfReason = bias.Reason;
 
-            _bot.Print($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}", _ctx));
             ApplyHtfBiasScoreOnly(symbolSignals, bias, "CRYPTO");
         }
         else if (isMetalSymbol && _metalBias != null)
@@ -1153,7 +1153,7 @@ namespace GeminiV26.Core
             _ctx.MetalHtfConfidence01 = bias.Confidence01;
             _ctx.MetalHtfReason = bias.Reason;
 
-            _bot.Print($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}", _ctx));
             ApplyHtfBiasScoreOnly(symbolSignals, bias, "XAU");
         }
         else if (isIndexSymbol && _indexBias != null)
@@ -1163,7 +1163,7 @@ namespace GeminiV26.Core
             _ctx.IndexHtfConfidence01 = bias.Confidence01;
             _ctx.IndexHtfReason = bias.Reason;
 
-            _bot.Print($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}", _ctx));
             ApplyHtfBiasScoreOnly(symbolSignals, bias, "INDEX");
         }
 
@@ -1227,12 +1227,12 @@ namespace GeminiV26.Core
                     }
                 );
 
-                _bot.Print($"[TC] ENTRY WINNER {selected.Type} dir={selected.Direction} score={selected.Score}");
-                _bot.Print($"[DIR][ROUTED] sym={_bot.SymbolName} type={selected.Type} routedDir={selected.Direction} score={selected.Score}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[TC] ENTRY WINNER {selected.Type} dir={selected.Direction} score={selected.Score}", _ctx));
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][ROUTED] sym={_bot.SymbolName} type={selected.Type} routedDir={selected.Direction} score={selected.Score}", _ctx));
 
                 _ctx.RoutedDirection = selected.Direction;
                 _ctx.FinalDirection = selected.Direction;
-                _bot.Print($"[DIR][SET] sym={_ctx.Symbol} finalDir={_ctx.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][SET] sym={_ctx.Symbol} finalDir={_ctx.FinalDirection}", _ctx));
 
                 if (_ctx.FinalDirection == TradeDirection.None)
                 {
@@ -1240,7 +1240,7 @@ namespace GeminiV26.Core
                     return;
                 }
 
-                _bot.Print($"[DIR][FINAL] sym={_bot.SymbolName} routed={_ctx.RoutedDirection} final={_ctx.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][FINAL] sym={_bot.SymbolName} routed={_ctx.RoutedDirection} final={_ctx.FinalDirection}", _ctx));
                 DirectionGuard.Validate(_ctx, null, _bot.Print);
 
                 if (!ValidateDirectionConsistency(_ctx, selected))
@@ -1248,11 +1248,11 @@ namespace GeminiV26.Core
                     return;
                 }
 
-                _bot.Print($"[DIR][EXEC_PRE] sym={_bot.SymbolName} finalCtxDir={_ctx.FinalDirection}");
-                _bot.Print($"[DIR][EXEC_CONFIRMED] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_PRE] sym={_bot.SymbolName} finalCtxDir={_ctx.FinalDirection}", _ctx));
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_CONFIRMED] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}", _ctx));
 
                 if (!HasDirectionTraceCompleteness(_ctx))
-                    _bot.Print($"[DIR][TRACE_INCOMPLETE] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}");
+                    _bot.Print(TradeLogIdentity.WithTempId($"[DIR][TRACE_INCOMPLETE] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}", _ctx));
 
                 var gateDir = ToTradeTypeStrict(_ctx.FinalDirection);
 

--- a/Core/TradeManagement/AdaptiveTrailingEngine.cs
+++ b/Core/TradeManagement/AdaptiveTrailingEngine.cs
@@ -3,6 +3,7 @@ using cAlgo.API;
 using cAlgo.API.Indicators;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 
 namespace GeminiV26.Core.TradeManagement
 {
@@ -124,7 +125,7 @@ namespace GeminiV26.Core.TradeManagement
                 if (!ctx.TrailNoImprovementLogged)
                 {
                     ctx.TrailNoImprovementLogged = true;
-                    _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=no_improvement");
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=no_improvement", ctx, pos));
                 }
                 return;
             }
@@ -136,13 +137,13 @@ namespace GeminiV26.Core.TradeManagement
             double minDelta = Math.Max(profile.MinSlUpdateDeltaPips * _bot.Symbol.PipSize, atr * 0.05);
             if (Math.Abs(newSl - oldSl) < minDelta)
             {
-                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=below_min_delta minDelta={minDelta:0.00000}");
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=below_min_delta minDelta={minDelta:0.00000}", ctx, pos));
                 return;
             }
 
             if (ctx.LastTrailingStopTarget.HasValue && Math.Abs(ctx.LastTrailingStopTarget.Value - newSl) < epsilon)
             {
-                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=duplicate_target");
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=duplicate_target", ctx, pos));
                 return;
             }
 
@@ -154,17 +155,17 @@ namespace GeminiV26.Core.TradeManagement
 
             if (!result.IsSuccessful)
             {
-                _bot.Print($"[TRAIL] modify FAILED pos={pos.Id} error={result.Error}");
-                _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=modify_failed error={result.Error}");
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[TRAIL] modify FAILED pos={pos.Id} error={result.Error}", ctx, pos));
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=modify_failed error={result.Error}", ctx, pos));
                 return;
             }
 
             ctx.LastTrailingStopTarget = newSl;
             ctx.LastStopLossPrice = newSl;
             ctx.TrailingActivated = true;
-            _bot.Print($"[TRAIL] modified pos={pos.Id} oldSL={oldSl} newSL={newSl}");
-            _bot.Print($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slNew={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=updated");
-            _bot.Print($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(isLong ? _bot.Symbol.Bid : _bot.Symbol.Ask)} sl={newSl} tp={pos.TakeProfit}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TRAIL] modified pos={pos.Id} oldSL={oldSl} newSL={newSl}", ctx, pos));
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slNew={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=updated", ctx, pos));
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(isLong ? _bot.Symbol.Bid : _bot.Symbol.Ask)} sl={newSl} tp={pos.TakeProfit}", ctx, pos));
         }
 
         private bool TryBuildStructureStop(bool isLong, StructureSnapshot structure, TrailingProfile profile, double atr, double slAtrMultiplier, out double newSl, out string reason, out int anchorBarsAgo)
@@ -278,7 +279,7 @@ namespace GeminiV26.Core.TradeManagement
                 ctx.TrailNoStructureLogged = true;
             }
 
-            _bot.Print(message);
+            _bot.Print(TradeLogIdentity.WithPositionIds(message, ctx));
         }
 
 

--- a/Core/TradeManagement/TrendTradeManager.cs
+++ b/Core/TradeManagement/TrendTradeManager.cs
@@ -3,6 +3,7 @@ using cAlgo.API;
 using cAlgo.API.Indicators;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 
 namespace GeminiV26.Core.TradeManagement
 {
@@ -74,8 +75,8 @@ namespace GeminiV26.Core.TradeManagement
             if (isRunner && !ctx.RunnerActivated)
             {
                 ctx.RunnerActivated = true;
-                _bot.Print($"[TTM] Runner mode activated.");
-                _bot.Print($"[TTM][RUNNER] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} pos={position.Id} sl={FormatPrice(position.StopLoss)} tp={FormatPrice(position.TakeProfit)} reason=tp1_hit");
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[TTM] Runner mode activated.", ctx, position));
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[TTM][RUNNER] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} pos={position.Id} sl={FormatPrice(position.StopLoss)} tp={FormatPrice(position.TakeProfit)} reason=tp1_hit", ctx, position));
             }
 
             double priceNow = isLong ? _bot.Symbol.Bid : _bot.Symbol.Ask;
@@ -145,7 +146,7 @@ namespace GeminiV26.Core.TradeManagement
 
             if (profileStateChanged || profileBucketChanged)
             {
-                _bot.Print($"[TTM][PROFILE] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} state={state} score={score} slMult={slAtrMultiplier:0.00} tpMult={tpAtrMultiplier:0.00} reason=confidence_profile");
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[TTM][PROFILE] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} state={state} score={score} slMult={slAtrMultiplier:0.00} tpMult={tpAtrMultiplier:0.00} reason=confidence_profile", ctx, position));
                 ctx.LastProfileState = state.ToString();
                 ctx.LastProfileBucket = confidenceBucket;
             }
@@ -164,7 +165,7 @@ namespace GeminiV26.Core.TradeManagement
 
             if (stateChanged || valueChanged)
             {
-                _bot.Print($"[TTM] state={state} score={score} mode={mode} allowTp2Ext={allowTp2Extension} mult={tpAtrMultiplier:0.00}");
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[TTM] state={state} score={score} mode={mode} allowTp2Ext={allowTp2Extension} mult={tpAtrMultiplier:0.00}", ctx, position));
                 ctx.LastTtmAllowTp2Extension = allowTp2Extension;
                 ctx.LastTtmTp2Multiplier = tpAtrMultiplier;
             }
@@ -262,7 +263,7 @@ namespace GeminiV26.Core.TradeManagement
 
             ctx.LastTp2State = state;
             ctx.LastTp2Value = value;
-            _bot.Print(message);
+            _bot.Print(TradeLogIdentity.WithPositionIds(message, ctx));
         }
 
         private string GetConfidenceBucket(int score)

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -19,6 +19,7 @@
 // =========================================================
 using cAlgo.API;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -54,7 +55,7 @@ namespace GeminiV26.Core
             int validCount = signals.Count(e => e != null && e.IsValid);
 
             _bot.Print($"[TR] evals={signals.Count} nonNull={nonNullCount} valid={validCount} threshold={EntryDecisionPolicy.MinScoreThreshold}");
-            LogCandidates("CAND", signals);
+            LogCandidates("CAND", signals, entryContext);
 
             EntryEvaluation winner = null;
 
@@ -84,7 +85,7 @@ namespace GeminiV26.Core
                     }
                 }
 
-                _bot.Print($"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} score={candidate.Score} threshold={EntryDecisionPolicy.MinScoreThreshold} valid={candidate.IsValid.ToString().ToLowerInvariant()} state={candidate.State} trigger={candidate.TriggerConfirmed.ToString().ToLowerInvariant()} → {decision}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} score={candidate.Score} threshold={EntryDecisionPolicy.MinScoreThreshold} valid={candidate.IsValid.ToString().ToLowerInvariant()} state={candidate.State} trigger={candidate.TriggerConfirmed.ToString().ToLowerInvariant()} → {decision}", entryContext));
             }
 
             if (winner == null)
@@ -93,7 +94,7 @@ namespace GeminiV26.Core
                 return null;
             }
 
-            _bot.Print($"[TR] WINNER: {winner.Type} dir={winner.Direction} score={winner.Score} valid={winner.IsValid} reason={winner.Reason}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[TR] WINNER: {winner.Type} dir={winner.Direction} score={winner.Score} valid={winner.IsValid} reason={winner.Reason}", entryContext));
             return winner;
         }
 
@@ -122,45 +123,45 @@ namespace GeminiV26.Core
             {
                 if (eval.HtfConfidence01 >= 0.80 && entryContext?.LogicBiasConfidence < 60)
                 {
-                    _bot.Print(
+                    _bot.Print(TradeLogIdentity.WithTempId(
                         $"[HTF][BLOCK] strong opposite HTF + weak LTF type={eval.Type} dir={eval.Direction} " +
-                        $"score={eval.Score} htfConf={eval.HtfConfidence01:F2} logicConf={entryContext?.LogicBiasConfidence ?? 0}");
-                    return RejectFxCandidate(eval, decisionScore, "HTF_STRONG_OPPOSITE_LTF_WEAK");
+                        $"score={eval.Score} htfConf={eval.HtfConfidence01:F2} logicConf={entryContext?.LogicBiasConfidence ?? 0}", entryContext));
+                    return RejectFxCandidate(eval, decisionScore, "HTF_STRONG_OPPOSITE_LTF_WEAK", entryContext);
                 }
 
                 int originalScore = eval.Score;
                 eval.Score = Math.Max(0, eval.Score - HtfMismatchPenalty);
-                _bot.Print(
+                _bot.Print(TradeLogIdentity.WithTempId(
                     $"[HTF][PENALTY] mismatch applied type={eval.Type} dir={eval.Direction} " +
-                    $"score={originalScore}->{eval.Score} htfConf={eval.HtfConfidence01:F2} logicConf={entryContext?.LogicBiasConfidence ?? 0}");
+                    $"score={originalScore}->{eval.Score} htfConf={eval.HtfConfidence01:F2} logicConf={entryContext?.LogicBiasConfidence ?? 0}", entryContext));
             }
 
             if (decisionScore < EntryDecisionPolicy.MinScoreThreshold)
-                return RejectFxCandidate(eval, decisionScore, "FX_SCORE_BELOW_THRESHOLD");
+                return RejectFxCandidate(eval, decisionScore, "FX_SCORE_BELOW_THRESHOLD", entryContext);
 
             if (!eval.HasTrigger)
             {
                 if (eval.State == EntryState.SETUP_DETECTED)
-                    return RejectFxCandidate(eval, decisionScore, "FX_EARLY_BLOCK");
+                    return RejectFxCandidate(eval, decisionScore, "FX_EARLY_BLOCK", entryContext);
 
-                return RejectFxCandidate(eval, decisionScore, "FX_TRIGGER_REQUIRED");
+                return RejectFxCandidate(eval, decisionScore, "FX_TRIGGER_REQUIRED", entryContext);
             }
 
             if (decisionScore < 45)
-                return RejectFxCandidate(eval, decisionScore, "FX_MIN_QUALITY_BLOCK");
+                return RejectFxCandidate(eval, decisionScore, "FX_MIN_QUALITY_BLOCK", entryContext);
 
             return true;
         }
 
-        private bool RejectFxCandidate(EntryEvaluation eval, int decisionScore, string reasonToken)
+        private bool RejectFxCandidate(EntryEvaluation eval, int decisionScore, string reasonToken, EntryContext entryContext)
         {
             eval.IsValid = false;
             eval.Reason = string.IsNullOrWhiteSpace(eval.Reason)
                 ? $"[{reasonToken}]"
                 : $"{eval.Reason} [{reasonToken}]";
 
-            _bot.Print(
-                $"[FX FILTER] type={eval.Type} dir={eval.Direction} score={eval.Score} decisionScore={decisionScore} reason={reasonToken}");
+            _bot.Print(TradeLogIdentity.WithTempId(
+                $"[FX FILTER] type={eval.Type} dir={eval.Direction} score={eval.Score} decisionScore={decisionScore} reason={reasonToken}", entryContext));
 
             return false;
         }
@@ -168,14 +169,14 @@ namespace GeminiV26.Core
         // =========================================================
         // LOGGING
         // =========================================================
-        private void LogCandidates(string scope, IEnumerable<EntryEvaluation> list)
+        private void LogCandidates(string scope, IEnumerable<EntryEvaluation> list, EntryContext entryContext)
         {
             if (list == null) return;
 
             foreach (var e in list)
             {
                 if (e == null) continue;
-                _bot.Print($"[TR] {scope} {e.Type} dir={e.Direction} valid={e.IsValid} state={e.State} trigger={e.TriggerConfirmed} score={e.Score} reason={e.Reason}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[TR] {scope} {e.Type} dir={e.Direction} valid={e.IsValid} state={e.State} trigger={e.TriggerConfirmed} score={e.Score} reason={e.Reason}", entryContext));
             }
         }
 

--- a/Core/TradeViabilityMonitor.cs
+++ b/Core/TradeViabilityMonitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using cAlgo.API;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 
 namespace GeminiV26.Core
 {
@@ -40,9 +41,8 @@ namespace GeminiV26.Core
 
             if (barsSinceEntry <= 12)
             {
-                _bot.Print(
-                    $"[TVM DBG] barsSinceEntry={barsSinceEntry} currentBarIndex={currentBarIndex} entryBarIndex={entryBarIndex}"
-                );
+                _bot.Print(TradeLogIdentity.WithPositionIds(
+                    $"[TVM DBG] barsSinceEntry={barsSinceEntry} currentBarIndex={currentBarIndex} entryBarIndex={entryBarIndex}", ctx));
             }
 
             if (barsSinceEntry <= 0)
@@ -155,10 +155,9 @@ namespace GeminiV26.Core
             bool atrShrinking,
             bool marketTrend)
         {
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[TVM PHASE] EARLY bars={barsSinceEntry} mfeR={ctx.MfeR:0.00} maeR={ctx.MaeR:0.00} " +
-                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}"
-            );
+                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}", ctx));
 
             if (!ctx.MarketTrend)
             {
@@ -184,13 +183,11 @@ namespace GeminiV26.Core
             bool momentumWeak = ctx.Adx_M5 < 20.0 || atrShrinking;
             bool fastAdverse = ctx.MaeR > 0.25 && barsSinceEntry <= 2;
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[TVM EARLY] noProgress={noProgress} adverseExpansion={adverseExpansion} " +
-                $"momentumWeak={momentumWeak} atrShrinking={atrShrinking}"
-            );
-            _bot.Print(
-                $"[TVM EARLY] fastAdverse={fastAdverse} maeR={ctx.MaeR:0.00} bars={barsSinceEntry}"
-            );
+                $"momentumWeak={momentumWeak} atrShrinking={atrShrinking}", ctx));
+            _bot.Print(TradeLogIdentity.WithPositionIds(
+                $"[TVM EARLY] fastAdverse={fastAdverse} maeR={ctx.MaeR:0.00} bars={barsSinceEntry}", ctx));
 
             int dangerCount = 0;
             if (noProgress)
@@ -202,17 +199,16 @@ namespace GeminiV26.Core
             if (fastAdverse)
                 dangerCount++;
 
-            _bot.Print($"[TVM DECISION] phase=EARLY dangerCount={dangerCount} threshold=2");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TVM DECISION] phase=EARLY dangerCount={dangerCount} threshold=2", ctx));
 
             if (dangerCount >= 2)
             {
                 ctx.IsDeadTrade = true;
                 ctx.DeadTradeReason = "EARLY_FAILURE";
 
-                _bot.Print(
+                _bot.Print(TradeLogIdentity.WithPositionIds(
                     $"[TVM EXIT] reason=EARLY_FAILURE mfeR={ctx.MfeR:0.00} " +
-                    $"maeR={ctx.MaeR:0.00} bars={barsSinceEntry}"
-                );
+                    $"maeR={ctx.MaeR:0.00} bars={barsSinceEntry}", ctx));
 
                 return true;
             }
@@ -227,10 +223,9 @@ namespace GeminiV26.Core
             Bars m5,
             TradeType tradeType)
         {
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[TVM PHASE] DEVELOPMENT bars={barsSinceEntry} mfeR={ctx.MfeR:0.00} maeR={ctx.MaeR:0.00} " +
-                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}"
-            );
+                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}", ctx));
 
             if (!ctx.MarketTrend)
             {
@@ -262,27 +257,24 @@ namespace GeminiV26.Core
             bool structureBreak = ctx.MaeR > 0.60 || IsStructureWeakening(tradeType, m5);
             bool noContinuation = barsSinceEntry >= 4 && ctx.MfeR < 0.20;
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[TVM DEVELOPMENT] momentumDecay={momentumDecay} noContinuation={noContinuation} " +
-                $"structureBreak={structureBreak}"
-            );
+                $"structureBreak={structureBreak}", ctx));
 
             bool shouldExit = structureBreak || (momentumDecay && noContinuation);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[TVM DECISION] phase=DEVELOPMENT structureBreak={structureBreak} " +
-                $"combo={(momentumDecay && noContinuation)}"
-            );
+                $"combo={(momentumDecay && noContinuation)}", ctx));
 
             if (shouldExit)
             {
                 ctx.IsDeadTrade = true;
                 ctx.DeadTradeReason = "DEVELOPMENT_FAILURE";
 
-                _bot.Print(
+                _bot.Print(TradeLogIdentity.WithPositionIds(
                     $"[TVM EXIT] reason=DEVELOPMENT_FAILURE mfeR={ctx.MfeR:0.00} " +
-                    $"maeR={ctx.MaeR:0.00} bars={barsSinceEntry}"
-                );
+                    $"maeR={ctx.MaeR:0.00} bars={barsSinceEntry}", ctx));
 
                 return true;
             }
@@ -295,10 +287,9 @@ namespace GeminiV26.Core
             int barsSinceEntry,
             bool marketTrend)
         {
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[TVM PHASE] MATURE bars={barsSinceEntry} mfeR={ctx.MfeR:0.00} maeR={ctx.MaeR:0.00} " +
-                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}"
-            );
+                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}", ctx));
 
             if (!ctx.MarketTrend)
             {
@@ -310,25 +301,22 @@ namespace GeminiV26.Core
             bool maximumAdverseExcursion = ctx.MaeR > 0.80;
             bool weakDevelopment = barsSinceEntry > 12 && ctx.MfeR < 0.30;
 
-            _bot.Print(
-                $"[TVM MATURE] maxAdverse={maximumAdverseExcursion} weakDevelopment={weakDevelopment}"
-            );
+            _bot.Print(TradeLogIdentity.WithPositionIds(
+                $"[TVM MATURE] maxAdverse={maximumAdverseExcursion} weakDevelopment={weakDevelopment}", ctx));
 
             bool shouldExit = maximumAdverseExcursion || weakDevelopment;
 
-            _bot.Print(
-                $"[TVM DECISION] phase=MATURE maxAdverse={maximumAdverseExcursion} weakDevelopment={weakDevelopment}"
-            );
+            _bot.Print(TradeLogIdentity.WithPositionIds(
+                $"[TVM DECISION] phase=MATURE maxAdverse={maximumAdverseExcursion} weakDevelopment={weakDevelopment}", ctx));
 
             if (shouldExit)
             {
                 ctx.IsDeadTrade = true;
                 ctx.DeadTradeReason = "MATURE_FAILURE";
 
-                _bot.Print(
+                _bot.Print(TradeLogIdentity.WithPositionIds(
                     $"[TVM EXIT] reason=MATURE_FAILURE mfeR={ctx.MfeR:0.00} " +
-                    $"maeR={ctx.MaeR:0.00} bars={barsSinceEntry}"
-                );
+                    $"maeR={ctx.MaeR:0.00} bars={barsSinceEntry}", ctx));
 
                 return true;
             }

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.AUDNZD
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
                     if (reached)
                     {
-                        _bot.Print($"[AUDNZD][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[AUDNZD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[AUDNZD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[AUDNZD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -59,11 +60,11 @@ namespace GeminiV26.Instruments.AUDNZD
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             var ms = _marketStateDetector.Evaluate();
@@ -178,7 +179,8 @@ namespace GeminiV26.Instruments.AUDNZD
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
             {
@@ -186,10 +188,13 @@ namespace GeminiV26.Instruments.AUDNZD
                 return;
             }
 
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
+
             var ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -231,13 +236,12 @@ namespace GeminiV26.Instruments.AUDNZD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[AUDNZD EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
-                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}"
-            );
+                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.AUDUSD
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
                     if (reached)
                     {
-                        _bot.Print($"[AUDUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[AUDUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[AUDUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[AUDUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -59,11 +60,11 @@ namespace GeminiV26.Instruments.AUDUSD
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             var ms = _marketStateDetector.Evaluate();
@@ -172,7 +173,8 @@ namespace GeminiV26.Instruments.AUDUSD
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
             {
@@ -180,10 +182,13 @@ namespace GeminiV26.Instruments.AUDUSD
                 return;
             }
 
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
+
             var ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -228,13 +233,12 @@ namespace GeminiV26.Instruments.AUDUSD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[AUDUSD EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
-                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}"
-            );
+                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -4,6 +4,7 @@ using cAlgo.API;
 using cAlgo.API.Indicators;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.BTCUSD
@@ -179,25 +180,22 @@ namespace GeminiV26.Instruments.BTCUSD
                                 ? m1Bar.High >= tp1Price
                                 : m1Bar.Low <= tp1Price;
 
-                            _bot.Print(
+                            _bot.Print(TradeLogIdentity.WithPositionIds(
                                 $"[BTCUSD][TP1][CHECK] pos={pos.Id} " +
                                 $"tp1={tp1Price} m1High={m1Bar.High} m1Low={m1Bar.Low} " +
-                                $"bid={sym.Bid} ask={sym.Ask} reached={reached}"
-                            );
+                                $"bid={sym.Bid} ask={sym.Ask} reached={reached}", ctx, pos));
                         }
 
-                        _bot.Print(
+                        _bot.Print(TradeLogIdentity.WithPositionIds(
                             $"[BTCUSD][TP1][CHECK:FALLBACK] pos={pos.Id} " +
-                            $"tp1={tp1Price} bid={sym.Bid} ask={sym.Ask} reached={reached}"
-                        );
+                            $"tp1={tp1Price} bid={sym.Bid} ask={sym.Ask} reached={reached}", ctx, pos));
                     }
 
                     if (reached)
                     {
-                        _bot.Print(
+                        _bot.Print(TradeLogIdentity.WithPositionIds(
                             $"[BTCUSD][TP1][HIT] symbol={pos.SymbolName} pos={pos.Id} " +
-                            $"dir={pos.TradeType} tp1={tp1Price} rDist={rDist} tp1R={ctx.Tp1R}"
-                        );
+                            $"dir={pos.TradeType} tp1={tp1Price} rDist={rDist} tp1R={ctx.Tp1R}", ctx, pos));
 
                         ExecuteTp1(pos, ctx, rDist);
 
@@ -220,12 +218,11 @@ namespace GeminiV26.Instruments.BTCUSD
 
                             if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                             {
-                                _bot.Print(
+                                _bot.Print(TradeLogIdentity.WithPositionIds(
                                     $"[TVM EXIT] {pos.SymbolName} pos={pos.Id} " +
                                     $"reason={ctx.DeadTradeReason} " +
                                     $"MFE_R={ctx.MfeR:0.00} MAE_R={ctx.MaeR:0.00} " +
-                                    $"barsM5={ctx.BarsSinceEntryM5}"
-                                );
+                                    $"barsM5={ctx.BarsSinceEntryM5}", ctx, pos));
 
                                 _bot.ClosePosition(pos);
                                 _contexts.Remove(key);
@@ -285,10 +282,9 @@ namespace GeminiV26.Instruments.BTCUSD
 
             if (closeUnits < minUnits)
             {
-                _bot.Print(
+                _bot.Print(TradeLogIdentity.WithPositionIds(
                     $"[BTCUSD][TP1][SKIP] partial close below min " +
-                    $"pos={pos.Id} requested={closeUnits} min={minUnits}"
-                );
+                    $"pos={pos.Id} requested={closeUnits} min={minUnits}", ctx, pos));
                 return;
             }
 
@@ -302,25 +298,23 @@ namespace GeminiV26.Instruments.BTCUSD
 
             if (closeUnits < minUnits)
             {
-                _bot.Print(
+                _bot.Print(TradeLogIdentity.WithPositionIds(
                     $"[BTCUSD][TP1][SKIP] adjusted partial close below min " +
-                    $"pos={pos.Id} adjusted={closeUnits} min={minUnits}"
-                );
+                    $"pos={pos.Id} adjusted={closeUnits} min={minUnits}", ctx, pos));
                 return;
             }
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
             {
-                _bot.Print($"[BTCUSD][TP1][FAIL] partial close failed pos={pos.Id}");
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[BTCUSD][TP1][FAIL] partial close failed pos={pos.Id}", ctx, pos));
                 return;
             }
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} " +
                 $"direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} " +
-                $"closedUnits={closeUnits}"
-            );
+                $"closedUnits={closeUnits}", ctx, pos));
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
@@ -464,11 +458,10 @@ namespace GeminiV26.Instruments.BTCUSD
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
 
             var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} " +
                 $"direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym?.Bid : sym?.Ask)} " +
-                $"oldTp={currentTp} newTp={newTp}"
-            );
+                $"oldTp={currentTp} newTp={newTp}", ctx, pos));
 
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.Risk.PositionSizing;
 using GeminiV26.Instruments.CRYPTO;
 using GeminiV26.Instruments.BTCUSD;
@@ -61,11 +62,11 @@ namespace GeminiV26.Instruments.BTCUSD
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             _bot.Print("[BTCUSD][EXEC] ExecuteEntry");
@@ -161,7 +162,8 @@ namespace GeminiV26.Instruments.BTCUSD
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
             {
@@ -172,6 +174,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
 
             long posId = result.Position.Id;
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={posId} symbol={result.Position.SymbolName}");
 
             // =========================================================
             // POSITION CONTEXT (SSOT)
@@ -180,6 +183,7 @@ namespace GeminiV26.Instruments.BTCUSD
             {
                 PositionId = posId,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
 
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -221,13 +225,12 @@ namespace GeminiV26.Instruments.BTCUSD
                                              TrailingMode.Tight;
 
             _positionContexts[posId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[BTCUSD][EXEC] OPEN {tradeType} " +
-                $"vol={ctx.EntryVolumeInUnits} FC={ctx.FinalConfidence}"
-            );
+                $"vol={ctx.EntryVolumeInUnits} FC={ctx.FinalConfidence}", ctx));
         }
 
         // =========================================================

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -4,6 +4,7 @@ using cAlgo.API;
 using cAlgo.API.Indicators;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.ETHUSD
@@ -169,7 +170,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
                     if (reached)
                     {
-                        _bot.Print($"[ETHUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[ETHUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
 
                         ExecuteTp1(pos, ctx, rDist);
 

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.Risk.PositionSizing;
 using GeminiV26.Instruments.CRYPTO;
 using GeminiV26.Instruments.ETHUSD;
@@ -61,11 +62,11 @@ namespace GeminiV26.Instruments.ETHUSD
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             _bot.Print("[ETHUSD][EXEC] ExecuteEntry");
@@ -161,7 +162,8 @@ namespace GeminiV26.Instruments.ETHUSD
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
             {
@@ -172,6 +174,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
 
             long posId = result.Position.Id;
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={posId} symbol={result.Position.SymbolName}");
 
             // =========================================================
             // POSITION CONTEXT (SSOT)
@@ -180,6 +183,7 @@ namespace GeminiV26.Instruments.ETHUSD
             {
                 PositionId = posId,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
 
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -220,13 +224,12 @@ namespace GeminiV26.Instruments.ETHUSD
                                              TrailingMode.Tight;
 
             _positionContexts[posId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[ETHUSD][EXEC] OPEN {tradeType} " +
-                $"vol={ctx.EntryVolumeInUnits} FC={ctx.FinalConfidence}"
-            );
+                $"vol={ctx.EntryVolumeInUnits} FC={ctx.FinalConfidence}", ctx));
         }
 
         // =========================================================

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.EURJPY
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.EURJPY
 
                     if (reached)
                     {
-                        _bot.Print($"[EURJPY][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EURJPY][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.EURJPY
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[EURJPY][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[EURJPY][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -59,11 +60,11 @@ namespace GeminiV26.Instruments.EURJPY
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             var ms = _marketStateDetector.Evaluate();
@@ -172,7 +173,8 @@ namespace GeminiV26.Instruments.EURJPY
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
             {
@@ -180,10 +182,13 @@ namespace GeminiV26.Instruments.EURJPY
                 return;
             }
 
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
+
             var ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -228,13 +233,12 @@ namespace GeminiV26.Instruments.EURJPY
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[EURJPY EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
-                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}"
-            );
+                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.EURUSD
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.EURUSD
 
                     if (reached)
                     {
-                        _bot.Print($"[EURUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EURUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.EURUSD
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[EURUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[EURUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -59,11 +60,11 @@ namespace GeminiV26.Instruments.EURUSD
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             var ms = _marketStateDetector?.Evaluate();
@@ -163,7 +164,8 @@ namespace GeminiV26.Instruments.EURUSD
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
                     
             if (!result.IsSuccessful || result.Position == null)
             {
@@ -171,10 +173,13 @@ namespace GeminiV26.Instruments.EURUSD
                 return;
             }
 
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
+
             var ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -220,13 +225,12 @@ namespace GeminiV26.Instruments.EURUSD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[EUR EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
-                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}"
-            );            
+                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.GBPJPY
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
                     if (reached)
                     {
-                        _bot.Print($"[GBPJPY][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[GBPJPY][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[GBPJPY][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[GBPJPY][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -59,11 +60,11 @@ namespace GeminiV26.Instruments.GBPJPY
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             var ms = _marketStateDetector.Evaluate();
@@ -172,7 +173,8 @@ namespace GeminiV26.Instruments.GBPJPY
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
             {
@@ -180,10 +182,13 @@ namespace GeminiV26.Instruments.GBPJPY
                 return;
             }
 
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
+
             var ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -228,13 +233,12 @@ namespace GeminiV26.Instruments.GBPJPY
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[GBPJPY EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
-                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}"
-            );
+                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.GBPUSD
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
                     if (reached)
                     {
-                        _bot.Print($"[GBPUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[GBPUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[GBPUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[GBPUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using cAlgo.API.Indicators;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -62,11 +63,11 @@ namespace GeminiV26.Instruments.GBPUSD
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             // =====================================================
@@ -188,17 +189,21 @@ namespace GeminiV26.Instruments.GBPUSD
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
                 return;
 
             long positionKey = result.Position.Id;
 
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
+
             var ctx = new PositionContext
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -226,7 +231,7 @@ namespace GeminiV26.Instruments.GBPUSD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[positionKey] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
         }
 

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.GER40
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.GER40
 
                     if (reached)
                     {
-                        _bot.Print($"[GER40][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[GER40][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.GER40
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[GER40][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[GER40][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.INDEX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -52,11 +53,11 @@ namespace GeminiV26.Instruments.GER40
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             // =========================
@@ -156,12 +157,14 @@ namespace GeminiV26.Instruments.GER40
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
                 return;
 
             long positionKey = Convert.ToInt64(result.Position.Id);
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={positionKey} symbol={result.Position.SymbolName}");
 
             // =========================
             // CONTEXT – TELJES, R-ALAPÚ
@@ -170,6 +173,7 @@ namespace GeminiV26.Instruments.GER40
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -206,7 +210,7 @@ namespace GeminiV26.Instruments.GER40
             ctx.ComputeFinalConfidence();
 
             _positionContexts[positionKey] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
         }
 

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.NAS100
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.NAS100
 
                     if (reached)
                     {
-                        _bot.Print($"[NAS100][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[NAS100][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.NAS100
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[NAS100][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[NAS100][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.INDEX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -52,11 +53,11 @@ namespace GeminiV26.Instruments.NAS100
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             if (_marketStateDetector != null)
@@ -166,12 +167,14 @@ namespace GeminiV26.Instruments.NAS100
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
                 return;
 
             long positionKey = Convert.ToInt64(result.Position.Id);
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={positionKey} symbol={result.Position.SymbolName}");
 
             // =========================
             // CONTEXT – TELJES, R-ALAPÚ
@@ -180,6 +183,7 @@ namespace GeminiV26.Instruments.NAS100
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -215,7 +219,7 @@ namespace GeminiV26.Instruments.NAS100
             ctx.ComputeFinalConfidence();
 
             _positionContexts[positionKey] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
         }
 

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.NZDUSD
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
                     if (reached)
                     {
-                        _bot.Print($"[NZDUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[NZDUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[NZDUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[NZDUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -59,11 +60,11 @@ namespace GeminiV26.Instruments.NZDUSD
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             var ms = _marketStateDetector.Evaluate();
@@ -172,7 +173,8 @@ namespace GeminiV26.Instruments.NZDUSD
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
             {
@@ -180,10 +182,13 @@ namespace GeminiV26.Instruments.NZDUSD
                 return;
             }
 
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
+
             var ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -228,13 +233,12 @@ namespace GeminiV26.Instruments.NZDUSD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[NZDUSD EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
-                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}"
-            );
+                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.US30
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.US30
 
                     if (reached)
                     {
-                        _bot.Print($"[US30][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[US30][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.US30
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[US30][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[US30][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.INDEX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -52,11 +53,11 @@ namespace GeminiV26.Instruments.US30
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             if (_marketStateDetector != null)
@@ -144,17 +145,20 @@ namespace GeminiV26.Instruments.US30
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
                 return;
 
             long positionKey = Convert.ToInt64(result.Position.Id);
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={positionKey} symbol={result.Position.SymbolName}");
 
             var ctx = new PositionContext
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -195,7 +199,7 @@ namespace GeminiV26.Instruments.US30
             ctx.ComputeFinalConfidence();
 
             _positionContexts[positionKey] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
         }
 

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.USDCAD
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.USDCAD
 
                     if (reached)
                     {
-                        _bot.Print($"[USDCAD][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[USDCAD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.USDCAD
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[USDCAD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[USDCAD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -59,11 +60,11 @@ namespace GeminiV26.Instruments.USDCAD
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             var ms = _marketStateDetector.Evaluate();
@@ -172,7 +173,8 @@ namespace GeminiV26.Instruments.USDCAD
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
             {
@@ -180,10 +182,13 @@ namespace GeminiV26.Instruments.USDCAD
                 return;
             }
 
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
+
             var ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -228,13 +233,12 @@ namespace GeminiV26.Instruments.USDCAD
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[USDCAD EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
-                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}"
-            );
+                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.USDCHF
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.USDCHF
 
                     if (reached)
                     {
-                        _bot.Print($"[USDCHF][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[USDCHF][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.USDCHF
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[USDCHF][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[USDCHF][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -59,11 +60,11 @@ namespace GeminiV26.Instruments.USDCHF
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             var ms = _marketStateDetector.Evaluate();
@@ -172,7 +173,8 @@ namespace GeminiV26.Instruments.USDCHF
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
             {
@@ -180,10 +182,13 @@ namespace GeminiV26.Instruments.USDCHF
                 return;
             }
 
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
+
             var ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -228,13 +233,12 @@ namespace GeminiV26.Instruments.USDCHF
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[USDCHF EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
-                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}"
-            );
+                $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 
 namespace GeminiV26.Instruments.USDJPY
@@ -143,7 +144,7 @@ namespace GeminiV26.Instruments.USDJPY
 
                     if (reached)
                     {
-                        _bot.Print($"[USDJPY][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[USDJPY][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace GeminiV26.Instruments.USDJPY
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[USDJPY][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[USDJPY][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
 
@@ -56,11 +57,11 @@ namespace GeminiV26.Instruments.USDJPY
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             // =====================================================
@@ -162,15 +163,19 @@ namespace GeminiV26.Instruments.USDJPY
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips);
+                tp2Pips,
+                entryContext.TempId);
 
             if (!result.IsSuccessful || result.Position == null)
                 return;
+
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
 
             var ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -218,7 +223,7 @@ namespace GeminiV26.Instruments.USDJPY
             ctx.ComputeFinalConfidence();
 
             _positionContexts[ctx.PositionId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
         }
 

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -20,6 +20,7 @@
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
 using GeminiV26.Data;
 using GeminiV26.Data.Models;
@@ -198,7 +199,7 @@ namespace GeminiV26.Instruments.XAUUSD
  
                     if (hit)
                     {                        
-                        _bot.Print($"[XAUUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}");
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[XAUUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -212,7 +213,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
-                            _bot.Print($"[XAUUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}");
+                            _bot.Print(TradeLogIdentity.WithPositionIds($"[XAUUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
 
                             _bot.ClosePosition(pos);
 
@@ -268,22 +269,22 @@ namespace GeminiV26.Instruments.XAUUSD
             long flooredUnits = (long)Math.Floor(rawUnitsD);
             long closeVolume = (long)sym.NormalizeVolumeInUnits(flooredUnits, RoundingMode.Down);
 
-            _bot.Print($"[EXIT] PARTIAL CLOSE check symbol={pos.SymbolName} positionId={pos.Id} volumeInUnits={pos.VolumeInUnits} frac={frac} rawUnits={rawUnitsD} flooredUnits={flooredUnits} closeVolume={closeVolume} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE check symbol={pos.SymbolName} positionId={pos.Id} volumeInUnits={pos.VolumeInUnits} frac={frac} rawUnits={rawUnitsD} flooredUnits={flooredUnits} closeVolume={closeVolume} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}", ctx, pos));
             
             if (closeVolume < sym.VolumeInUnitsMin)
             {
-                _bot.Print($"[EXIT] PARTIAL CLOSE skipped symbol={pos.SymbolName} positionId={pos.Id} reason=closeVolumeBelowMin rawUnits={rawUnitsD} flooredUnits={flooredUnits} closeVolume={closeVolume} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}");
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE skipped symbol={pos.SymbolName} positionId={pos.Id} reason=closeVolumeBelowMin rawUnits={rawUnitsD} flooredUnits={flooredUnits} closeVolume={closeVolume} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}", ctx, pos));
                 return;
             }
 
             var closeResult = _bot.ClosePosition(pos, closeVolume);
             if (!closeResult.IsSuccessful)
             {
-                _bot.Print($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} tp1={ctx.Tp1Price} rawUnits={rawUnitsD} flooredUnits={flooredUnits} closeVolume={closeVolume} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}");
+                _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} tp1={ctx.Tp1Price} rawUnits={rawUnitsD} flooredUnits={flooredUnits} closeVolume={closeVolume} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}", ctx, pos));
                 return;
             }
 
-            _bot.Print($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} closedUnits={closeVolume}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} closedUnits={closeVolume}", ctx, pos));
 
             // TP1 state (SSOT) – csak itt állítjuk
             ctx.Tp1Hit = true;
@@ -326,7 +327,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
             ctx.BePrice = bePrice;
             double newSl = bePrice;
-            _bot.Print($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} be={bePrice}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} be={bePrice}", ctx, pos));
 
             _bot.ModifyPosition(
                 pos,
@@ -472,6 +473,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 {
                     PositionId = pos.Id,
                     Symbol = pos.SymbolName,
+                    TempId = pos.Comment ?? string.Empty,
                     EntryPrice = pos.EntryPrice,
 
                     EntryVolumeInUnits = pos.VolumeInUnits,
@@ -524,7 +526,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 return;
 
             _bot.ModifyPosition(pos, pos.StopLoss, newTp);
-            _bot.Print($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} oldTp={currentTp} newTp={newTp}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} oldTp={currentTp} newTp={newTp}", ctx, pos));
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 using GeminiV26.Core.Risk.PositionSizing;
 using GeminiV26.Instruments.METAL;
 
@@ -79,11 +80,11 @@ namespace GeminiV26.Instruments.XAUUSD
             DirectionGuard.Validate(entryContext, null, _bot.Print);
 
 
-            _bot.Print($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_FINAL] symbol={_bot.SymbolName} finalDir={entryContext.FinalDirection}", entryContext));
 
             if (entry.Direction != entryContext.FinalDirection)
             {
-                _bot.Print($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_MISMATCH] entryDir={entry.Direction} finalDir={entryContext.FinalDirection}", entryContext));
                 // DO NOT TRUST entry.Direction
             }
             // =====================================================
@@ -133,6 +134,7 @@ namespace GeminiV26.Instruments.XAUUSD
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
                 FinalDirection = entryContext.FinalDirection,
@@ -267,7 +269,8 @@ namespace GeminiV26.Instruments.XAUUSD
                 volumeUnits,
                 _botLabel,
                 slPips,
-                tp2Pips
+                tp2Pips,
+                entryContext.TempId
             );
 
             if (!result.IsSuccessful || result.Position == null)
@@ -275,6 +278,8 @@ namespace GeminiV26.Instruments.XAUUSD
                 _bot.Print("[XAU EXEC] Order execution failed");
                 return;
             }
+
+            _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
 
             // =====================================================
             // 9 CONTEXT FINALIZÁLÁS (FILL UTÁN)
@@ -308,15 +313,14 @@ namespace GeminiV26.Instruments.XAUUSD
             // 10 REGISTER CONTEXT
             // =====================================================
             _positionContexts[ctx.PositionId] = ctx;
-            _bot.Print($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}");
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 
-            _bot.Print(
+            _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[XAU EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
                 $"FC={ctx.FinalConfidence} fill={ctx.EntryPrice:F2} " +
                 $"SL={slPriceActual:F2} R={rDist:F2} " +
-                $"TP1={ctx.Tp1Price:F2} TP2={ctx.Tp2Price:F2}"
-            );
+                $"TP1={ctx.Tp1Price:F2} TP2={ctx.Tp2Price:F2}", ctx));
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Introduce a unified trade identifier so every entry and execution log can be correlated end-to-end (tempId → posId → lifecycle) while preserving all existing trading behaviour and messages.
- Keep an immutable confidence calculation and do not change any trading logic, thresholds, scoring or flow; only extend logs and store identifiers for traceability.

### Description

- Add a lightweight logging helper `TradeLogIdentity` that can inject `tempId` and `posId` into existing log strings without replacing or removing any original messages.
- Generate `tempId` in `EntryContextBuilder` as `"{symbol}_{_bot.Server.Time:yyyyMMdd_HHmmss_fff}"`, store it on `EntryContext.TempId`, propagate it into `PositionContext.TempId`, and preserve it during rehydrate from `Position.Comment`.
- Auto-append `tempId` for entry-stage logs by wiring `EntryContext.Print` through `TradeLogIdentity.WithTempId`, and wrap router/entry/logic propagation prints to include `tempId` (e.g. `ENTRY START`, `DIR LOGIC`, `ROUTER_CAND`, `ENTRY DECISION`).
- At execution time pass `entryContext.TempId` into the order comment (`ExecuteMarketOrder(..., entryContext.TempId)`), emit an additional `[TRADE LINK] tempId=... posId=... symbol=...` line immediately after a successful fill, and assign `PositionContext.TempId = entryContext.TempId` (no change to execution logic or order sizing).
- Extend post-execution and lifecycle logs (e.g. `[DIR][SET]`, `OPEN`, TP1/partial-close, `TVM EXIT`, `TP2 EXTENDED`, trailing, `REHYDRATE`) to include `posId` and reuse `tempId` where available by wrapping prints with `TradeLogIdentity.WithPositionIds` (all original message bodies are preserved).

### Testing

- Ran `git diff --check` to validate whitespace/trailing issues and fixed the single trailing whitespace; the check passed after fixes.
- Searched the tree with `rg` for injection points (`TempId =|[TRADE LINK]|WithTempId(|WithPositionIds(`) to validate coverage and ensure `tempId`/`posId` were propagated; matches show the helper usage in entry, executor, exit and TVM/TTM components (successful).
- Inspected repository status and commit summary (`git status --short`, `git show --stat`) to confirm changes were staged and committed; commit created successfully.

All changes were limited to logging fields and context plumbing; no trading logic, decision thresholds, scoring, routing, or behavior were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1230688a483288c42cf5fdb128b87)