### PR TITLE
Add MONDAY_0700_0830_BLOCK and allow XAUUSD in Asia (XAU_ASIA_ALLOWED)

### DIFF
--- a/Core/Gates/GlobalSessionGate.cs
+++ b/Core/Gates/GlobalSessionGate.cs
@@ -51,6 +51,15 @@ public class GlobalSessionGate
             Reason = "Default blocked"
         };
 
+        if (utc.DayOfWeek == DayOfWeek.Monday &&
+            utc.TimeOfDay >= new TimeSpan(7, 0, 0) &&
+            utc.TimeOfDay < new TimeSpan(8, 30, 0))
+        {
+            decision.Reason = "MONDAY_0700_0830_BLOCK";
+            LogGate(symbol, tf, GetTimeframeTier(tf), decision);
+            return decision;
+        }
+
         if (IsCrypto(symbol))
         {
             decision.Bucket = SessionBucket.CryptoAlwaysOn;

--- a/Instruments/XAUUSD/XauSessionGate.cs
+++ b/Instruments/XAUUSD/XauSessionGate.cs
@@ -37,8 +37,8 @@ namespace GeminiV26.Instruments.XAUUSD
             {
                 if (h >= 0 && h < 8)
                 {
-                    _bot.Print("[XAU SESSION] BLOCKED: Asian disabled");
-                    return false;
+                    _bot.Print("[XAU SESSION] ALLOWED: XAU_ASIA_ALLOWED");
+                    return true;
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Enforce a global hard stop that blocks trading for all instruments on Mondays from 07:00–08:30 UTC. 
- Remove the instrument-level restriction that prevented XAUUSD from trading in the Asia session so XAUUSD may trade in Asia under normal rules except during the Monday block.

### Description
- Inserted an early hard-block check at the start of `GlobalSessionGate.GetDecision` that returns a blocked `SessionDecision` with `Reason = "MONDAY_0700_0830_BLOCK"` when `utc.DayOfWeek == DayOfWeek.Monday` and `utc.TimeOfDay` is in `[07:00,08:30)`; this executes before crypto or any other session logic.
- Modified `Instruments/XAUUSD/XauSessionGate.cs` so that when `_profile.AllowAsian` is false and the hour is in the Asia window (`h >= 0 && h < 8`) the gate now explicitly allows XAUUSD and logs `"[XAU SESSION] ALLOWED: XAU_ASIA_ALLOWED"` instead of blocking.
- Preserved evaluation order: (1) Monday hard block, (2) existing normal session logic, (3) XAU Asia allow override; left DST, session calendar, London/NY/Overlap, and all non-session modules unchanged.
- Only changed the two session-gate files: `Core/Gates/GlobalSessionGate.cs` and `Instruments/XAUUSD/XauSessionGate.cs`.

### Testing
- Ran an automated Python self-check that asserts the presence and placement of `MONDAY_0700_0830_BLOCK` and `XAU_ASIA_ALLOWED`, verifies boundary time logic for Monday 07:15, 08:29 and 08:30, and confirms XAU Asia override behavior; all assertions passed.
- Performed automated source-level sanity checks confirming the Monday-block check appears before the crypto allow-path and that no DST/session-calendar code was modified; checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12d65aed08328a942eb261dae5863)