### PR TITLE
Fix TP1 exit manager log string syntax regression

### DIFF
--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -181,9 +181,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.EURJPY
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.EURUSD
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.GER40
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.NAS100
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.US30
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.USDCAD
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.USDCHF
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -159,9 +159,7 @@ namespace GeminiV26.Instruments.USDJPY
 
                     if (reached)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -225,9 +225,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
                     if (hit)
                     {
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]
-pos={pos.Id}
-tp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }


### PR DESCRIPTION
### Motivation
- A prior change introduced broken multi-line interpolated strings in multiple instrument `*ExitManager.cs` files which broke C# syntax around the TP1 hit logging. 
- Restore valid log string syntax so TP1 detection/handling blocks compile and log correctly across instruments.

### Description
- Replace malformed multi-line interpolated TP1 log literals with single interpolated strings using escaped `\n` line breaks (e.g. `"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}"`) in the exit managers. 
- The fix was applied to 15 exit manager files across FX, indices, metals and crypto under `Instruments/*/*ExitManager.cs`. 
- No behavioural changes to TP1 detection or `ExecuteTp1` invocation were made, only the logging string syntax was corrected.

### Testing
- Ran `git diff --check` to validate there are no basic whitespace/syntax diff issues and it passed. 
- Executed a Python-based scan to verify there are no remaining occurrences of the broken pattern ` $"[TP1][HIT]\npos=` and the scan returned zero matches. 
- Attempted to run local C# build tools (`dotnet`, `csc`, `mcs`) but they are not available in this environment, so no compile/run tests were executed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17cbf31d88328aeac20d87c3232b1)