### PR TITLE
Fix runtime symbol resolution and persist position pip size

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -95,6 +95,8 @@ namespace GeminiV26.Core
 
         public double EntryPrice { get; set; }
 
+        public double PipSize { get; set; }
+
         // =========================
         // TP / state flags
         // =========================

--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -348,6 +348,7 @@ namespace GeminiV26.Core.Runtime
                 EntryTimeUtc = position.EntryTime.ToUniversalTime(),
                 EntryPrice = entryPrice,
                 RiskPriceDistance = riskDistance,
+                PipSize = symbol.PipSize,
                 Tp1Hit = tp1Hit,
                 Tp1Executed = tp1Hit,
                 Tp1CloseFraction = 0,

--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 
 namespace GeminiV26.Core
 {

--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -219,6 +219,7 @@ namespace GeminiV26.Instruments.AUDNZD
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -216,6 +216,7 @@ namespace GeminiV26.Instruments.AUDUSD
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -209,6 +209,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,
                 RemainingVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -209,6 +209,7 @@ namespace GeminiV26.Instruments.ETHUSD
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,
                 RemainingVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -216,6 +216,7 @@ namespace GeminiV26.Instruments.EURJPY
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -205,6 +205,7 @@ namespace GeminiV26.Instruments.EURUSD
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -216,6 +216,7 @@ namespace GeminiV26.Instruments.GBPJPY
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -229,6 +229,7 @@ namespace GeminiV26.Instruments.GBPUSD
                 EntryPrice = result.Position.EntryPrice,
 
                 RiskPriceDistance = slPriceDist, // now consistent with sizing & SL & TP
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Hit = false,

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -200,6 +200,7 @@ namespace GeminiV26.Instruments.GER40
                 EntryPrice = result.Position.EntryPrice,
 
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -209,6 +209,7 @@ namespace GeminiV26.Instruments.NAS100
                 EntryPrice = result.Position.EntryPrice,
 
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -216,6 +216,7 @@ namespace GeminiV26.Instruments.NZDUSD
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -185,6 +185,7 @@ namespace GeminiV26.Instruments.US30
 
                 // TP1 fix: keep full R-context so ExitManager can evaluate TP1 deterministically
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -216,6 +216,7 @@ namespace GeminiV26.Instruments.USDCAD
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -216,6 +216,7 @@ namespace GeminiV26.Instruments.USDCHF
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -206,6 +206,7 @@ namespace GeminiV26.Instruments.USDJPY
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
                 RiskPriceDistance = slPriceDist,
+                PipSize = entryContext.PipSize,
 
                 Tp1R = tp1R,
                 Tp1Ratio = tp1Ratio,

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -524,6 +524,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
                     // SSOT snapshot
                     RiskPriceDistance = rDist,
+                    PipSize = bot.Symbol.PipSize,
                     LastStopLossPrice = pos.StopLoss.Value,
 
                     Tp1Hit = false,

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -153,6 +153,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 EntryPrice = tradeType == TradeType.Buy
                     ? _bot.Symbol.Ask
                     : _bot.Symbol.Bid,
+                PipSize = entryContext.PipSize > 0 ? entryContext.PipSize : _bot.Symbol.PipSize,
 
                 // TP1 policy (Phase 3.7.x – determinisztikus XAU)
                 Tp1Hit = false,
@@ -296,6 +297,7 @@ namespace GeminiV26.Instruments.XAUUSD
             // =====================================================
             ctx.PositionId = result.Position.Id;
             ctx.EntryPrice = result.Position.EntryPrice;
+            ctx.PipSize = entryContext.PipSize > 0 ? entryContext.PipSize : _bot.Symbol.PipSize;
 
             ctx.EntryVolumeInUnits = result.Position.VolumeInUnits;
             ctx.RemainingVolumeInUnits = result.Position.VolumeInUnits;


### PR DESCRIPTION
### Motivation

- Runtime symbol lookups were failing because `RuntimeSymbolResolver` lacked the `cAlgo.API.Internals` import required to resolve `Symbol` metadata.  
- `PositionContext` no longer contained a stored `PipSize`, which broke exit-price fallback and caused compilation/runtime inconsistencies.  
- Executors and rehydrate paths must persist the position-level pip precision so exit and logging code can compute exit prices reliably after creation or restart.

### Description

- Added `using cAlgo.API.Internals;` to `Core/RuntimeSymbolResolver.cs` so `Symbol` metadata and `MarketData` lookups resolve correctly.  
- Added `public double PipSize { get; set; }` to `Core/PositionContext.cs` to store per-position pip precision.  
- Propagated and persisted `PipSize` from `EntryContext` into newly created `PositionContext` instances across instrument executors (multiple files under `Instruments/*`) and set `PipSize` on rehydrated contexts in `Core/Runtime/RehydrateService.cs` and XAU rehydrate/exit snapshots in `Instruments/XAUUSD/*`.  
- In the XAU executor, use `entryContext.PipSize` when > 0 otherwise fall back to `_bot.Symbol.PipSize` to keep behavior safe when entry context lacks a runtime pip value.

### Testing

- Ran `git diff --check` which reported no spacing or patch errors.  
- Verified changes and occurrences with repository searches (ripgrep) to confirm `PipSize =` assignments were added to the intended files.  
- Attempted `dotnet build -v minimal` but the environment does not have `dotnet` installed, so a full compile was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1adcdae648328b7a8e240cac7b25a)