### PR TITLE
Fix logging-related compile regressions

### DIFF
--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core.Entry;
 
 namespace GeminiV26.Core.Logging

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -87,6 +87,7 @@ namespace GeminiV26.Instruments.BTCUSD
             // 🔑 ENTRY LOGIC – PRE-EXEC CONFIDENCE
             // =========================================================
             _entryLogic.Evaluate(out _, out int logicConfidence);
+            int statePenalty = 0;
 
             int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
             int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence);

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -87,6 +87,7 @@ namespace GeminiV26.Instruments.ETHUSD
             // 🔑 ENTRY LOGIC – PRE-EXEC CONFIDENCE
             // =========================================================
             _entryLogic.Evaluate(out _, out int logicConfidence);
+            int statePenalty = 0;
 
             int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
             int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence);

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -104,13 +104,13 @@ namespace GeminiV26.Instruments.XAUUSD
             // =====================================================
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildStateSnapshot(ctx, position, stateSymbol), ctx, position));
+                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildStateSnapshot(ctx, pos, stateSymbol), ctx, pos));
                     ctx.LastStateTraceBarIndex = ctx.BarsSinceEntryM5;
                     ctx.LastStateTraceFingerprint = stateFingerprint;
                 }


### PR DESCRIPTION
### Motivation
- Fix compile errors introduced by recent logging changes that caused unresolved `Symbol` type, undefined `position` identifier in XAU exit manager, and missing `statePenalty` locals in some executors.

### Description
- Add the missing `using cAlgo.API.Internals;` import to `Core/Logging/TradeAuditLog.cs` so `BuildStateSnapshot(..., Symbol symbol)` resolves to the cAlgo `Symbol` type.
- Correct references in `Instruments/XAUUSD/XauExitManager.cs` to use the existing `pos` parameter and update the `BuildStateSnapshot` call to pass `pos` instead of the nonexistent `position` variable.
- Restore `int statePenalty = 0;` local declarations in `Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs` and `Instruments/ETHUSD/EthUsdInstrumentExecutor.cs` to satisfy the logging snapshot call without changing logic.
- Commit message: `Fix logging-related compile regressions`.

### Testing
- Ran `git diff --check` which reported no issues after the changes. (succeeded)
- Verified targeted source checks with `rg -n "position\.SymbolName|BuildStateSnapshot\(ctx, position|statePenalty"` across the modified files to confirm fixes. (succeeded)
- Performed `git add` + `git commit` with the fix applied. (succeeded)
- Note: a full project build was not executed because no `.sln` or `.csproj` files are present in the workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1737cc78083288db6993fea8df53b)