### PR TITLE
Guard ExitManagers against stale/rehydrated positions

### DIFF
--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.AUDNZD
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.AUDNZD
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.AUDNZD
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.AUDNZD
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.AUDUSD
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.AUDUSD
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.AUDUSD
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.AUDUSD
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -106,18 +106,13 @@ namespace GeminiV26.Instruments.BTCUSD
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
-                {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
-                }
-
+                var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
+                {
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
                     continue;
+                }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
@@ -304,6 +299,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 return;
             }
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
             {
@@ -311,6 +307,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 return;
             }
 
+            closeExecuted = true;
             _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} " +
                 $"direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} " +
@@ -321,6 +318,12 @@ namespace GeminiV26.Instruments.BTCUSD
 
             // 2) TP1 state
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             // 3) BE / protective SL after TP1
             ApplyBreakEven(pos, ctx, rDist);
@@ -368,7 +371,7 @@ namespace GeminiV26.Instruments.BTCUSD
             if (!improve)
                 return;
 
-            _bot.ModifyPosition(pos, desiredSl, pos.TakeProfit);
+            SafeModify(pos, desiredSl, pos.TakeProfit);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -378,7 +381,7 @@ namespace GeminiV26.Instruments.BTCUSD
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -455,7 +458,7 @@ namespace GeminiV26.Instruments.BTCUSD
             if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
 
             var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
             _bot.Print(TradeLogIdentity.WithPositionIds(
@@ -466,6 +469,35 @@ namespace GeminiV26.Instruments.BTCUSD
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -90,19 +90,13 @@ namespace GeminiV26.Instruments.ETHUSD
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-
-                foreach (var p in _bot.Positions)
-                {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
-                }
-
+                var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
+                {
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
                     continue;
+                }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
@@ -271,17 +265,25 @@ namespace GeminiV26.Instruments.ETHUSD
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
 
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
 
             ctx.RemainingVolumeInUnits =
                 Math.Max(0, pos.VolumeInUnits - closeUnits);
 
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -293,7 +295,7 @@ namespace GeminiV26.Instruments.ETHUSD
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -355,11 +357,40 @@ namespace GeminiV26.Instruments.ETHUSD
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
 
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.EURJPY
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.EURJPY
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.EURJPY
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.EURJPY
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.EURUSD
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.EURUSD
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.EURUSD
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.EURUSD
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.GBPJPY
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.GBPJPY
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.GBPJPY
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.GBPJPY
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.GBPUSD
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.GBPUSD
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.GBPUSD
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.GBPUSD
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.GER40
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.GER40
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.GER40
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.GER40
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.NAS100
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.NAS100
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.NAS100
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.NAS100
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.NZDUSD
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.NZDUSD
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.NZDUSD
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.NZDUSD
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.US30
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.US30
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.US30
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.US30
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.USDCAD
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.USDCAD
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.USDCAD
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.USDCAD
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.USDCHF
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.USDCHF
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.USDCHF
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.USDCHF
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -73,17 +73,15 @@ namespace GeminiV26.Instruments.USDJPY
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                Position pos = null;
-                foreach (var p in _bot.Positions)
+                var pos = FindPosition(ctx.PositionId);
+                if (pos == null)
                 {
-                    if (Convert.ToInt64(p.Id) == key)
-                    {
-                        pos = p;
-                        break;
-                    }
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
+                    continue;
                 }
 
-                if (pos == null || !pos.StopLoss.HasValue)
+                if (!pos.StopLoss.HasValue)
                     continue;
 
                 var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
@@ -212,13 +210,21 @@ namespace GeminiV26.Instruments.USDJPY
             if (closeUnits < minUnits)
                 return;
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
+            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             ApplyBreakEven(pos, ctx, rDist);
         }
@@ -230,7 +236,7 @@ namespace GeminiV26.Instruments.USDJPY
                     ? pos.EntryPrice + rDist * BeOffsetR
                     : pos.EntryPrice - rDist * BeOffsetR;
 
-            _bot.ModifyPosition(pos, bePrice, pos.TakeProfit);
+            SafeModify(pos, bePrice, pos.TakeProfit);
 
             ctx.BePrice = bePrice;
             ctx.BeMode = BeMode.AfterTp1;
@@ -287,10 +293,39 @@ namespace GeminiV26.Instruments.USDJPY
             if (!outward)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
         }
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
+        }
+
         private static bool IsLong(PositionContext ctx)
         {
             return ctx?.FinalDirection == TradeDirection.Long;

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -120,14 +120,23 @@ namespace GeminiV26.Instruments.XAUUSD
         // =====================================================
         public void OnTick()
         {
-            foreach (var ctx in _contexts.Values)
+            var keys = new List<long>(_contexts.Keys);
+
+            foreach (var key in keys)
             {
+                if (!_contexts.TryGetValue(key, out var ctx) || ctx == null)
+                    continue;
+
                 if (ctx.FinalDirection == TradeDirection.None)
                     continue;
 
-                var pos = _bot.Positions.FirstOrDefault(p => p.Id == ctx.PositionId);
+                var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
+                {
+                    _bot.Print($"[EXIT][CLEANUP] Position not found: {ctx.PositionId}");
+                    _contexts.Remove(key);
                     continue;
+                }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
@@ -277,6 +286,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 return;
             }
 
+            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeVolume);
             if (!closeResult.IsSuccessful)
             {
@@ -284,6 +294,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 return;
             }
 
+            closeExecuted = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} closedUnits={closeVolume}", ctx, pos));
 
             // TP1 state (SSOT) – csak itt állítjuk
@@ -293,6 +304,12 @@ namespace GeminiV26.Instruments.XAUUSD
             ctx.Tp1ClosedVolumeInUnits = closeVolume;
             ctx.RemainingVolumeInUnits =
                 Math.Max(0, pos.VolumeInUnits - closeVolume);
+
+            if (closeExecuted && FindPosition(ctx.PositionId) == null)
+            {
+                _bot.Print($"[EXIT][SKIP MODIFY AFTER CLOSE] {ctx.PositionId}");
+                return;
+            }
 
             // BE (profilból)
             ApplyBreakEven(pos, ctx, rDist);
@@ -329,7 +346,7 @@ namespace GeminiV26.Instruments.XAUUSD
             double newSl = bePrice;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] BE MOVE applied symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} be={bePrice}", ctx, pos));
 
-            _bot.ModifyPosition(
+            SafeModify(
                 pos,
                 Normalize(bePrice, sym.TickSize, sym.Digits),
                 pos.TakeProfit
@@ -398,7 +415,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (improvePips < _profile.MinTrailImprovePips)
                 return;
 
-            _bot.ModifyPosition(
+            SafeModify(
                  pos,
                 Normalize(newSl, sym.TickSize, sym.Digits),
                 pos.TakeProfit
@@ -525,10 +542,39 @@ namespace GeminiV26.Instruments.XAUUSD
             if (ctx.LastExtendedTp2.HasValue && Math.Abs(ctx.LastExtendedTp2.Value - newTp) < _bot.Symbol.PipSize)
                 return;
 
-            _bot.ModifyPosition(pos, pos.StopLoss, newTp);
+            SafeModify(pos, pos.StopLoss, newTp);
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} oldTp={currentTp} newTp={newTp}", ctx, pos));
             ctx.LastExtendedTp2 = newTp;
             ctx.Tp2ExtensionMultiplierApplied = desiredR / baseR;
+        }
+
+
+        private Position FindPosition(long positionId)
+        {
+            foreach (var position in _bot.Positions)
+            {
+                if (Convert.ToInt64(position.Id) == positionId)
+                    return position;
+            }
+
+            return null;
+        }
+
+        private void SafeModify(Position position, double? sl, double? tp)
+        {
+            if (position == null)
+                return;
+
+            var livePos = FindPosition(Convert.ToInt64(position.Id));
+            if (livePos == null)
+            {
+                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                return;
+            }
+
+            var result = _bot.ModifyPosition(livePos, sl, tp);
+            if (!result.IsSuccessful)
+                _bot.Print($"[SAFE_MODIFY][FAIL] {position.Id} error={result.Error}");
         }
 
         private static bool IsLong(PositionContext ctx)


### PR DESCRIPTION
### Motivation
- Rehydrate can leave stale PositionContext objects active after a position is closed, which allowed subsequent `ModifyPosition` calls on non-existing positions and produced `EntityNotFound` runtime errors. 
- The fix makes ExitManagers resilient to rehydrate desyncs while preserving existing TP1/partial-close and trailing semantics. 

### Description
- Add a hard existence guard at the start of every ExitManager tick loop that re-resolves the live `Position` via `FindPosition`, logs `[EXIT][CLEANUP]` and removes stale contexts when no live position exists.  
- Prevent any modify after a successful TP1 close by setting a local `closeExecuted` flag and returning early with `[EXIT][SKIP MODIFY AFTER CLOSE]` if the live position no longer exists.  
- Replace direct `_bot.ModifyPosition` calls with `SafeModify`, which re-resolves the live `Position`, logs `[SAFE_MODIFY][SKIP]` when missing and `[SAFE_MODIFY][FAIL]` on modify errors, and otherwise forwards the call safely.  
- Apply the same pattern (existence guard, `FindPosition`, `SafeModify`, and minimal logs) consistently across all 16 instrument ExitManagers including FX, indices, metals and crypto (XAU, BTC, ETH). 

### Testing
- Ran a repository validation script that verified all ExitManager files include the required `FindPosition`, `SafeModify`, and the four minimal log markers and the script validated all 16 ExitManagers (succeeded).  
- Ran `git diff --check` to ensure no whitespace/diff-check issues were introduced (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c14f6e2cf083288106748c16dc3baa)