### PR TITLE
Centralize runtime symbol resolution and remove direct string-based symbol access

### DIFF
--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -13,6 +13,7 @@ namespace GeminiV26.Core.Entry
     public class EntryContextBuilder
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly CryptoHtfBiasEngine _cryptoHtf;
         private readonly FxHtfBiasEngine _fxHtf;
         private readonly IndexHtfBiasEngine _indexHtf;
@@ -21,6 +22,7 @@ namespace GeminiV26.Core.Entry
         public EntryContextBuilder(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _cryptoHtf = new CryptoHtfBiasEngine(_bot);
             _fxHtf = new FxHtfBiasEngine(_bot);
             _indexHtf = new IndexHtfBiasEngine(_bot);
@@ -67,9 +69,9 @@ namespace GeminiV26.Core.Entry
             // -------------------------
             // BAR DATA
             // -------------------------
-            ctx.M1 = _bot.MarketData.GetBars(TimeFrame.Minute, symbol);
-            ctx.M5 = _bot.MarketData.GetBars(TimeFrame.Minute5, symbol);
-            ctx.M15 = _bot.MarketData.GetBars(TimeFrame.Minute15, symbol);
+            ctx.M1 = _runtimeSymbols.GetBars(TimeFrame.Minute, symbol);
+            ctx.M5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, symbol);
+            ctx.M15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, symbol);
 
             if (ctx.M1 == null || ctx.M5 == null || ctx.M15 == null)
                 return ctx;
@@ -101,7 +103,7 @@ namespace GeminiV26.Core.Entry
                 (atr_m5.Result[m5Idx - 2] - atr_m5.Result[m5Idx - 4]);
 
             // pip konverzió
-            var sym = _bot.Symbols.GetSymbol(symbol);
+            var sym = _runtimeSymbols.ResolveSymbol(symbol);
             double pipSize = sym?.PipSize ?? 0;
 
             ctx.PipSize = pipSize;   // <<< EZ AZ ÚJ SOR

--- a/Core/HtfBias/CryptoHtfBiasEngine.cs
+++ b/Core/HtfBias/CryptoHtfBiasEngine.cs
@@ -19,6 +19,7 @@ namespace GeminiV26.Core.HtfBias
     public sealed class CryptoHtfBiasEngine : IHtfBiasProvider
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
 
         private static readonly TimeFrame BiasTf = TimeFrame.Hour4;
         private static readonly TimeFrame UpdateTf = TimeFrame.Hour;
@@ -66,6 +67,7 @@ namespace GeminiV26.Core.HtfBias
         public CryptoHtfBiasEngine(Robot bot)
         {
             _bot = bot ?? throw new ArgumentNullException(nameof(bot));
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
         }
 
         public HtfBiasSnapshot Get(string symbolName)
@@ -90,8 +92,8 @@ namespace GeminiV26.Core.HtfBias
             {
                 c = new CryptoBiasContext
                 {
-                    H4 = _bot.MarketData.GetBars(BiasTf, symbolName),
-                    H1 = _bot.MarketData.GetBars(UpdateTf, symbolName)
+                    H4 = _runtimeSymbols.GetBars(BiasTf, symbolName),
+                    H1 = _runtimeSymbols.GetBars(UpdateTf, symbolName)
                 };
 
                 SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "CRYPTO_HTF INIT NEUTRAL", 0.0);

--- a/Core/HtfBias/FxHtfBiasEngine.cs
+++ b/Core/HtfBias/FxHtfBiasEngine.cs
@@ -19,6 +19,7 @@ namespace GeminiV26.Core.HtfBias
     public sealed class FxHtfBiasEngine : IHtfBiasProvider
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
 
         private static readonly TimeFrame BiasTf = TimeFrame.Hour4;
         private static readonly TimeFrame UpdateTf = TimeFrame.Hour;
@@ -64,6 +65,7 @@ namespace GeminiV26.Core.HtfBias
         public FxHtfBiasEngine(Robot bot)
         {
             _bot = bot ?? throw new ArgumentNullException(nameof(bot));
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
         }
 
         public HtfBiasSnapshot Get(string symbolName)
@@ -78,8 +80,8 @@ namespace GeminiV26.Core.HtfBias
             {
                 c = new FxBiasContext
                 {
-                    H4 = _bot.MarketData.GetBars(BiasTf, symbolName),
-                    H1 = _bot.MarketData.GetBars(UpdateTf, symbolName)
+                    H4 = _runtimeSymbols.GetBars(BiasTf, symbolName),
+                    H1 = _runtimeSymbols.GetBars(UpdateTf, symbolName)
                 };
 
                 SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "FX_HTF INIT NEUTRAL", 0.50);

--- a/Core/HtfBias/IndexHtfBiasEngine.cs
+++ b/Core/HtfBias/IndexHtfBiasEngine.cs
@@ -19,6 +19,7 @@ namespace GeminiV26.Core.HtfBias
     public sealed class IndexHtfBiasEngine : IHtfBiasProvider
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
 
         private static readonly TimeFrame BiasTf = TimeFrame.Hour;
         private static readonly TimeFrame UpdateTf = TimeFrame.Minute15;
@@ -63,6 +64,7 @@ namespace GeminiV26.Core.HtfBias
         public IndexHtfBiasEngine(Robot bot)
         {
             _bot = bot ?? throw new ArgumentNullException(nameof(bot));
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
         }
 
         public HtfBiasSnapshot Get(string symbolName)
@@ -90,8 +92,8 @@ namespace GeminiV26.Core.HtfBias
 
             c = new IndexBiasContext
             {
-                H1 = _bot.MarketData.GetBars(BiasTf, symbolName),
-                M15 = _bot.MarketData.GetBars(UpdateTf, symbolName)
+                H1 = _runtimeSymbols.GetBars(BiasTf, symbolName),
+                M15 = _runtimeSymbols.GetBars(UpdateTf, symbolName)
             };
 
             SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "INDEX_HTF INIT NEUTRAL", 0.30);
@@ -393,7 +395,7 @@ namespace GeminiV26.Core.HtfBias
 
         private double GetAtrFallback(string symbolName)
         {
-            var symbol = _bot.Symbols.GetSymbol(symbolName);
+            var symbol = _runtimeSymbols.ResolveSymbol(symbolName);
             double tick = symbol?.TickSize ?? _bot.Symbol.TickSize;
             return Math.Max(tick * 50.0, 1e-6);
         }

--- a/Core/HtfBias/MetalHtfBiasEngine.cs
+++ b/Core/HtfBias/MetalHtfBiasEngine.cs
@@ -16,6 +16,7 @@ namespace GeminiV26.Core.HtfBias
     public sealed class MetalHtfBiasEngine : IHtfBiasProvider
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
 
         // === HTF settings (XAU) ===
         private static readonly TimeFrame BiasTf = TimeFrame.Hour;        // H1 bias
@@ -69,6 +70,7 @@ namespace GeminiV26.Core.HtfBias
         public MetalHtfBiasEngine(Robot bot)
         {
             _bot = bot ?? throw new ArgumentNullException(nameof(bot)); 
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
         }
 
         /*
@@ -99,8 +101,8 @@ namespace GeminiV26.Core.HtfBias
             {
                 c = new MetalBiasContext
                 {
-                    H1 = _bot.MarketData.GetBars(BiasTf, symbolName),
-                    M15 = _bot.MarketData.GetBars(UpdateTf, symbolName)
+                    H1 = _runtimeSymbols.GetBars(BiasTf, symbolName),
+                    M15 = _runtimeSymbols.GetBars(UpdateTf, symbolName)
                 };
 
                 if (c.H1 == null || c.M15 == null)

--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -16,6 +16,7 @@ namespace GeminiV26.Core.Runtime
     public sealed class RehydrateService
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly Dictionary<long, PositionContext> _registry;
         private readonly ContextRegistry _contextRegistry;
         private readonly string _botLabel;
@@ -31,6 +32,7 @@ namespace GeminiV26.Core.Runtime
             MarketMemoryEngine memoryEngine)
         {
             _bot = bot ?? throw new ArgumentNullException(nameof(bot));
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _registry = registry ?? throw new ArgumentNullException(nameof(registry));
             _contextRegistry = contextRegistry ?? throw new ArgumentNullException(nameof(contextRegistry));
             _botLabel = botLabel ?? string.Empty;
@@ -198,7 +200,7 @@ namespace GeminiV26.Core.Runtime
                 return result;
             }
 
-            var symbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var symbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (symbol == null)
             {
                 _bot.Print($"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=missing_symbol_metadata");
@@ -452,7 +454,7 @@ namespace GeminiV26.Core.Runtime
 
         private bool TryComputeBarsSinceEntry(PositionContext ctx, string symbolName, TimeFrame timeFrame)
         {
-            Bars bars = _bot.MarketData.GetBars(timeFrame, symbolName);
+            Bars bars = _runtimeSymbols.GetBars(timeFrame, symbolName);
             if (bars == null || bars.Count == 0)
                 return false;
 
@@ -470,7 +472,7 @@ namespace GeminiV26.Core.Runtime
             if (ctx.RiskPriceDistance <= 0 || ctx.FinalDirection == TradeDirection.None)
                 return false;
 
-            Bars bars = _bot.MarketData.GetBars(timeFrame, symbolName);
+            Bars bars = _runtimeSymbols.GetBars(timeFrame, symbolName);
             if (bars == null || bars.Count == 0)
                 return false;
 

--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using cAlgo.API;
+
+namespace GeminiV26.Core
+{
+    /// <summary>
+    /// Central runtime symbol access layer.
+    ///
+    /// Goals:
+    /// - keep canonical instrument names inside the strategy
+    /// - resolve broker/runtime symbol names from valid live context
+    /// - prevent scattered direct string-based Symbols.GetSymbol / MarketData.GetBars calls
+    /// </summary>
+    public sealed class RuntimeSymbolResolver
+    {
+        private readonly Robot _bot;
+        private readonly Dictionary<string, string> _runtimeNamesByCanonical = new(StringComparer.OrdinalIgnoreCase);
+
+        public RuntimeSymbolResolver(Robot bot)
+        {
+            _bot = bot ?? throw new ArgumentNullException(nameof(bot));
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            RegisterRuntimeName(_bot.SymbolName);
+            RegisterRuntimeName(_bot.Symbol?.Name);
+
+            foreach (var position in _bot.Positions)
+            {
+                RegisterRuntimeName(position?.SymbolName);
+            }
+
+            if (_bot.Symbols is IEnumerable enumerable)
+            {
+                foreach (var item in enumerable)
+                {
+                    if (item is Symbol symbol)
+                    {
+                        RegisterRuntimeName(symbol.Name);
+                    }
+                }
+            }
+        }
+
+        public bool TryResolveRuntimeName(string symbolReference, out string runtimeName)
+        {
+            runtimeName = null;
+
+            if (string.IsNullOrWhiteSpace(symbolReference))
+                return false;
+
+            Refresh();
+
+            string requested = symbolReference.Trim();
+            string canonical = SymbolRouting.NormalizeSymbol(requested);
+            if (string.IsNullOrWhiteSpace(canonical))
+                return false;
+
+            if (SymbolRouting.NormalizeSymbol(_bot.SymbolName) == canonical)
+            {
+                runtimeName = _bot.SymbolName;
+                return true;
+            }
+
+            if (_runtimeNamesByCanonical.TryGetValue(canonical, out runtimeName) && !string.IsNullOrWhiteSpace(runtimeName))
+                return true;
+
+            var directSymbol = _bot.Symbols.GetSymbol(requested);
+            if (directSymbol != null)
+            {
+                runtimeName = directSymbol.Name;
+                RegisterRuntimeName(runtimeName);
+                return true;
+            }
+
+            return false;
+        }
+
+        public Symbol ResolveSymbol(string symbolReference)
+        {
+            if (string.IsNullOrWhiteSpace(symbolReference))
+                return null;
+
+            if (SymbolRouting.NormalizeSymbol(symbolReference) == SymbolRouting.NormalizeSymbol(_bot.SymbolName))
+                return _bot.Symbol;
+
+            return TryResolveRuntimeName(symbolReference, out var runtimeName)
+                ? _bot.Symbols.GetSymbol(runtimeName)
+                : null;
+        }
+
+        public Symbol ResolveSymbol(Position position)
+        {
+            return position == null ? null : ResolveSymbol(position.SymbolName);
+        }
+
+        public Bars GetBars(TimeFrame timeFrame, string symbolReference)
+        {
+            return TryResolveRuntimeName(symbolReference, out var runtimeName)
+                ? _bot.MarketData.GetBars(timeFrame, runtimeName)
+                : null;
+        }
+
+        private void RegisterRuntimeName(string runtimeName)
+        {
+            if (string.IsNullOrWhiteSpace(runtimeName))
+                return;
+
+            string canonical = SymbolRouting.NormalizeSymbol(runtimeName);
+            if (string.IsNullOrWhiteSpace(canonical))
+                return;
+
+            _runtimeNamesByCanonical[canonical] = runtimeName;
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -73,6 +73,7 @@ namespace GeminiV26.Core
     public class TradeCore
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeRouter _router;
 
         private readonly EntryRouter _entryRouter;
@@ -289,6 +290,7 @@ namespace GeminiV26.Core
         public TradeCore(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _router = new TradeRouter(_bot);
             _symbolCanonical = SymbolRouting.NormalizeSymbol(_bot.SymbolName);
             _instrumentClass = SymbolRouting.ResolveInstrumentClass(_symbolCanonical);
@@ -1866,17 +1868,16 @@ namespace GeminiV26.Core
             if (_isMemoryReady)
                 return;
 
-            var symbols = GetAllMemorySymbols()
-                .ToDictionary(symbol => symbol, ResolveMarketDataSymbol, StringComparer.OrdinalIgnoreCase);
+            var symbols = GetAllMemorySymbols();
 
-            foreach (var pair in symbols)
+            foreach (var symbol in symbols)
             {
-                _memoryEngine.Initialize(pair.Key);
-                _memoryEngine.BuildFromHistory(pair.Key, LoadMemoryHistory(pair.Value));
+                _memoryEngine.Initialize(symbol);
+                _memoryEngine.BuildFromHistory(symbol, LoadMemoryHistory(symbol));
             }
 
             _isMemoryReady = true;
-            _bot.Print($"[MEMORY][COVERAGE] ratio={_memoryEngine.GetCoverageRatio(symbols.Keys)}");
+            _bot.Print($"[MEMORY][COVERAGE] ratio={_memoryEngine.GetCoverageRatio(symbols)}");
             _bot.Print($"[BOOT][MEMORY_READY] symbols={symbols.Count}");
         }
 
@@ -1885,7 +1886,13 @@ namespace GeminiV26.Core
             if (string.IsNullOrWhiteSpace(symbol))
                 return new List<Bar>();
 
-            Bars bars = _bot.MarketData.GetBars(TimeFrame.Minute5, symbol);
+            Bars bars = _runtimeSymbols.GetBars(TimeFrame.Minute5, symbol);
+            if (bars == null)
+            {
+                _bot.Print($"[MEMORY][SYMBOL_UNRESOLVED] canonical={NormalizeSymbol(symbol)}");
+                return new List<Bar>();
+            }
+
             return ToClosedBarList(bars);
         }
 
@@ -2344,7 +2351,16 @@ namespace GeminiV26.Core
                     exitMode = "SL";
             }
 
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
+            double pipSize = sym?.PipSize ?? (ctx?.PipSize > 0 ? ctx.PipSize : 0);
+            double exitPrice = pipSize > 0
+                ? pos.EntryPrice + pos.Pips * pipSize * (pos.TradeType == TradeType.Buy ? 1 : -1)
+                : pos.EntryPrice;
+
+            if (pipSize <= 0)
+            {
+                _bot.Print($"[EXIT][WARN] pos={pos.Id} symbol={pos.SymbolName} reason=missing_runtime_pipsize");
+            }
 
             _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[EXIT][BROKER_CLOSE_DETECTED]\nreason={MapBrokerCloseReason(args.Reason)}",
@@ -2356,7 +2372,7 @@ namespace GeminiV26.Core
                     pos,
                     args.Reason.ToString(),
                     _bot.Server.Time,
-                    pos.EntryPrice + pos.Pips * sym.PipSize * (pos.TradeType == TradeType.Buy ? 1 : -1)),
+                    exitPrice),
                 ctx,
                 pos));
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={args.Reason}\ndetail=broker_closed_event", ctx, pos));
@@ -2369,7 +2385,7 @@ namespace GeminiV26.Core
                     ExitMode = exitMode,
                     ExitReason = args.Reason.ToString(),
                     ExitTimeUtc = _bot.Server.Time,
-                    ExitPrice = pos.EntryPrice + pos.Pips * sym.PipSize * (pos.TradeType == TradeType.Buy ? 1 : -1),
+                    ExitPrice = exitPrice,
                     NetProfit = pos.NetProfit,
                     GrossProfit = pos.GrossProfit,
                     Commissions = pos.Commissions,
@@ -2523,23 +2539,6 @@ namespace GeminiV26.Core
                 .Where(symbol => !string.IsNullOrWhiteSpace(symbol))
                 .OrderBy(symbol => symbol, StringComparer.OrdinalIgnoreCase)
                 .ToList();
-        }
-
-        private static string ResolveMarketDataSymbol(string canonicalSymbol)
-        {
-            if (string.IsNullOrWhiteSpace(canonicalSymbol))
-                return string.Empty;
-
-            return canonicalSymbol.ToUpperInvariant() switch
-            {
-                "NAS100" => "NAS100",
-                "US30" => "US30",
-                "GER40" => "GER40",
-                "XAUUSD" => "XAUUSD",
-                "BTCUSD" => "BTCUSD",
-                "ETHUSD" => "ETHUSD",
-                _ => canonicalSymbol.ToUpperInvariant()
-            };
         }
 
         private bool RegisterRehydratedContextWithExitManager(PositionContext ctx)

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.AUDNZD
     public class AudNzdExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.AUDNZD
         public AudNzdExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.AUDNZD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.AUDNZD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.AUDUSD
     public class AudUsdExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.AUDUSD
         public AudUsdExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.AUDUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.AUDUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -18,6 +18,7 @@ namespace GeminiV26.Instruments.BTCUSD
     public class BtcUsdExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
 
         // PositionId -> context
         private readonly Dictionary<long, PositionContext> _contexts = new();
@@ -42,6 +43,7 @@ namespace GeminiV26.Instruments.BTCUSD
         public BtcUsdExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -92,7 +94,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -134,7 +136,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -182,7 +184,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -213,8 +215,8 @@ namespace GeminiV26.Instruments.BTCUSD
 
                         if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                         {
-                            var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                            var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                            var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                            var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                             if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                             {
@@ -275,7 +277,7 @@ namespace GeminiV26.Instruments.BTCUSD
         // =========================================================
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 
@@ -474,7 +476,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
             SafeModify(pos, pos.StopLoss, newTp);
 
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} " +
                 $"direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym?.Bid : sym?.Ask)} " +

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -12,6 +12,7 @@ namespace GeminiV26.Instruments.ETHUSD
     public class EthUsdExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
 
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
@@ -34,6 +35,7 @@ namespace GeminiV26.Instruments.ETHUSD
         public EthUsdExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
 
             _tvm = new TradeViabilityMonitor(bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
@@ -79,7 +81,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -118,7 +120,7 @@ namespace GeminiV26.Instruments.ETHUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -167,7 +169,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -194,8 +196,8 @@ namespace GeminiV26.Instruments.ETHUSD
 
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -262,7 +264,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
 
             if (sym == null)
                 return;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.EURJPY
     public class EurJpyExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.EURJPY
         public EurJpyExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.EURJPY
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.EURJPY
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.EURJPY
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.EURJPY
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.EURJPY
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.EURUSD
     public class EurUsdExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.EURUSD
         public EurUsdExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.EURUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.EURUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.EURUSD
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.EURUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.EURUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.GBPJPY
     public class GbpJpyExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.GBPJPY
         public GbpJpyExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.GBPJPY
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.GBPJPY
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.GBPUSD
     public class GbpUsdExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.GBPUSD
         public GbpUsdExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.GBPUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.GBPUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.GER40
     public class Ger40ExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.GER40
         public Ger40ExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.GER40
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.GER40
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.GER40
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.GER40
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.GER40
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.NAS100
     public class NasExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.NAS100
         public NasExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.NAS100
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.NAS100
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.NAS100
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.NAS100
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.NAS100
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.NZDUSD
     public class NzdUsdExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.NZDUSD
         public NzdUsdExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.NZDUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.NZDUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.US30
     public class Us30ExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.US30
         public Us30ExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.US30
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.US30
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.US30
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.US30
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.US30
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.USDCAD
     public class UsdCadExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.USDCAD
         public UsdCadExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.USDCAD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.USDCAD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.USDCAD
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.USDCAD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.USDCAD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.USDCHF
     public class UsdChfExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.USDCHF
         public UsdChfExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.USDCHF
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.USDCHF
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.USDCHF
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.USDCHF
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.USDCHF
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -11,6 +11,7 @@ namespace GeminiV26.Instruments.USDJPY
     public class UsdJpyExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
         private readonly AdaptiveTrailingEngine _adaptiveTrailingEngine;
@@ -23,6 +24,7 @@ namespace GeminiV26.Instruments.USDJPY
         public UsdJpyExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _tvm = new TradeViabilityMonitor(_bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
             _adaptiveTrailingEngine = new AdaptiveTrailingEngine(_bot);
@@ -62,7 +64,7 @@ namespace GeminiV26.Instruments.USDJPY
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(position.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -101,7 +103,7 @@ namespace GeminiV26.Instruments.USDJPY
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -146,7 +148,7 @@ namespace GeminiV26.Instruments.USDJPY
 
                     if (!reached)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -167,8 +169,8 @@ namespace GeminiV26.Instruments.USDJPY
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.USDJPY
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -35,6 +35,7 @@ namespace GeminiV26.Instruments.XAUUSD
     public class XauExitManager
     {
         private readonly Robot _bot;
+        private readonly RuntimeSymbolResolver _runtimeSymbols;
         private readonly EventLogger _eventLogger;
 
         // Profile (matrixból) – TP1/BE paraméterek innen jönnek
@@ -52,6 +53,7 @@ namespace GeminiV26.Instruments.XAUUSD
         public XauExitManager(Robot bot)
         {
             _bot = bot;
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _eventLogger = new EventLogger(bot.SymbolName);
             _tvm = new TradeViabilityMonitor(bot);
             _trendTradeManager = new TrendTradeManager(_bot, _bot.Bars);
@@ -104,7 +106,7 @@ namespace GeminiV26.Instruments.XAUUSD
             // =====================================================
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var stateSymbol = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (stateSymbol != null)
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
@@ -158,7 +160,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
                 if (sym == null)
                     continue;
 
@@ -211,7 +213,7 @@ namespace GeminiV26.Instruments.XAUUSD
                                         
                     if (!hit)
                     {
-                        var m1 = _bot.MarketData.GetBars(TimeFrame.Minute, pos.SymbolName);
+                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
 
                         if (m1 != null && m1.Count > 0)
                         {
@@ -234,8 +236,8 @@ namespace GeminiV26.Instruments.XAUUSD
                     
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _bot.MarketData.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _bot.MarketData.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
+                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -294,7 +296,7 @@ namespace GeminiV26.Instruments.XAUUSD
         // =====================================================
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 
@@ -352,7 +354,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 
@@ -390,7 +392,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (!pos.StopLoss.HasValue)
                 return;
 
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             if (sym == null)
                 return;
 
@@ -545,7 +547,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
                 return;
 
-            var sym = _bot.Symbols.GetSymbol(pos.SymbolName);
+            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
             double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
             double desiredR = baseR * decision.Tp2ExtensionMultiplier;
             double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;


### PR DESCRIPTION
### Motivation
- Eliminate scattered direct string-based runtime symbol access (e.g. `Symbols.GetSymbol("...")`, `MarketData.GetBars(..., symbol)`) that allowed broker-specific aliasing to bypass the instrument/runtime layer and caused issues like the GER40 symptom. 
- Provide a single, auditable runtime access layer that resolves broker runtime symbol names from valid context (active chart, live positions, runtime catalog) and prevents silent/hacked fallbacks.
- Keep entry/exit/risk behaviour unchanged while removing unsafe string-based lookups project-wide.

### Description
- Added a central `RuntimeSymbolResolver` (`Core/RuntimeSymbolResolver.cs`) that discovers and maps canonical -> runtime names and exposes `ResolveSymbol(...)` and `GetBars(...)` helpers. 
- Replaced direct runtime lookups with resolver usage in core lifecycle and instrument-critical places including `Core/TradeCore.cs`, `Core/Runtime/RehydrateService.cs`, `Core/Entry/EntryContextBuilder.cs`, and all HTF bias engines (`Core/HtfBias/*`), so bar and symbol metadata access now goes through the resolver. 
- Updated all instrument exit managers to use `_runtimeSymbols.ResolveSymbol(...)` and `_runtimeSymbols.GetBars(...)` instead of `Symbols.GetSymbol(...)` / `MarketData.GetBars(..., pos.SymbolName)` (multiple files under `Instruments/*` were changed); memory bootstrap mapping method was removed in favor of resolver-based history loading and explicit unresolved-symbol logging. 
- Behavioural constraints preserved: no broker-specific hardcoded mappings, no GER40-specific patch, no changes to entry/exit/risk logic; unresolved symbols intentionally return `null` and emit logs rather than performing silent fallbacks.

### Testing
- Ran a repo-wide audit using pattern searches and a Python-based check to confirm no direct `Symbols.GetSymbol(...)`, `MarketData.GetSymbol(...)` or `MarketData.GetBars(..., symbol)` remain outside `Core/RuntimeSymbolResolver.cs`, and the audit passed. 
- Performed `git diff --check` and `git status` validations and committed the changes (`Centralize runtime symbol resolution`). 
- Attempted to run `dotnet build` but `dotnet` is not available in this environment, so a full compile was not executed (manual/CI build required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a99ce1b08328a64c5779cb16b52f)