### PR TITLE
Add Gemini memory layer skeleton

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -1,5 +1,6 @@
 ﻿using cAlgo.API;
 using cAlgo.API.Internals;
+using Gemini.Memory;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Instruments.INDEX;
 using GeminiV26.Core.Matrix;
@@ -272,6 +273,12 @@ namespace GeminiV26.Core.Entry
 
         public SessionMatrixConfig SessionMatrixConfig { get; set; }
             = SessionMatrixDefaults.Neutral;
+
+        // =========================
+        // MEMORY
+        // =========================
+        public SymbolMemoryState MemoryState { get; set; }
+        public MemoryAssessment MemoryAssessment { get; set; }
 
         // =========================
         // TEMP BACKWARD COMPAT

--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -74,6 +74,12 @@ namespace GeminiV26.Core.Logging
                    $"adx={ctx?.Adx_M5 ?? 0:0.##}\n" +
                    $"htfDirection={htfDirection}\n" +
                    $"htfConfidence={htfConfidence}\n" +
+                   $"movePhase={ctx?.MemoryState?.MovePhase.ToString() ?? "Unknown"}\n" +
+                   $"moveAge={ctx?.MemoryState?.MoveAgeBars ?? 0}\n" +
+                   $"pullbackCount={ctx?.MemoryState?.PullbackCount ?? 0}\n" +
+                   $"isLateMove={ToLower(ctx?.MemoryAssessment?.IsLateMove ?? false)}\n" +
+                   $"isChaseRisk={ToLower(ctx?.MemoryAssessment?.IsChaseRisk ?? false)}\n" +
+                   $"contextTrust={FormatScore(ctx?.MemoryAssessment?.ContextTrustScore ?? 0)}\n" +
                    $"restartPhase={ResolveRestartPhase(ctx)}";
         }
 
@@ -218,6 +224,14 @@ namespace GeminiV26.Core.Logging
                 return "NA";
 
             return value.Value.ToString("0.#####", CultureInfo.InvariantCulture);
+        }
+
+        private static string FormatScore(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                return "0";
+
+            return value.ToString("0.##", CultureInfo.InvariantCulture);
         }
 
         private static string ToBase36(long value)

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -28,6 +28,8 @@
 // =========================================================
 
 using cAlgo.API;
+using cAlgo.API.Internals;
+using Gemini.Memory;
 using GeminiV26.Core.Entry;
 using GeminiV26.EntryTypes;
 using GeminiV26.EntryTypes.FX;
@@ -85,6 +87,7 @@ namespace GeminiV26.Core
         private readonly Dictionary<string, ArmedSetup> _armedSetups = new();
         private readonly TradeMetaStore _tradeMetaStore = new();
         private readonly TradeStatsTracker _statsTracker;
+        private readonly MarketMemoryEngine _memoryEngine;
         private readonly string _symbolCanonical;
         private readonly InstrumentClass _instrumentClass;
        
@@ -370,6 +373,7 @@ namespace GeminiV26.Core
                 new CsvTradeLogger(_logWriter, safePrint),
                 new CsvAnalyticsLogger(_logWriter, safePrint));
             _statsTracker = new TradeStatsTracker(safePrint);
+            _memoryEngine = new MarketMemoryEngine(safePrint);
             _globalSessionGate = new GlobalSessionGate(_bot);
             _sessionMatrix = new SessionMatrix(new SessionMatrixProvider());
 
@@ -937,6 +941,7 @@ namespace GeminiV26.Core
             // =========================
             _ctx.Session = SessionResolver.FromBucket(sessionDecision.Bucket);
             _bot.Print("[CTX_SESSION_ASSIGN] sessionFromGate={0} sessionAssigned={1}", sessionDecision.Bucket, _ctx.Session);
+            SyncMemoryState(_ctx);
 
             TradeType xauBias = TradeType.Buy;
             int xauBiasConfidence = 0;
@@ -1783,6 +1788,52 @@ namespace GeminiV26.Core
                 return "Transition";
 
             return _instrumentClass.ToString();
+        }
+
+        private void SyncMemoryState(EntryContext ctx)
+        {
+            if (ctx == null || string.IsNullOrWhiteSpace(ctx.Symbol))
+                return;
+
+            if (ctx.M5 == null || ctx.M5.Count <= 0)
+            {
+                ctx.MemoryState = _memoryEngine.GetState(ctx.Symbol);
+                ctx.MemoryAssessment = _memoryEngine.GetAssessment(ctx.Symbol);
+                return;
+            }
+
+            SymbolMemoryState state = _memoryEngine.GetState(ctx.Symbol);
+            if (state.BuildMode == MemoryBuildMode.Default)
+            {
+                _memoryEngine.BuildFromHistory(ctx.Symbol, ToClosedBarList(ctx.M5));
+            }
+            else
+            {
+                int lastClosedIndex = Math.Max(0, ctx.M5.Count - 2);
+                _memoryEngine.OnBar(ctx.Symbol, ctx.M5[lastClosedIndex]);
+            }
+
+            state = _memoryEngine.GetState(ctx.Symbol);
+            state.SessionName = ctx.Session.ToString();
+            state.SessionFatigueScore = Math.Max(0, ctx.BarsSinceStart);
+
+            ctx.MemoryState = state;
+            ctx.MemoryAssessment = _memoryEngine.GetAssessment(ctx.Symbol);
+        }
+
+        private static List<Bar> ToClosedBarList(Bars bars)
+        {
+            var result = new List<Bar>();
+            if (bars == null)
+                return result;
+
+            int closedCount = Math.Max(0, bars.Count - 1);
+            for (int i = 0; i < closedCount; i++)
+            {
+                result.Add(bars[i]);
+            }
+
+            return result;
         }
 
         private static bool ContainsAny(string value, params string[] tokens)

--- a/Gemini/Memory/MarketMemoryEngine.cs
+++ b/Gemini/Memory/MarketMemoryEngine.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using cAlgo.API;
+
+namespace Gemini.Memory
+{
+    public sealed class MarketMemoryEngine
+    {
+        private const int StaleImpulseThresholdBars = 8;
+        private const int ChaseRiskThresholdBars = 4;
+        private readonly Action<string> _log;
+
+        public Dictionary<string, SymbolMemoryState> States { get; } = new Dictionary<string, SymbolMemoryState>(StringComparer.OrdinalIgnoreCase);
+
+        public MarketMemoryEngine(Action<string> log = null)
+        {
+            _log = log;
+        }
+
+        public SymbolMemoryState GetState(string symbol)
+        {
+            if (string.IsNullOrWhiteSpace(symbol))
+                return Initialize(string.Empty);
+
+            return States.TryGetValue(symbol, out var state)
+                ? state
+                : Initialize(symbol);
+        }
+
+        public SymbolMemoryState Initialize(string symbol)
+        {
+            string key = symbol?.Trim() ?? string.Empty;
+            var state = new SymbolMemoryState
+            {
+                Symbol = key,
+                MovePhase = MovePhase.Unknown,
+                TrustLevel = MemoryTrustLevel.Unknown,
+                BuildMode = MemoryBuildMode.Default
+            };
+
+            States[key] = state;
+            return state;
+        }
+
+        public void BuildFromHistory(string symbol, List<Bar> bars)
+        {
+            var state = GetState(symbol);
+            _log?.Invoke($"[MEMORY][BUILD_START] symbol={state.Symbol} bars={(bars?.Count ?? 0)}");
+
+            state.MoveAgeBars = 0;
+            state.PullbackCount = 0;
+            state.BarsSinceImpulse = 0;
+            state.IsStaleImpulse = false;
+            state.IsImpulseDecay = false;
+            state.MovePhase = MovePhase.Unknown;
+            state.BuildMode = MemoryBuildMode.HistoricalReplay;
+            state.TrustLevel = MemoryTrustLevel.Medium;
+
+            if (bars == null || bars.Count == 0)
+            {
+                _log?.Invoke($"[MEMORY][DONE] symbol={state.Symbol} mode={state.BuildMode} phase={state.MovePhase} age={state.MoveAgeBars}");
+                return;
+            }
+
+            foreach (var bar in bars)
+            {
+                ReplayBar(state, bar);
+            }
+
+            _log?.Invoke($"[MEMORY][DONE] symbol={state.Symbol} mode={state.BuildMode} phase={state.MovePhase} age={state.MoveAgeBars} pullbacks={state.PullbackCount} sinceImpulse={state.BarsSinceImpulse}");
+        }
+
+        public void OnBar(string symbol, Bar bar)
+        {
+            var state = GetState(symbol);
+            if (state.BuildMode == MemoryBuildMode.Default)
+            {
+                state.BuildMode = MemoryBuildMode.Live;
+                state.TrustLevel = MemoryTrustLevel.Low;
+            }
+            else if (state.BuildMode == MemoryBuildMode.HistoricalReplay)
+            {
+                state.BuildMode = MemoryBuildMode.Live;
+                state.TrustLevel = MemoryTrustLevel.High;
+            }
+
+            state.MoveAgeBars++;
+            state.BarsSinceImpulse++;
+
+            if (IsStrongMove(bar))
+            {
+                state.MovePhase = MovePhase.Impulse;
+                state.MoveAgeBars = 1;
+                state.BarsSinceImpulse = 0;
+                state.IsStaleImpulse = false;
+                state.IsImpulseDecay = false;
+                _log?.Invoke($"[MEMORY][UPDATE] symbol={state.Symbol} age={state.MoveAgeBars} sinceImpulse={state.BarsSinceImpulse}");
+                _log?.Invoke($"[MEMORY][IMPULSE] symbol={state.Symbol} phase={state.MovePhase}");
+                return;
+            }
+
+            if (IsRetrace(bar))
+            {
+                state.PullbackCount++;
+                state.MovePhase = MovePhase.Pullback;
+                _log?.Invoke($"[MEMORY][PULLBACK] symbol={state.Symbol} pullbacks={state.PullbackCount}");
+            }
+            else if (state.BarsSinceImpulse > 1)
+            {
+                state.MovePhase = MovePhase.Decay;
+            }
+
+            state.IsImpulseDecay = state.MovePhase == MovePhase.Decay;
+            if (state.BarsSinceImpulse > StaleImpulseThresholdBars)
+            {
+                state.IsStaleImpulse = true;
+                state.MovePhase = MovePhase.Stale;
+            }
+
+            _log?.Invoke($"[MEMORY][UPDATE] symbol={state.Symbol} age={state.MoveAgeBars} sinceImpulse={state.BarsSinceImpulse}");
+        }
+
+        public MemoryAssessment GetAssessment(string symbol)
+        {
+            var state = GetState(symbol);
+            var assessment = new MemoryAssessment
+            {
+                IsLateMove = state.PullbackCount > 2 || state.IsStaleImpulse,
+                IsChaseRisk = state.BarsSinceImpulse > ChaseRiskThresholdBars,
+                ContextTrustScore = ResolveContextTrustScore(state.BuildMode),
+                RecommendedPenalty = 0
+            };
+
+            if (assessment.IsLateMove)
+                assessment.RecommendedPenalty -= 20;
+
+            if (assessment.IsChaseRisk)
+                assessment.RecommendedPenalty -= 15;
+
+            _log?.Invoke($"[MEMORY][ASSESSMENT] symbol={state.Symbol} late={assessment.IsLateMove} chase={assessment.IsChaseRisk} trust={assessment.ContextTrustScore:0.##} penalty={assessment.RecommendedPenalty}");
+            return assessment;
+        }
+
+        private void ReplayBar(SymbolMemoryState state, Bar bar)
+        {
+            state.MoveAgeBars++;
+            state.BarsSinceImpulse++;
+            _log?.Invoke($"[MEMORY][REPLAY] symbol={state.Symbol} age={state.MoveAgeBars} sinceImpulse={state.BarsSinceImpulse}");
+
+            if (IsStrongMove(bar))
+            {
+                state.MovePhase = MovePhase.Impulse;
+                state.MoveAgeBars = 1;
+                state.BarsSinceImpulse = 0;
+                state.IsStaleImpulse = false;
+                state.IsImpulseDecay = false;
+                _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
+                return;
+            }
+
+            if (IsRetrace(bar))
+            {
+                state.PullbackCount++;
+                state.MovePhase = MovePhase.Pullback;
+                _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase} pullbacks={state.PullbackCount}");
+            }
+            else if (state.BarsSinceImpulse > 1)
+            {
+                state.MovePhase = MovePhase.Decay;
+                state.IsImpulseDecay = true;
+                _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
+            }
+
+            if (state.BarsSinceImpulse > StaleImpulseThresholdBars)
+            {
+                state.IsStaleImpulse = true;
+                state.MovePhase = MovePhase.Stale;
+                _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
+            }
+        }
+
+        private static bool IsStrongMove(Bar bar)
+        {
+            if (bar == null)
+                return false;
+
+            double range = Math.Abs(bar.High - bar.Low);
+            if (range <= 0)
+                return false;
+
+            double body = Math.Abs(bar.Close - bar.Open);
+            return body >= range * 0.60;
+        }
+
+        private static bool IsRetrace(Bar bar)
+        {
+            if (bar == null)
+                return false;
+
+            double range = Math.Abs(bar.High - bar.Low);
+            if (range <= 0)
+                return false;
+
+            double body = Math.Abs(bar.Close - bar.Open);
+            return body <= range * 0.35;
+        }
+
+        private static double ResolveContextTrustScore(MemoryBuildMode buildMode)
+        {
+            return buildMode switch
+            {
+                MemoryBuildMode.HistoricalReplay => 0.70,
+                MemoryBuildMode.Live => 0.90,
+                _ => 0.30
+            };
+        }
+    }
+}

--- a/Gemini/Memory/MemoryAssessment.cs
+++ b/Gemini/Memory/MemoryAssessment.cs
@@ -1,0 +1,10 @@
+namespace Gemini.Memory
+{
+    public sealed class MemoryAssessment
+    {
+        public bool IsLateMove { get; set; }
+        public bool IsChaseRisk { get; set; }
+        public double ContextTrustScore { get; set; }
+        public int RecommendedPenalty { get; set; }
+    }
+}

--- a/Gemini/Memory/MemoryEnums.cs
+++ b/Gemini/Memory/MemoryEnums.cs
@@ -1,0 +1,26 @@
+namespace Gemini.Memory
+{
+    public enum MovePhase
+    {
+        Unknown = 0,
+        Impulse = 1,
+        Pullback = 2,
+        Decay = 3,
+        Stale = 4
+    }
+
+    public enum MemoryBuildMode
+    {
+        Default = 0,
+        HistoricalReplay = 1,
+        Live = 2
+    }
+
+    public enum MemoryTrustLevel
+    {
+        Unknown = 0,
+        Low = 1,
+        Medium = 2,
+        High = 3
+    }
+}

--- a/Gemini/Memory/SymbolMemoryState.cs
+++ b/Gemini/Memory/SymbolMemoryState.cs
@@ -1,0 +1,17 @@
+namespace Gemini.Memory
+{
+    public sealed class SymbolMemoryState
+    {
+        public string Symbol { get; set; } = string.Empty;
+        public MovePhase MovePhase { get; set; } = MovePhase.Unknown;
+        public int MoveAgeBars { get; set; }
+        public int PullbackCount { get; set; }
+        public int BarsSinceImpulse { get; set; }
+        public bool IsStaleImpulse { get; set; }
+        public bool IsImpulseDecay { get; set; }
+        public string SessionName { get; set; } = string.Empty;
+        public double SessionFatigueScore { get; set; }
+        public MemoryTrustLevel TrustLevel { get; set; } = MemoryTrustLevel.Unknown;
+        public MemoryBuildMode BuildMode { get; set; } = MemoryBuildMode.Default;
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a minimal, structure-first Memory Layer so the system can hold per-symbol historical and live memory state for later decision inputs.
- Provide entry-time visibility of memory-derived signals in audit logs without changing existing entry decision logic.

### Description
- Add `Gemini.Memory` namespace with enums (`MovePhase`, `MemoryBuildMode`, `MemoryTrustLevel`), `SymbolMemoryState`, and `MemoryAssessment` to model memory state and assessments.
- Add lightweight `MarketMemoryEngine` exposing `Dictionary<string, SymbolMemoryState>`, `GetState`, `Initialize`, `BuildFromHistory`, `OnBar`, and `GetAssessment` with simple replay/live update heuristics and memory log tags (`[MEMORY][BUILD_START]`, `[MEMORY][REPLAY]`, `[MEMORY][PHASE]`, `[MEMORY][UPDATE]`, `[MEMORY][IMPULSE]`, `[MEMORY][PULLBACK]`, `[MEMORY][ASSESSMENT]`, `[MEMORY][DONE]`).
- Wire the engine into `Core/TradeCore.cs`, synchronizing memory state after session assignment using closed M5 history and updating on the last closed bar, and attach `MemoryState`/`MemoryAssessment` to `EntryContext` for downstream consumers.
- Extend the entry snapshot format in `Core/Logging/TradeAuditLog.cs` to include `movePhase`, `moveAge`, `pullbackCount`, `isLateMove`, `isChaseRisk`, and `contextTrust` without modifying entry decision or confidence computation.

### Testing
- Ran repository checks including `git diff --check` and repository inspections to validate changed files and diff consistency, which succeeded.
- Attempted to run `dotnet build` but the environment does not provide the `dotnet` CLI, so a full compile was not executed (`/bin/bash: line 1: dotnet: command not found`).
- No unit tests were added or modified as this change is intentionally a non-invasive structural addition.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c177222e5483288b20ff8b96eec473)