### PR TITLE
Enforce market memory coverage audit in TradeCore

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -266,6 +266,25 @@ namespace GeminiV26.Core
         private static readonly TimeSpan ContextPruneInterval = TimeSpan.FromMinutes(5);
         private static readonly TimeSpan ContextMaxAge = TimeSpan.FromMinutes(30);
         private bool _isMemoryReady;
+        private static readonly string[] RequiredMemorySymbols =
+        {
+            "EURUSD",
+            "USDJPY",
+            "GBPUSD",
+            "AUDUSD",
+            "AUDNZD",
+            "EURJPY",
+            "GBPJPY",
+            "NZDUSD",
+            "USDCAD",
+            "USDCHF",
+            "XAUUSD",
+            "NAS100",
+            "US30",
+            "GER40",
+            "BTCUSD",
+            "ETHUSD"
+        };
 
         public TradeCore(Robot bot)
         {
@@ -685,6 +704,9 @@ namespace GeminiV26.Core
             string sym = NormalizeSymbol(rawSym);   // ✅ CANONICAL
 
             _bot.Print($"[ONBAR DBG] raw={rawSym} canonical={sym}");
+
+            EnsureStartupMemoryReady();
+            AuditMemoryCoverage();
 
             bool isFx = _fxMarketStateDetector != null && SymbolRouting.ResolveInstrumentClass(sym) == InstrumentClass.FX;
 
@@ -1844,20 +1866,8 @@ namespace GeminiV26.Core
             if (_isMemoryReady)
                 return;
 
-            var symbols = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                [_symbolCanonical] = _bot.SymbolName
-            };
-
-            foreach (var position in _bot.Positions)
-            {
-                if (position == null || string.IsNullOrWhiteSpace(position.SymbolName))
-                    continue;
-
-                string canonical = SymbolRouting.NormalizeSymbol(position.SymbolName);
-                if (!symbols.ContainsKey(canonical))
-                    symbols[canonical] = position.SymbolName;
-            }
+            var symbols = GetAllMemorySymbols()
+                .ToDictionary(symbol => symbol, ResolveMarketDataSymbol, StringComparer.OrdinalIgnoreCase);
 
             foreach (var pair in symbols)
             {
@@ -1866,6 +1876,7 @@ namespace GeminiV26.Core
             }
 
             _isMemoryReady = true;
+            _bot.Print($"[MEMORY][COVERAGE] ratio={_memoryEngine.GetCoverageRatio(symbols.Keys)}");
             _bot.Print($"[BOOT][MEMORY_READY] symbols={symbols.Count}");
         }
 
@@ -2456,6 +2467,79 @@ namespace GeminiV26.Core
         private static string NormalizeSymbol(string symbol)
         {
             return SymbolRouting.NormalizeSymbol(symbol);
+        }
+
+        private void AuditMemoryCoverage()
+        {
+            var symbols = GetAllMemorySymbols();
+            bool isStartupWindow = BotRestartState.BarsSinceStart <= 5;
+
+            foreach (var symbol in symbols)
+            {
+                SymbolMemoryState memoryState = _memoryEngine.GetState(symbol);
+                bool isNull = memoryState == null;
+                bool isBuilt = memoryState?.IsBuilt == true;
+
+                if (isNull || !isBuilt)
+                {
+                    _bot.Print($"[MEMORY][MISSING] symbol={symbol} built={isBuilt} stateNull={isNull}");
+
+                    if (isStartupWindow)
+                        _bot.Print($"[MEMORY][CRITICAL] symbol={symbol} missing_after_startup");
+
+                    continue;
+                }
+
+                _bot.Print(
+                    $"[DEBUG][MEMORY][OK] symbol={symbol} phase={memoryState.MovePhase} age={memoryState.MoveAgeBars} pullbacks={memoryState.PullbackCount}");
+            }
+
+            _bot.Print($"[MEMORY][COVERAGE] ratio={_memoryEngine.GetCoverageRatio(symbols)}");
+        }
+
+        private List<string> GetAllMemorySymbols()
+        {
+            var symbols = new HashSet<string>(RequiredMemorySymbols, StringComparer.OrdinalIgnoreCase)
+            {
+                _symbolCanonical,
+                NormalizeSymbol(_bot.SymbolName)
+            };
+
+            foreach (var position in _bot.Positions)
+            {
+                if (position == null || string.IsNullOrWhiteSpace(position.SymbolName))
+                    continue;
+
+                symbols.Add(NormalizeSymbol(position.SymbolName));
+            }
+
+            foreach (var memorySymbol in _memoryEngine.States.Keys)
+            {
+                if (!string.IsNullOrWhiteSpace(memorySymbol))
+                    symbols.Add(NormalizeSymbol(memorySymbol));
+            }
+
+            return symbols
+                .Where(symbol => !string.IsNullOrWhiteSpace(symbol))
+                .OrderBy(symbol => symbol, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static string ResolveMarketDataSymbol(string canonicalSymbol)
+        {
+            if (string.IsNullOrWhiteSpace(canonicalSymbol))
+                return string.Empty;
+
+            return canonicalSymbol.ToUpperInvariant() switch
+            {
+                "NAS100" => "NAS100",
+                "US30" => "US30",
+                "GER40" => "GER40",
+                "XAUUSD" => "XAUUSD",
+                "BTCUSD" => "BTCUSD",
+                "ETHUSD" => "ETHUSD",
+                _ => canonicalSymbol.ToUpperInvariant()
+            };
         }
 
         private bool RegisterRehydratedContextWithExitManager(PositionContext ctx)

--- a/Gemini/Memory/MarketMemoryEngine.cs
+++ b/Gemini/Memory/MarketMemoryEngine.cs
@@ -17,6 +17,25 @@ namespace Gemini.Memory
             _log = log;
         }
 
+        public int TotalSymbolCount { get; private set; }
+        public double MemoryCoverageRatio { get; private set; }
+
+        public int BuiltSymbolCount
+        {
+            get
+            {
+                int count = 0;
+
+                foreach (var state in States.Values)
+                {
+                    if (state != null && state.IsBuilt)
+                        count++;
+                }
+
+                return count;
+            }
+        }
+
         public SymbolMemoryState GetState(string symbol)
         {
             if (string.IsNullOrWhiteSpace(symbol))
@@ -35,7 +54,8 @@ namespace Gemini.Memory
                 Symbol = key,
                 MovePhase = MovePhase.Unknown,
                 TrustLevel = MemoryTrustLevel.Unknown,
-                BuildMode = MemoryBuildMode.Default
+                BuildMode = MemoryBuildMode.Default,
+                IsBuilt = false
             };
 
             States[key] = state;
@@ -59,9 +79,11 @@ namespace Gemini.Memory
             state.MovePhase = MovePhase.Unknown;
             state.BuildMode = MemoryBuildMode.HistoricalReplay;
             state.TrustLevel = MemoryTrustLevel.Medium;
+            state.IsBuilt = false;
 
             if (bars == null || bars.Count == 0)
             {
+                state.IsBuilt = true;
                 _log?.Invoke($"[MEMORY][REPLAY] symbol={state.Symbol} bars=0 reason=no_history");
                 _log?.Invoke($"[MEMORY][DONE] symbol={state.Symbol} mode={state.BuildMode} phase={state.MovePhase} age={state.MoveAgeBars}");
                 return;
@@ -72,12 +94,15 @@ namespace Gemini.Memory
                 ReplayBar(state, bar);
             }
 
+            state.IsBuilt = true;
             _log?.Invoke($"[MEMORY][DONE] symbol={state.Symbol} mode={state.BuildMode} phase={state.MovePhase} age={state.MoveAgeBars} pullbacks={state.PullbackCount} sinceImpulse={state.BarsSinceImpulse}");
         }
 
         public void OnBar(string symbol, Bar bar)
         {
             var state = GetState(symbol);
+            state.IsBuilt = true;
+
             if (state.BuildMode == MemoryBuildMode.Default)
             {
                 state.BuildMode = MemoryBuildMode.Live;
@@ -131,6 +156,38 @@ namespace Gemini.Memory
             }
 
             _log?.Invoke($"[MEMORY][UPDATE] symbol={state.Symbol} age={state.MoveAgeBars} sinceImpulse={state.BarsSinceImpulse}");
+        }
+
+        public string GetCoverageRatio(IEnumerable<string> symbols)
+        {
+            int totalSymbols = 0;
+            int builtSymbols = 0;
+
+            if (symbols != null)
+            {
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var symbol in symbols)
+                {
+                    if (string.IsNullOrWhiteSpace(symbol))
+                        continue;
+
+                    string key = symbol.Trim();
+                    if (!seen.Add(key))
+                        continue;
+
+                    totalSymbols++;
+
+                    if (States.TryGetValue(key, out var state) && state != null && state.IsBuilt)
+                        builtSymbols++;
+                }
+            }
+
+            TotalSymbolCount = totalSymbols;
+            MemoryCoverageRatio = totalSymbols > 0
+                ? (double)builtSymbols / totalSymbols
+                : 0d;
+
+            return $"{builtSymbols}/{totalSymbols}";
         }
 
         public MemoryAssessment GetAssessment(string symbol)

--- a/Gemini/Memory/SymbolMemoryState.cs
+++ b/Gemini/Memory/SymbolMemoryState.cs
@@ -17,5 +17,6 @@ namespace Gemini.Memory
         public double SessionFatigueScore { get; set; }
         public MemoryTrustLevel TrustLevel { get; set; } = MemoryTrustLevel.Unknown;
         public MemoryBuildMode BuildMode { get; set; } = MemoryBuildMode.Default;
+        public bool IsBuilt { get; set; }
     }
 }


### PR DESCRIPTION
### Motivation
- Biztossítani kell, hogy minden instrumentumhoz MarketMemory legyen inicializálva és felépítve, ez runtime integritási követelmény (nem opcionális). 
- A cél egy audit-only megoldás, ami nem blokkolja a trade-et és nem módosítja az entry/exit/TP/SL vagy risk logikát.

### Description
- A `TradeCore.OnBar()` elején mostantól `EnsureStartupMemoryReady()` és `AuditMemoryCoverage()` fut, amelyek bootstrapolják és ellenőrzik az összes kötelező symbol memóriáját; a kötelező univerzum explicit: FX, Index, Metal és Crypto (pl. EURUSD, XAUUSD, NAS100, US30, GER40, BTCUSD, ETHUSD stb.).
- `MarketMemoryEngine` és `SymbolMemoryState` bővítve: `IsBuilt` flag, `BuiltSymbolCount`, `TotalSymbolCount`, `MemoryCoverageRatio` és `GetCoverageRatio()` hozzáadva a coverage méréséhez és logolásához; `BuildFromHistory()` és `OnBar()` most karbantartja az `IsBuilt` státuszt.
- Runtime logok: hiányzó memória esetén `[MEMORY][MISSING]`, startup első 5 baron belül hiány esetén `[MEMORY][CRITICAL]`, sikeres memória esetén debug log `[DEBUG][MEMORY][OK]`, és minden audit kör végén `[MEMORY][COVERAGE]` ratio formátumban; minden log audit-only és nem befolyásolja a trading pipeline-t.
- Startup bootstrap módosítva: az összes szükséges symbolra meghívódik `Initialize()` és `BuildFromHistory()` (nincs conditional skip), és azonnal logolja a coverage arányt.

### Testing
- `git diff --check` futott és nem talált problémát (sikeres).
- `dotnet --info` lefuttatása sikertelen volt, mert a konténerben nincs telepítve a .NET SDK (`dotnet: command not found`), így a teljes projektszintű build nem volt elvégezhető itt (nem futtatható a compile-phase ebben a környezetben).
- Repo-ellenőrzés: keresésekkel (`rg`) ellenőriztem a releváns hivatkozásokat és hogy nincs `.sln`/`.csproj` a fájlfa gyökérében, ezért projekt buildet nem tudtam lokálisan elindítani.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c192de524483289d10f80c7beb50a4)