### PR TITLE
Separate TP1/full-close state and fix TP1 execution guards

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -99,6 +99,10 @@ namespace GeminiV26.Core
         // =========================
         public bool Tp1Hit { get; set; }
 
+        public bool Tp1Executed { get; set; }
+
+        public bool IsFullyClosing { get; set; }
+
         // =========================
         // Take profit prices (resolved at entry time)
         // =========================

--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -356,6 +356,7 @@ namespace GeminiV26.Core.Runtime
                 EntryPrice = entryPrice,
                 RiskPriceDistance = riskDistance,
                 Tp1Hit = tp1Hit,
+                Tp1Executed = tp1Hit,
                 Tp1CloseFraction = 0,
                 Tp1ClosedVolumeInUnits = tp1ClosedVolumeInUnits,
                 EntryVolumeInUnits = entryVolumeInUnits,

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.AUDNZD
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.AUDNZD
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[AUDNZD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.AUDNZD
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[AUDNZD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,22 +239,15 @@ namespace GeminiV26.Instruments.AUDNZD
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.AUDUSD
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.AUDUSD
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[AUDUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.AUDUSD
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[AUDUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,22 +239,15 @@ namespace GeminiV26.Instruments.AUDUSD
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -123,7 +123,10 @@ namespace GeminiV26.Instruments.BTCUSD
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -188,25 +191,12 @@ namespace GeminiV26.Instruments.BTCUSD
                             reached = IsLong(ctx)
                                 ? m1Bar.High >= tp1Price
                                 : m1Bar.Low <= tp1Price;
-
-                            _bot.Print(TradeLogIdentity.WithPositionIds(
-                                $"[BTCUSD][TP1][CHECK] pos={pos.Id} " +
-                                $"tp1={tp1Price} m1High={m1Bar.High} m1Low={m1Bar.Low} " +
-                                $"bid={sym.Bid} ask={sym.Ask} reached={reached}", ctx, pos));
                         }
-
-                        _bot.Print(TradeLogIdentity.WithPositionIds(
-                            $"[BTCUSD][TP1][CHECK:FALLBACK] pos={pos.Id} " +
-                            $"tp1={tp1Price} bid={sym.Bid} ask={sym.Ask} reached={reached}", ctx, pos));
                     }
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds(
-                            $"[BTCUSD][TP1][HIT] symbol={pos.SymbolName} pos={pos.Id} " +
-                            $"dir={pos.TradeType} tp1={tp1Price} rDist={rDist} tp1R={ctx.Tp1R}", ctx, pos));
-
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
 
                         // Legacy viselkedés:
@@ -244,6 +234,7 @@ namespace GeminiV26.Instruments.BTCUSD
                                     $"MFE_R={ctx.MfeR:0.00} MAE_R={ctx.MaeR:0.00} " +
                                     $"barsM5={ctx.BarsSinceEntryM5}", ctx, pos));
 
+                                ctx.IsFullyClosing = true;
                                 _bot.ClosePosition(pos);
                                 _contexts.Remove(key);
                                 continue;
@@ -324,7 +315,6 @@ namespace GeminiV26.Instruments.BTCUSD
                 return;
             }
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
             {
@@ -332,7 +322,6 @@ namespace GeminiV26.Instruments.BTCUSD
                 return;
             }
 
-            closeExecuted = true;
             _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} " +
                 $"direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} " +
@@ -343,12 +332,8 @@ namespace GeminiV26.Instruments.BTCUSD
 
             // 2) TP1 state
             ctx.Tp1Hit = true;
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             // 3) BE / protective SL after TP1
             ApplyBreakEven(pos, ctx, rDist);

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -107,7 +107,10 @@ namespace GeminiV26.Instruments.ETHUSD
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -176,15 +179,12 @@ namespace GeminiV26.Instruments.ETHUSD
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[ETHUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
-
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
-
                         continue;
                     }
 
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.ETHUSD
                                 $"[ETHUSD TVM EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}"
                             );
 
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
 
                             _contexts.Remove(key);
@@ -292,25 +293,19 @@ namespace GeminiV26.Instruments.ETHUSD
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
 
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
 
             ctx.RemainingVolumeInUnits =
                 Math.Max(0, pos.VolumeInUnits - closeUnits);
 
             ctx.Tp1Hit = true;
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.EURJPY
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.EURJPY
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EURJPY][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.EURJPY
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EURJPY][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,22 +239,15 @@ namespace GeminiV26.Instruments.EURJPY
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.EURUSD
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.EURUSD
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EURUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.EURUSD
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EURUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,22 +239,15 @@ namespace GeminiV26.Instruments.EURUSD
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.GBPJPY
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.GBPJPY
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[GBPJPY][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.GBPJPY
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[GBPJPY][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,22 +239,15 @@ namespace GeminiV26.Instruments.GBPJPY
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.GBPUSD
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.GBPUSD
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[GBPUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.GBPUSD
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[GBPUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,22 +239,15 @@ namespace GeminiV26.Instruments.GBPUSD
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.GER40
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.GER40
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[GER40][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.GER40
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[GER40][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,22 +239,15 @@ namespace GeminiV26.Instruments.GER40
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.NAS100
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.NAS100
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[NAS100][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.NAS100
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[NAS100][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,22 +239,15 @@ namespace GeminiV26.Instruments.NAS100
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.NZDUSD
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.NZDUSD
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[NZDUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.NZDUSD
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[NZDUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,21 +239,15 @@ namespace GeminiV26.Instruments.NZDUSD
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.US30
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.US30
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[US30][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.US30
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[US30][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,22 +239,15 @@ namespace GeminiV26.Instruments.US30
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.USDCAD
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.USDCAD
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[USDCAD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.USDCAD
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[USDCAD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,21 +239,15 @@ namespace GeminiV26.Instruments.USDCAD
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.USDCHF
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.USDCHF
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[USDCHF][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.USDCHF
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[USDCHF][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,21 +239,15 @@ namespace GeminiV26.Instruments.USDCHF
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -90,7 +90,10 @@ namespace GeminiV26.Instruments.USDJPY
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -154,12 +157,11 @@ namespace GeminiV26.Instruments.USDJPY
                         }
                     }
 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={reached.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
-
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[USDJPY][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -183,13 +185,12 @@ namespace GeminiV26.Instruments.USDJPY
                                 $"reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[USDJPY][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
                             continue;
                         }
                     }
-
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][MISS]\ntp1={tp1Price:0.#####}\nrDist={rDist:0.#####}", ctx, pos));
                     continue;
                 }
 
@@ -238,22 +239,15 @@ namespace GeminiV26.Instruments.USDJPY
             if (closeUnits < minUnits)
                 return;
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
                 return;
 
-            closeExecuted = true;
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             ApplyBreakEven(pos, ctx, rDist);
         }

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -147,7 +147,10 @@ namespace GeminiV26.Instruments.XAUUSD
                 var pos = FindPosition(ctx.PositionId);
                 if (pos == null)
                 {
-                    _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(ctx.PositionId, "position_not_found"), ctx));
+                    if (ctx.Tp1Executed && !ctx.IsFullyClosing)
+                        continue;
+
+                    _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
                     continue;
                 }
@@ -219,13 +222,12 @@ namespace GeminiV26.Instruments.XAUUSD
                                 : bar.Low <= tp1Price;
                         }
                     }
- 
-                    _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][CHECK]\ntp1={tp1Price:0.#####}\nreached={hit.ToString().ToLowerInvariant()}\nrDist={rDist:0.#####}", ctx, pos));
 
                     if (hit)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1] hit", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[XAUUSD][TP1][HIT] pos={pos.Id} tp1={tp1Price}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
+pos={pos.Id}
+tp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -251,6 +253,7 @@ namespace GeminiV26.Instruments.XAUUSD
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] reason={ctx.DeadTradeReason}", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds($"[XAUUSD][TVM][EXIT] pos={pos.Id} reason={ctx.DeadTradeReason}", ctx, pos));
 
+                            ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
 
                             _eventLogger.Log(new EventRecord
@@ -313,7 +316,6 @@ namespace GeminiV26.Instruments.XAUUSD
                 return;
             }
 
-            bool closeExecuted = false;
             var closeResult = _bot.ClosePosition(pos, closeVolume);
             if (!closeResult.IsSuccessful)
             {
@@ -321,22 +323,17 @@ namespace GeminiV26.Instruments.XAUUSD
                 return;
             }
 
-            closeExecuted = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} closedUnits={closeVolume}", ctx, pos));
 
             // TP1 state (SSOT) – csak itt állítjuk
             ctx.Tp1Hit = true;
+            ctx.Tp1Executed = true;
+            _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeVolume}", ctx, pos));
 
             // Remaining volume (analytics + rehydrate friendliness)
             ctx.Tp1ClosedVolumeInUnits = closeVolume;
             ctx.RemainingVolumeInUnits =
                 Math.Max(0, pos.VolumeInUnits - closeVolume);
-
-            if (closeExecuted && FindPosition(ctx.PositionId) == null)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds($"[CLEANUP] skip modify after close positionId={ctx.PositionId}", ctx));
-                return;
-            }
 
             // BE (profilból)
             ApplyBreakEven(pos, ctx, rDist);


### PR DESCRIPTION
### Motivation
- TP1 partial-close flow was being short-circuited by a single `IsClosing` flag and an early position-existence guard, causing TP1 to be treated as a full close and blocking BE/trailing logic.
- The change ensures TP1 executes fully (partial close → BE) and that full closes still trigger cleanup, while avoiding premature removal of contexts and noisy TP1 logs.

### Description
- Added explicit flags on `PositionContext`: `Tp1Executed` and `IsFullyClosing` and persisted `Tp1Executed` on rehydrate by setting `Tp1Executed = tp1Hit` in `RehydrateService`.
- Updated instrument ExitManagers (all `*ExitManager.cs` under `Instruments/…`) to: use the new flags, skip cleanup only when `ctx.Tp1Executed && !ctx.IsFullyClosing`, set `ctx.IsFullyClosing = true` only on actual full-close flows, and mark `ctx.Tp1Executed = true` immediately after a successful partial close (TP1).
- Removed the local `closeExecuted` plumbing and the old post-close `skip modify after close` early-return; instead the managers now continue into `ApplyBreakEven` and trailing after TP1 partial close when appropriate.
- Simplified and cleaned up TP1 logging: removed repetitive `[TP1][CHECK]`/`[TP1][MISS]` noise and introduced `[TP1][HIT]`, `[TP1][EXECUTED]`, and `[EXIT][CLEANUP]` messages as the canonical events.

### Testing
- Ran repository syntactic checks: `git diff --check` (no whitespace errors) — success.
- Executed a Python validation script to assert all instrument ExitManagers include `ctx.Tp1Executed = true;`, `ctx.IsFullyClosing = true;` on full closes, presence of `[TP1][EXECUTED]` and absence of old noisy `[TP1][CHECK]`/`[TP1][MISS]` and obsolete `closeExecuted` patterns — validation succeeded for all managers.
- Attempted `dotnet build` but the environment lacks `dotnet` so a full compile could not be run here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17a28f0a0832894ab8fa2331552f8)