### PR TITLE
Add runtime symbol resolver guard layer and explicit fallback logging

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -275,8 +275,11 @@ namespace GeminiV26.Core.Entry
             = SessionMatrixDefaults.Neutral;
 
         // =========================
-        // MEMORY
+        // MEMORY / RESOLVER SNAPSHOT
         // =========================
+        public bool RuntimeResolved { get; set; }
+        public bool MemoryResolved { get; set; }
+        public bool MemoryUsable { get; set; }
         public SymbolMemoryState MemoryState { get; set; }
         public MemoryAssessment MemoryAssessment { get; set; }
 

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -69,12 +69,18 @@ namespace GeminiV26.Core.Entry
             // -------------------------
             // BAR DATA
             // -------------------------
-            ctx.M1 = _runtimeSymbols.GetBars(TimeFrame.Minute, symbol);
-            ctx.M5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, symbol);
-            ctx.M15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, symbol);
-
-            if (ctx.M1 == null || ctx.M5 == null || ctx.M15 == null)
+            if (!_runtimeSymbols.TryGetBars(TimeFrame.Minute, symbol, out var m1) ||
+                !_runtimeSymbols.TryGetBars(TimeFrame.Minute5, symbol, out var m5) ||
+                !_runtimeSymbols.TryGetBars(TimeFrame.Minute15, symbol, out var m15))
+            {
+                _bot.Print($"[RESOLVER][ENTRY_BLOCK] symbol={symbol} reason=unresolved_runtime_symbol");
                 return ctx;
+            }
+
+            ctx.M1 = m1;
+            ctx.M5 = m5;
+            ctx.M15 = m15;
+            ctx.RuntimeResolved = true;
 
             if (ctx.M1.Count < 10 || ctx.M5.Count < 30 || ctx.M15.Count < 30)
                 return ctx;
@@ -103,10 +109,15 @@ namespace GeminiV26.Core.Entry
                 (atr_m5.Result[m5Idx - 2] - atr_m5.Result[m5Idx - 4]);
 
             // pip konverzió
-            var sym = _runtimeSymbols.ResolveSymbol(symbol);
-            double pipSize = sym?.PipSize ?? 0;
+            if (!_runtimeSymbols.TryGetPipSize(symbol, out double pipSize) ||
+                !_runtimeSymbols.TryGetSymbolMeta(symbol, out _))
+            {
+                ctx.RuntimeResolved = false;
+                _bot.Print($"[RESOLVER][ENTRY_BLOCK] symbol={symbol} reason=unresolved_runtime_symbol");
+                return ctx;
+            }
 
-            ctx.PipSize = pipSize;   // <<< EZ AZ ÚJ SOR
+            ctx.PipSize = pipSize;
 
             ctx.AtrPips_M5 = (pipSize > 0)
                 ? (ctx.AtrM5 / pipSize)

--- a/Core/HtfBias/CryptoHtfBiasEngine.cs
+++ b/Core/HtfBias/CryptoHtfBiasEngine.cs
@@ -77,30 +77,25 @@ namespace GeminiV26.Core.HtfBias
             if (_ctx.TryGetValue(symbolName, out var c))
                 return c.Snapshot;
 
-            return new HtfBiasSnapshot
-            {
-                State = HtfBiasState.Neutral,
-                AllowedDirection = TradeDirection.None,
-                Confidence01 = 0.0,
-                Reason = "CRYPTO_HTF NOT_READY"
-            };
+            return CreateUnavailableSnapshot(symbolName);
         }
 
         private void UpdateIfNeeded(string symbolName)
         {
             if (!_ctx.TryGetValue(symbolName, out var c))
             {
-                c = new CryptoBiasContext
-                {
-                    H4 = _runtimeSymbols.GetBars(BiasTf, symbolName),
-                    H1 = _runtimeSymbols.GetBars(UpdateTf, symbolName)
-                };
-
+                c = new CryptoBiasContext();
+                _ctx[symbolName] = c;
                 SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "CRYPTO_HTF INIT NEUTRAL", 0.0);
 
-                if (c.H4 == null || c.H1 == null)
+                if (!_runtimeSymbols.TryGetBars(BiasTf, symbolName, out c.H4) ||
+                    !_runtimeSymbols.TryGetBars(UpdateTf, symbolName, out c.H1))
                 {
-                    _ctx[symbolName] = c;
+                    var unavailable = CreateUnavailableSnapshot(symbolName);
+                    c.Snapshot.State = unavailable.State;
+                    c.Snapshot.AllowedDirection = unavailable.AllowedDirection;
+                    c.Snapshot.Confidence01 = unavailable.Confidence01;
+                    c.Snapshot.Reason = unavailable.Reason;
                     return;
                 }
 
@@ -430,6 +425,18 @@ namespace GeminiV26.Core.HtfBias
             snapshot.Confidence01 = Clamp01(confidence01);
         }
 
+
+        private HtfBiasSnapshot CreateUnavailableSnapshot(string symbolName)
+        {
+            _bot.Print($"[RESOLVER][HTF_FAIL] symbol={symbolName} reason=unresolved_runtime_symbol");
+            return new HtfBiasSnapshot
+            {
+                State = HtfBiasState.Neutral,
+                AllowedDirection = TradeDirection.None,
+                Confidence01 = 0.0,
+                Reason = "HTF_UNAVAILABLE unresolved_runtime_symbol"
+            };
+        }
         private static double Clamp01(double value)
         {
             if (value < 0.0)

--- a/Core/HtfBias/FxHtfBiasEngine.cs
+++ b/Core/HtfBias/FxHtfBiasEngine.cs
@@ -71,26 +71,32 @@ namespace GeminiV26.Core.HtfBias
         public HtfBiasSnapshot Get(string symbolName)
         {
             UpdateIfNeeded(symbolName);
-            return _ctx[symbolName].Snapshot;
+            return _ctx.TryGetValue(symbolName, out var context)
+                ? context.Snapshot
+                : CreateUnavailableSnapshot(symbolName);
         }
 
         private void UpdateIfNeeded(string symbolName)
         {
             if (!_ctx.TryGetValue(symbolName, out var c))
             {
-                c = new FxBiasContext
-                {
-                    H4 = _runtimeSymbols.GetBars(BiasTf, symbolName),
-                    H1 = _runtimeSymbols.GetBars(UpdateTf, symbolName)
-                };
-
+                c = new FxBiasContext();
+                _ctx[symbolName] = c;
                 SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "FX_HTF INIT NEUTRAL", 0.50);
 
-                if (c.H4 == null || c.H4.Count < EmaSlow + 8 || c.H1 == null || c.H1.Count < 10)
+                if (!_runtimeSymbols.TryGetBars(BiasTf, symbolName, out c.H4) ||
+                    !_runtimeSymbols.TryGetBars(UpdateTf, symbolName, out c.H1))
                 {
-                    _ctx[symbolName] = c;
+                    var unavailable = CreateUnavailableSnapshot(symbolName);
+                    c.Snapshot.State = unavailable.State;
+                    c.Snapshot.AllowedDirection = unavailable.AllowedDirection;
+                    c.Snapshot.Confidence01 = unavailable.Confidence01;
+                    c.Snapshot.Reason = unavailable.Reason;
                     return;
                 }
+
+                if (c.H4.Count < EmaSlow + 8 || c.H1.Count < 10)
+                    return;
 
                 c.Ema50 = _bot.Indicators.ExponentialMovingAverage(c.H4.ClosePrices, EmaFast);
                 c.Ema200 = _bot.Indicators.ExponentialMovingAverage(c.H4.ClosePrices, EmaSlow);
@@ -355,6 +361,18 @@ namespace GeminiV26.Core.HtfBias
             snap.Confidence01 = Clamp01(conf01);
         }
 
+
+        private HtfBiasSnapshot CreateUnavailableSnapshot(string symbolName)
+        {
+            _bot.Print($"[RESOLVER][HTF_FAIL] symbol={symbolName} reason=unresolved_runtime_symbol");
+            return new HtfBiasSnapshot
+            {
+                State = HtfBiasState.Neutral,
+                AllowedDirection = TradeDirection.None,
+                Confidence01 = 0.0,
+                Reason = "HTF_UNAVAILABLE unresolved_runtime_symbol"
+            };
+        }
         private static double Clamp01(double v) => v < 0 ? 0 : (v > 1 ? 1 : v);
     }
 }

--- a/Core/HtfBias/IndexHtfBiasEngine.cs
+++ b/Core/HtfBias/IndexHtfBiasEngine.cs
@@ -71,15 +71,7 @@ namespace GeminiV26.Core.HtfBias
         {
             var c = EnsureContext(symbolName);
             if (c == null)
-            {
-                return new HtfBiasSnapshot
-                {
-                    State = HtfBiasState.Neutral,
-                    AllowedDirection = TradeDirection.None,
-                    Confidence01 = 0.25,
-                    Reason = "INDEX_HTF INIT NEUTRAL (context unavailable)"
-                };
-            }
+                return CreateUnavailableSnapshot(symbolName);
 
             UpdateIfNeeded(symbolName, c);
             return c.Snapshot;
@@ -90,17 +82,20 @@ namespace GeminiV26.Core.HtfBias
             if (_ctx.TryGetValue(symbolName, out var c))
                 return c;
 
-            c = new IndexBiasContext
-            {
-                H1 = _runtimeSymbols.GetBars(BiasTf, symbolName),
-                M15 = _runtimeSymbols.GetBars(UpdateTf, symbolName)
-            };
-
+            c = new IndexBiasContext();
             SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "INDEX_HTF INIT NEUTRAL", 0.30);
             _ctx[symbolName] = c;
 
-            if (c.H1 == null || c.M15 == null)
+            if (!_runtimeSymbols.TryGetBars(BiasTf, symbolName, out c.H1) ||
+                !_runtimeSymbols.TryGetBars(UpdateTf, symbolName, out c.M15))
+            {
+                var unavailable = CreateUnavailableSnapshot(symbolName);
+                c.Snapshot.State = unavailable.State;
+                c.Snapshot.AllowedDirection = unavailable.AllowedDirection;
+                c.Snapshot.Confidence01 = unavailable.Confidence01;
+                c.Snapshot.Reason = unavailable.Reason;
                 return c;
+            }
 
             c.Ema21 = _bot.Indicators.ExponentialMovingAverage(c.H1.ClosePrices, EmaImpulse);
             c.Ema50 = _bot.Indicators.ExponentialMovingAverage(c.H1.ClosePrices, EmaStructure);
@@ -395,8 +390,9 @@ namespace GeminiV26.Core.HtfBias
 
         private double GetAtrFallback(string symbolName)
         {
-            var symbol = _runtimeSymbols.ResolveSymbol(symbolName);
-            double tick = symbol?.TickSize ?? _bot.Symbol.TickSize;
+            double tick = _runtimeSymbols.TryGetSymbolMeta(symbolName, out var symbol)
+                ? symbol.TickSize
+                : _bot.Symbol.TickSize;
             return Math.Max(tick * 50.0, 1e-6);
         }
 
@@ -408,6 +404,18 @@ namespace GeminiV26.Core.HtfBias
             snap.Confidence01 = Clamp01(conf01);
         }
 
+
+        private HtfBiasSnapshot CreateUnavailableSnapshot(string symbolName)
+        {
+            _bot.Print($"[RESOLVER][HTF_FAIL] symbol={symbolName} reason=unresolved_runtime_symbol");
+            return new HtfBiasSnapshot
+            {
+                State = HtfBiasState.Neutral,
+                AllowedDirection = TradeDirection.None,
+                Confidence01 = 0.0,
+                Reason = "HTF_UNAVAILABLE unresolved_runtime_symbol"
+            };
+        }
         private static double Clamp01(double value)
         {
             if (value < 0) return 0;

--- a/Core/HtfBias/MetalHtfBiasEngine.cs
+++ b/Core/HtfBias/MetalHtfBiasEngine.cs
@@ -92,29 +92,38 @@ namespace GeminiV26.Core.HtfBias
         public HtfBiasSnapshot Get(string symbolName)
         {
             UpdateIfNeeded(symbolName);
-            return _ctx[symbolName].Snapshot;
+            return _ctx.TryGetValue(symbolName, out var context)
+                ? context.Snapshot
+                : CreateUnavailableSnapshot(symbolName);
         }
 
         private void UpdateIfNeeded(string symbolName)
         {
             if (!_ctx.TryGetValue(symbolName, out var c))
             {
-                c = new MetalBiasContext
-                {
-                    H1 = _runtimeSymbols.GetBars(BiasTf, symbolName),
-                    M15 = _runtimeSymbols.GetBars(UpdateTf, symbolName)
-                };
+                c = new MetalBiasContext();
+                _ctx[symbolName] = c;
 
-                if (c.H1 == null || c.M15 == null)
+                if (!_runtimeSymbols.TryGetBars(BiasTf, symbolName, out c.H1) ||
+                    !_runtimeSymbols.TryGetBars(UpdateTf, symbolName, out c.M15))
+                {
+                    var unavailable = CreateUnavailableSnapshot(symbolName);
+                    c.Snapshot.State = unavailable.State;
+                    c.Snapshot.AllowedDirection = unavailable.AllowedDirection;
+                    c.Snapshot.Confidence01 = unavailable.Confidence01;
+                    c.Snapshot.Reason = unavailable.Reason;
                     return;
+                }
 
                 c.Ema21 = _bot.Indicators.ExponentialMovingAverage(c.H1.ClosePrices, EmaFast);
                 c.Ema55 = _bot.Indicators.ExponentialMovingAverage(c.H1.ClosePrices, EmaSlow);
                 c.AtrH1 = _bot.Indicators.AverageTrueRange(c.H1, 14, MovingAverageType.Exponential);
                 c.Dms = _bot.Indicators.DirectionalMovementSystem(c.H1, 14);
 
-                _ctx[symbolName] = c;
             }
+
+            if (c.M15 == null || c.H1 == null || c.Ema21 == null || c.Ema55 == null || c.AtrH1 == null || c.Dms == null)
+                return;
 
             if (c.M15.Count < 10 || c.H1.Count < Math.Max(EmaSlow, 80))
                 return;
@@ -241,6 +250,18 @@ namespace GeminiV26.Core.HtfBias
             snap.Confidence01 = Clamp01(conf01);
         }
 
+
+        private HtfBiasSnapshot CreateUnavailableSnapshot(string symbolName)
+        {
+            _bot.Print($"[RESOLVER][HTF_FAIL] symbol={symbolName} reason=unresolved_runtime_symbol");
+            return new HtfBiasSnapshot
+            {
+                State = HtfBiasState.Neutral,
+                AllowedDirection = TradeDirection.None,
+                Confidence01 = 0.0,
+                Reason = "HTF_UNAVAILABLE unresolved_runtime_symbol"
+            };
+        }
         private static double Clamp01(double v) => v < 0 ? 0 : (v > 1 ? 1 : v);
     }
 }

--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -80,6 +80,9 @@ namespace GeminiV26.Core.Logging
                    $"isLateMove={ToLower(ctx?.MemoryAssessment?.IsLateMove ?? false)}\n" +
                    $"isChaseRisk={ToLower(ctx?.MemoryAssessment?.IsChaseRisk ?? false)}\n" +
                    $"contextTrust={FormatScore(ctx?.MemoryAssessment?.ContextTrustScore ?? 0)}\n" +
+                   $"runtimeResolved={ToLower(ctx?.RuntimeResolved ?? false)}\n" +
+                   $"memoryResolved={ToLower(ctx?.MemoryResolved ?? false)}\n" +
+                   $"memoryUsable={ToLower(ctx?.MemoryUsable ?? false)}\n" +
                    $"restartPhase={ResolveRestartPhase(ctx)}";
         }
 

--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -279,6 +279,8 @@ namespace GeminiV26.Core
 
         public MemoryTrustLevel ContextTrust { get; set; } = MemoryTrustLevel.Unknown;
 
+        public bool RuntimeSymbolAvailable { get; set; } = true;
+
         // =========================================================
         // FinalConfidence calculation
         // =========================================================

--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -200,13 +200,44 @@ namespace GeminiV26.Core.Runtime
                 return result;
             }
 
-            var symbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (symbol == null)
+            if (!_runtimeSymbols.TryGetSymbolMeta(position.SymbolName, out var symbol))
             {
+                _bot.Print($"[REHYDRATE][RESOLVER_FAIL] symbol={position.SymbolName} positionId={positionKey}");
                 _bot.Print($"[REHYDRATE_WARN] pos={positionKey} symbol={position.SymbolName} reason=missing_symbol_metadata");
                 _bot.Print(TradeLogIdentity.WithPositionIds("[REHYDRATE][WARN]\nreason=missing_symbol_metadata", positionKey, position.Comment, position.SymbolName));
+
+                var unresolvedContext = new PositionContext
+                {
+                    PositionId = positionKey,
+                    Symbol = position.SymbolName,
+                    TempId = position.Comment ?? string.Empty,
+                    EntryType = "REHYDRATED",
+                    EntryReason = "Startup rehydrate from live open position",
+                    FinalDirection = position.TradeType == TradeType.Buy ? TradeDirection.Long : TradeDirection.Short,
+                    EntryScore = 50,
+                    LogicConfidence = 50,
+                    EntryTime = position.EntryTime,
+                    EntryTimeUtc = position.EntryTime.ToUniversalTime(),
+                    EntryPrice = position.EntryPrice,
+                    RemainingVolumeInUnits = position.VolumeInUnits,
+                    InitialVolumeInUnits = position.VolumeInUnits,
+                    EntryVolumeInUnits = position.VolumeInUnits,
+                    IsRehydrated = true,
+                    RehydratedAtUtc = _bot.Server.Time.ToUniversalTime(),
+                    RehydrateSource = "LiveOpenPosition",
+                    ContextTrust = MemoryTrustLevel.Low,
+                    RuntimeSymbolAvailable = false,
+                    MarketTrend = true,
+                    Adx_M5 = 0
+                };
+                unresolvedContext.ComputeFinalConfidence();
+                result.Context = unresolvedContext;
+                result.UsedFallback = true;
+                result.DefaultedLifecycleFields = true;
                 return result;
             }
+
+            _bot.Print($"[REHYDRATE][RESOLVER_OK] symbol={position.SymbolName} positionId={positionKey}");
 
             double entryPrice = position.EntryPrice;
             if (!IsFinitePositive(entryPrice))
@@ -368,12 +399,14 @@ namespace GeminiV26.Core.Runtime
                 RehydratedAtUtc = _bot.Server.Time.ToUniversalTime(),
                 RehydrateSource = "LiveOpenPosition",
                 MarketTrend = direction != TradeDirection.None,
-                Adx_M5 = 0
+                Adx_M5 = 0,
+                RuntimeSymbolAvailable = true
             };
 
             // AGENTS rule: PositionContext létrehozás után azonnal számoljuk a FinalConfidence-t.
             ctx.ComputeFinalConfidence();
-            AttachMemoryState(ctx, position.SymbolName, ref defaultedLifecycleFields);
+            if (ctx.RuntimeSymbolAvailable)
+                AttachMemoryState(ctx, position.SymbolName, ref defaultedLifecycleFields);
             RebuildTradeExcursions(ctx, position);
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, position));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, position));
@@ -455,7 +488,12 @@ namespace GeminiV26.Core.Runtime
 
         private bool TryComputeBarsSinceEntry(PositionContext ctx, string symbolName, TimeFrame timeFrame)
         {
-            Bars bars = _runtimeSymbols.GetBars(timeFrame, symbolName);
+            if (!_runtimeSymbols.TryGetBars(timeFrame, symbolName, out Bars bars))
+            {
+                _bot.Print($"[REHYDRATE][RESOLVER_FAIL] symbol={symbolName} positionId={ctx.PositionId}");
+                return false;
+            }
+
             if (bars == null || bars.Count == 0)
                 return false;
 
@@ -473,7 +511,12 @@ namespace GeminiV26.Core.Runtime
             if (ctx.RiskPriceDistance <= 0 || ctx.FinalDirection == TradeDirection.None)
                 return false;
 
-            Bars bars = _runtimeSymbols.GetBars(timeFrame, symbolName);
+            if (!_runtimeSymbols.TryGetBars(timeFrame, symbolName, out Bars bars))
+            {
+                _bot.Print($"[REHYDRATE][RESOLVER_FAIL] symbol={symbolName} positionId={ctx.PositionId}");
+                return false;
+            }
+
             if (bars == null || bars.Count == 0)
                 return false;
 

--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -51,46 +51,112 @@ namespace GeminiV26.Core
         {
             runtimeName = null;
 
-            if (string.IsNullOrWhiteSpace(symbolReference))
-                return false;
-
-            Refresh();
-
-            string requested = symbolReference.Trim();
-            string canonical = SymbolRouting.NormalizeSymbol(requested);
-            if (string.IsNullOrWhiteSpace(canonical))
-                return false;
-
-            if (SymbolRouting.NormalizeSymbol(_bot.SymbolName) == canonical)
+            try
             {
-                runtimeName = _bot.SymbolName;
-                return true;
+                if (string.IsNullOrWhiteSpace(symbolReference))
+                    return false;
+
+                Refresh();
+
+                string requested = symbolReference.Trim();
+                string canonical = SymbolRouting.NormalizeSymbol(requested);
+                if (string.IsNullOrWhiteSpace(canonical))
+                    return false;
+
+                if (SymbolRouting.NormalizeSymbol(_bot.SymbolName) == canonical)
+                {
+                    runtimeName = _bot.SymbolName;
+                    return true;
+                }
+
+                if (_runtimeNamesByCanonical.TryGetValue(canonical, out runtimeName) && !string.IsNullOrWhiteSpace(runtimeName))
+                    return true;
+
+                var directSymbol = _bot.Symbols.GetSymbol(requested);
+                if (directSymbol != null)
+                {
+                    runtimeName = directSymbol.Name;
+                    RegisterRuntimeName(runtimeName);
+                    return true;
+                }
+            }
+            catch
+            {
+                runtimeName = null;
+                return false;
             }
 
-            if (_runtimeNamesByCanonical.TryGetValue(canonical, out runtimeName) && !string.IsNullOrWhiteSpace(runtimeName))
-                return true;
-
-            var directSymbol = _bot.Symbols.GetSymbol(requested);
-            if (directSymbol != null)
-            {
-                runtimeName = directSymbol.Name;
-                RegisterRuntimeName(runtimeName);
-                return true;
-            }
-
+            runtimeName = null;
             return false;
+        }
+
+        public bool TryResolveSymbol(string symbolReference, out Symbol symbol)
+        {
+            symbol = null;
+
+            try
+            {
+                if (string.IsNullOrWhiteSpace(symbolReference))
+                    return false;
+
+                if (SymbolRouting.NormalizeSymbol(symbolReference) == SymbolRouting.NormalizeSymbol(_bot.SymbolName))
+                {
+                    symbol = _bot.Symbol;
+                    return symbol != null;
+                }
+
+                if (!TryResolveRuntimeName(symbolReference, out var runtimeName))
+                    return false;
+
+                symbol = _bot.Symbols.GetSymbol(runtimeName);
+                return symbol != null;
+            }
+            catch
+            {
+                symbol = null;
+                return false;
+            }
+        }
+
+        public bool TryGetBars(TimeFrame timeFrame, string symbolReference, out Bars bars)
+        {
+            bars = null;
+
+            try
+            {
+                if (!TryResolveRuntimeName(symbolReference, out var runtimeName))
+                    return false;
+
+                bars = _bot.MarketData.GetBars(timeFrame, runtimeName);
+                return bars != null;
+            }
+            catch
+            {
+                bars = null;
+                return false;
+            }
+        }
+
+        public bool TryGetPipSize(string symbolReference, out double pipSize)
+        {
+            pipSize = 0;
+
+            if (!TryGetSymbolMeta(symbolReference, out var symbol))
+                return false;
+
+            pipSize = symbol.PipSize;
+            return pipSize > 0;
+        }
+
+        public bool TryGetSymbolMeta(string symbolReference, out Symbol symbol)
+        {
+            return TryResolveSymbol(symbolReference, out symbol);
         }
 
         public Symbol ResolveSymbol(string symbolReference)
         {
-            if (string.IsNullOrWhiteSpace(symbolReference))
-                return null;
-
-            if (SymbolRouting.NormalizeSymbol(symbolReference) == SymbolRouting.NormalizeSymbol(_bot.SymbolName))
-                return _bot.Symbol;
-
-            return TryResolveRuntimeName(symbolReference, out var runtimeName)
-                ? _bot.Symbols.GetSymbol(runtimeName)
+            return TryResolveSymbol(symbolReference, out var symbol)
+                ? symbol
                 : null;
         }
 
@@ -101,8 +167,8 @@ namespace GeminiV26.Core
 
         public Bars GetBars(TimeFrame timeFrame, string symbolReference)
         {
-            return TryResolveRuntimeName(symbolReference, out var runtimeName)
-                ? _bot.MarketData.GetBars(timeFrame, runtimeName)
+            return TryGetBars(timeFrame, symbolReference, out var bars)
+                ? bars
                 : null;
         }
 

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -709,6 +709,7 @@ namespace GeminiV26.Core
 
             EnsureStartupMemoryReady();
             AuditMemoryCoverage();
+            AuditResolverCoverage();
 
             bool isFx = _fxMarketStateDetector != null && SymbolRouting.ResolveInstrumentClass(sym) == InstrumentClass.FX;
 
@@ -1825,11 +1826,15 @@ namespace GeminiV26.Core
             if (ctx.M5 == null || ctx.M5.Count <= 0)
             {
                 ctx.MemoryState = _memoryEngine.GetState(memorySymbol);
+                ctx.MemoryResolved = ctx.MemoryState?.IsResolved == true;
+                ctx.MemoryUsable = ctx.MemoryState?.IsUsable == true;
                 ctx.MemoryAssessment = _memoryEngine.GetAssessment(memorySymbol);
                 return;
             }
 
             SymbolMemoryState state = _memoryEngine.GetState(memorySymbol);
+            _memoryEngine.MarkResolved(memorySymbol);
+
             if (state.BuildMode == MemoryBuildMode.Default)
             {
                 _memoryEngine.BuildFromHistory(memorySymbol, ToClosedBarList(ctx.M5));
@@ -1845,6 +1850,8 @@ namespace GeminiV26.Core
             state.SessionFatigueScore = Math.Max(0, ctx.BarsSinceStart);
 
             ctx.MemoryState = state;
+            ctx.MemoryResolved = state.IsResolved;
+            ctx.MemoryUsable = state.IsUsable;
             ctx.MemoryAssessment = _memoryEngine.GetAssessment(memorySymbol);
         }
 
@@ -1877,7 +1884,9 @@ namespace GeminiV26.Core
             }
 
             _isMemoryReady = true;
-            _bot.Print($"[MEMORY][COVERAGE] ratio={_memoryEngine.GetCoverageRatio(symbols)}");
+            _bot.Print($"[MEMORY][COVERAGE] built={_memoryEngine.GetBuiltCoverageRatio(symbols)}");
+            _bot.Print($"[MEMORY][RESOLVE_COVERAGE] resolved={_memoryEngine.GetResolvedCoverageRatio(symbols)}");
+            _bot.Print($"[MEMORY][USABLE_COVERAGE] usable={_memoryEngine.GetUsableCoverageRatio(symbols)}");
             _bot.Print($"[BOOT][MEMORY_READY] symbols={symbols.Count}");
         }
 
@@ -1886,12 +1895,15 @@ namespace GeminiV26.Core
             if (string.IsNullOrWhiteSpace(symbol))
                 return new List<Bar>();
 
-            Bars bars = _runtimeSymbols.GetBars(TimeFrame.Minute5, symbol);
-            if (bars == null)
+            if (!_runtimeSymbols.TryGetBars(TimeFrame.Minute5, symbol, out Bars bars))
             {
-                _bot.Print($"[MEMORY][SYMBOL_UNRESOLVED] canonical={NormalizeSymbol(symbol)}");
+                string normalizedSymbol = NormalizeSymbol(symbol);
+                _memoryEngine.MarkResolveFailure(normalizedSymbol, "unresolved_runtime_symbol");
+                _bot.Print($"[MEMORY][SYMBOL_UNRESOLVED] canonical={normalizedSymbol}");
                 return new List<Bar>();
             }
+
+            _memoryEngine.MarkResolved(NormalizeSymbol(symbol));
 
             return ToClosedBarList(bars);
         }
@@ -2495,6 +2507,8 @@ namespace GeminiV26.Core
                 SymbolMemoryState memoryState = _memoryEngine.GetState(symbol);
                 bool isNull = memoryState == null;
                 bool isBuilt = memoryState?.IsBuilt == true;
+                bool isResolved = memoryState?.IsResolved == true;
+                bool isUsable = memoryState?.IsUsable == true;
 
                 if (isNull || !isBuilt)
                 {
@@ -2506,11 +2520,43 @@ namespace GeminiV26.Core
                     continue;
                 }
 
+                if (!isResolved)
+                {
+                    _bot.Print($"[MEMORY][MISSING] symbol={symbol} built={isBuilt} resolved={isResolved} usable={isUsable} reason={memoryState?.ResolveFailureReason ?? string.Empty}");
+                    continue;
+                }
+
                 _bot.Print(
-                    $"[DEBUG][MEMORY][OK] symbol={symbol} phase={memoryState.MovePhase} age={memoryState.MoveAgeBars} pullbacks={memoryState.PullbackCount}");
+                    $"[DEBUG][MEMORY][OK] symbol={symbol} phase={memoryState.MovePhase} age={memoryState.MoveAgeBars} pullbacks={memoryState.PullbackCount} usable={isUsable}");
             }
 
-            _bot.Print($"[MEMORY][COVERAGE] ratio={_memoryEngine.GetCoverageRatio(symbols)}");
+            _bot.Print($"[MEMORY][COVERAGE] built={_memoryEngine.GetBuiltCoverageRatio(symbols)}");
+            _bot.Print($"[MEMORY][RESOLVE_COVERAGE] resolved={_memoryEngine.GetResolvedCoverageRatio(symbols)}");
+            _bot.Print($"[MEMORY][USABLE_COVERAGE] usable={_memoryEngine.GetUsableCoverageRatio(symbols)}");
+        }
+
+        private void AuditResolverCoverage()
+        {
+            var symbols = GetAllMemorySymbols();
+            int resolved = 0;
+            int total = 0;
+            bool isStartupWindow = BotRestartState.BarsSinceStart <= 5;
+
+            foreach (var symbol in symbols)
+            {
+                total++;
+                if (_runtimeSymbols.TryResolveSymbol(symbol, out _))
+                {
+                    resolved++;
+                    continue;
+                }
+
+                _bot.Print($"[RESOLVER][MISSING] symbol={symbol}");
+                if (isStartupWindow)
+                    _bot.Print($"[RESOLVER][CRITICAL] symbol={symbol} missing_after_startup");
+            }
+
+            _bot.Print($"[RESOLVER][COVERAGE] resolved={resolved}/{total}");
         }
 
         private List<string> GetAllMemorySymbols()

--- a/Gemini/Memory/MarketMemoryEngine.cs
+++ b/Gemini/Memory/MarketMemoryEngine.cs
@@ -20,21 +20,9 @@ namespace Gemini.Memory
         public int TotalSymbolCount { get; private set; }
         public double MemoryCoverageRatio { get; private set; }
 
-        public int BuiltSymbolCount
-        {
-            get
-            {
-                int count = 0;
-
-                foreach (var state in States.Values)
-                {
-                    if (state != null && state.IsBuilt)
-                        count++;
-                }
-
-                return count;
-            }
-        }
+        public int BuiltSymbolCount => CountStates(state => state.IsBuilt);
+        public int ResolvedSymbolCount => CountStates(state => state.IsResolved);
+        public int UsableSymbolCount => CountStates(state => state.IsUsable);
 
         public SymbolMemoryState GetState(string symbol)
         {
@@ -55,11 +43,30 @@ namespace Gemini.Memory
                 MovePhase = MovePhase.Unknown,
                 TrustLevel = MemoryTrustLevel.Unknown,
                 BuildMode = MemoryBuildMode.Default,
-                IsBuilt = false
+                IsBuilt = false,
+                IsResolved = false,
+                IsUsable = false,
+                ResolveFailureReason = string.Empty
             };
 
             States[key] = state;
             return state;
+        }
+
+        public void MarkResolved(string symbol)
+        {
+            var state = GetState(symbol);
+            state.IsResolved = true;
+            state.ResolveFailureReason = string.Empty;
+            RecomputeUsable(state);
+        }
+
+        public void MarkResolveFailure(string symbol, string reason)
+        {
+            var state = GetState(symbol);
+            state.IsResolved = false;
+            state.IsUsable = false;
+            state.ResolveFailureReason = reason ?? string.Empty;
         }
 
         public void BuildFromHistory(string symbol, List<Bar> bars)
@@ -84,6 +91,7 @@ namespace Gemini.Memory
             if (bars == null || bars.Count == 0)
             {
                 state.IsBuilt = true;
+                RecomputeUsable(state);
                 _log?.Invoke($"[MEMORY][REPLAY] symbol={state.Symbol} bars=0 reason=no_history");
                 _log?.Invoke($"[MEMORY][DONE] symbol={state.Symbol} mode={state.BuildMode} phase={state.MovePhase} age={state.MoveAgeBars}");
                 return;
@@ -95,6 +103,7 @@ namespace Gemini.Memory
             }
 
             state.IsBuilt = true;
+            RecomputeUsable(state);
             _log?.Invoke($"[MEMORY][DONE] symbol={state.Symbol} mode={state.BuildMode} phase={state.MovePhase} age={state.MoveAgeBars} pullbacks={state.PullbackCount} sinceImpulse={state.BarsSinceImpulse}");
         }
 
@@ -120,6 +129,7 @@ namespace Gemini.Memory
             if (IsStrongMove(bar))
             {
                 ApplyImpulse(state, bar, "new_impulse");
+                RecomputeUsable(state);
                 _log?.Invoke($"[MEMORY][UPDATE] symbol={state.Symbol} age={state.MoveAgeBars} sinceImpulse={state.BarsSinceImpulse}");
                 _log?.Invoke($"[MEMORY][IMPULSE] symbol={state.Symbol} phase={state.MovePhase}");
                 return;
@@ -155,39 +165,37 @@ namespace Gemini.Memory
                 state.MovePhase = MovePhase.Stale;
             }
 
+            RecomputeUsable(state);
             _log?.Invoke($"[MEMORY][UPDATE] symbol={state.Symbol} age={state.MoveAgeBars} sinceImpulse={state.BarsSinceImpulse}");
         }
 
         public string GetCoverageRatio(IEnumerable<string> symbols)
         {
-            int totalSymbols = 0;
-            int builtSymbols = 0;
-
-            if (symbols != null)
-            {
-                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                foreach (var symbol in symbols)
-                {
-                    if (string.IsNullOrWhiteSpace(symbol))
-                        continue;
-
-                    string key = symbol.Trim();
-                    if (!seen.Add(key))
-                        continue;
-
-                    totalSymbols++;
-
-                    if (States.TryGetValue(key, out var state) && state != null && state.IsBuilt)
-                        builtSymbols++;
-                }
-            }
-
-            TotalSymbolCount = totalSymbols;
-            MemoryCoverageRatio = totalSymbols > 0
-                ? (double)builtSymbols / totalSymbols
+            var coverage = ComputeCoverage(symbols);
+            TotalSymbolCount = coverage.Total;
+            MemoryCoverageRatio = coverage.Total > 0
+                ? (double)coverage.Built / coverage.Total
                 : 0d;
 
-            return $"{builtSymbols}/{totalSymbols}";
+            return $"{coverage.Built}/{coverage.Total}";
+        }
+
+        public string GetBuiltCoverageRatio(IEnumerable<string> symbols)
+        {
+            var coverage = ComputeCoverage(symbols);
+            return FormatCoverage(coverage.Built, coverage.Total);
+        }
+
+        public string GetResolvedCoverageRatio(IEnumerable<string> symbols)
+        {
+            var coverage = ComputeCoverage(symbols);
+            return FormatCoverage(coverage.Resolved, coverage.Total);
+        }
+
+        public string GetUsableCoverageRatio(IEnumerable<string> symbols)
+        {
+            var coverage = ComputeCoverage(symbols);
+            return FormatCoverage(coverage.Usable, coverage.Total);
         }
 
         public MemoryAssessment GetAssessment(string symbol)
@@ -197,7 +205,7 @@ namespace Gemini.Memory
             {
                 IsLateMove = state.PullbackCount > 2 || state.IsStaleImpulse,
                 IsChaseRisk = state.BarsSinceImpulse > ChaseRiskThresholdBars,
-                ContextTrustScore = ResolveContextTrustScore(state.BuildMode),
+                ContextTrustScore = state.IsUsable ? ResolveContextTrustScore(state.BuildMode) : 0.0,
                 RecommendedPenalty = 0
             };
 
@@ -365,6 +373,67 @@ namespace Gemini.Memory
                 return -1;
 
             return 0;
+        }
+
+        private int CountStates(Func<SymbolMemoryState, bool> predicate)
+        {
+            int count = 0;
+
+            foreach (var state in States.Values)
+            {
+                if (state != null && predicate(state))
+                    count++;
+            }
+
+            return count;
+        }
+
+        private (int Total, int Built, int Resolved, int Usable) ComputeCoverage(IEnumerable<string> symbols)
+        {
+            int totalSymbols = 0;
+            int builtSymbols = 0;
+            int resolvedSymbols = 0;
+            int usableSymbols = 0;
+
+            if (symbols != null)
+            {
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var symbol in symbols)
+                {
+                    if (string.IsNullOrWhiteSpace(symbol))
+                        continue;
+
+                    string key = symbol.Trim();
+                    if (!seen.Add(key))
+                        continue;
+
+                    totalSymbols++;
+
+                    if (!States.TryGetValue(key, out var state) || state == null)
+                        continue;
+
+                    if (state.IsBuilt)
+                        builtSymbols++;
+
+                    if (state.IsResolved)
+                        resolvedSymbols++;
+
+                    if (state.IsUsable)
+                        usableSymbols++;
+                }
+            }
+
+            return (totalSymbols, builtSymbols, resolvedSymbols, usableSymbols);
+        }
+
+        private static string FormatCoverage(int covered, int total) => $"{covered}/{total}";
+
+        private static void RecomputeUsable(SymbolMemoryState state)
+        {
+            if (state == null)
+                return;
+
+            state.IsUsable = state.IsBuilt && state.IsResolved;
         }
 
         private static double ResolveContextTrustScore(MemoryBuildMode buildMode)

--- a/Gemini/Memory/SymbolMemoryState.cs
+++ b/Gemini/Memory/SymbolMemoryState.cs
@@ -18,5 +18,8 @@ namespace Gemini.Memory
         public MemoryTrustLevel TrustLevel { get; set; } = MemoryTrustLevel.Unknown;
         public MemoryBuildMode BuildMode { get; set; } = MemoryBuildMode.Default;
         public bool IsBuilt { get; set; }
+        public bool IsResolved { get; set; }
+        public bool IsUsable { get; set; }
+        public string ResolveFailureReason { get; set; } = string.Empty;
     }
 }

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.AUDNZD
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.AUDNZD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.AUDNZD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.AUDUSD
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.AUDUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.AUDUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -82,6 +82,30 @@ namespace GeminiV26.Instruments.BTCUSD
         // =========================================================
         // BAR-LEVEL EXIT MANAGEMENT
         // =========================================================
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -94,8 +118,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -136,8 +159,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,9 +206,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
 
@@ -215,10 +235,13 @@ namespace GeminiV26.Instruments.BTCUSD
 
                         if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                         {
-                            var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                            var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                            if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
-                            if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                             {
                                 _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             _bot.Print(TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -277,8 +300,7 @@ namespace GeminiV26.Instruments.BTCUSD
         // =========================================================
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             // 1) Partial close (crypto-safe)
@@ -476,10 +498,13 @@ namespace GeminiV26.Instruments.BTCUSD
 
             SafeModify(pos, pos.StopLoss, newTp);
 
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
+            double? currentPrice = null;
+            if (TryResolveExitSymbol(pos, out var sym))
+                currentPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(
                 $"[EXIT] TP2 EXTENDED symbol={pos.SymbolName} positionId={pos.Id} " +
-                $"direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym?.Bid : sym?.Ask)} " +
+                $"direction={pos.TradeType} currentPrice={currentPrice} " +
                 $"oldTp={currentTp} newTp={newTp}", ctx, pos));
 
             ctx.LastExtendedTp2 = newTp;

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -69,6 +69,30 @@ namespace GeminiV26.Instruments.ETHUSD
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -81,8 +105,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -120,8 +143,7 @@ namespace GeminiV26.Instruments.ETHUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -169,9 +191,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
 
@@ -196,8 +216,11 @@ namespace GeminiV26.Instruments.ETHUSD
 
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -264,9 +287,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.EURJPY
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.EURJPY
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.EURJPY
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.EURJPY
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.EURJPY
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.EURJPY
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.EURUSD
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.EURUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.EURUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.EURUSD
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.EURUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.EURUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.GBPJPY
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.GBPJPY
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.GBPJPY
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.GBPUSD
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.GBPUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.GBPUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.GER40
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.GER40
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.GER40
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.GER40
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.GER40
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.GER40
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.NAS100
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.NAS100
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.NAS100
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.NAS100
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.NAS100
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.NAS100
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.NZDUSD
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.NZDUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.NZDUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.US30
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.US30
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.US30
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.US30
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.US30
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.US30
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.USDCAD
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.USDCAD
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.USDCAD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.USDCAD
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.USDCAD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.USDCAD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.USDCHF
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.USDCHF
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.USDCHF
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.USDCHF
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.USDCHF
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.USDCHF
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -52,6 +52,30 @@ namespace GeminiV26.Instruments.USDJPY
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position position)
         {
             if (position == null)
@@ -64,8 +88,7 @@ namespace GeminiV26.Instruments.USDJPY
 
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(position.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(position, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -103,8 +126,7 @@ namespace GeminiV26.Instruments.USDJPY
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -148,9 +170,7 @@ namespace GeminiV26.Instruments.USDJPY
 
                     if (!reached)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -169,8 +189,11 @@ namespace GeminiV26.Instruments.USDJPY
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -213,8 +236,7 @@ namespace GeminiV26.Instruments.USDJPY
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -96,6 +96,30 @@ namespace GeminiV26.Instruments.XAUUSD
         // =====================================================
         // BAR-LEVEL EXIT (jelenleg csak early exit placeholder)
         // =====================================================
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        {
+            symbol = null;
+            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        {
+            bars = null;
+            if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
+            {
+                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                return false;
+            }
+
+            return bars != null;
+        }
+
         public void OnBar(Position pos)
         {
             if (!_contexts.TryGetValue(pos.Id, out var ctx))
@@ -106,8 +130,7 @@ namespace GeminiV26.Instruments.XAUUSD
             // =====================================================
             ctx.BarsSinceEntryM5++;
 
-            var stateSymbol = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (stateSymbol != null)
+            if (TryResolveExitSymbol(pos, out var stateSymbol))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -160,8 +183,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-                if (sym == null)
+                if (!TryResolveExitSymbol(pos, out var sym))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -213,9 +235,7 @@ namespace GeminiV26.Instruments.XAUUSD
                                         
                     if (!hit)
                     {
-                        var m1 = _runtimeSymbols.GetBars(TimeFrame.Minute, pos.SymbolName);
-
-                        if (m1 != null && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
                         {
                             var bar = m1.LastBar;
 
@@ -236,8 +256,11 @@ namespace GeminiV26.Instruments.XAUUSD
                     
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        var m5 = _runtimeSymbols.GetBars(TimeFrame.Minute5, pos.SymbolName);
-                        var m15 = _runtimeSymbols.GetBars(TimeFrame.Minute15, pos.SymbolName);
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        {
+                            continue;
+                        }
 
                         if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
@@ -296,8 +319,7 @@ namespace GeminiV26.Instruments.XAUUSD
         // =====================================================
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             // Partial close fraction: ctx-ből (executor beállította)
@@ -354,8 +376,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
         {
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             double beOffsetR = _profile.BeOffsetR;
@@ -392,8 +413,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (!pos.StopLoss.HasValue)
                 return;
 
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
-            if (sym == null)
+            if (!TryResolveExitSymbol(pos, out var sym))
                 return;
 
             // ===== ATR (előre inicializált indikátor!) =====
@@ -548,7 +568,10 @@ namespace GeminiV26.Instruments.XAUUSD
             if (!decision.AllowTp2Extension || !ctx.Tp2Price.HasValue || !ctx.Tp2Price.Value.Equals(pos.TakeProfit ?? ctx.Tp2Price.Value))
                 return;
 
-            var sym = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
+            double? currentPrice = null;
+            if (TryResolveExitSymbol(pos, out var sym))
+                currentPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+
             double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;
             double desiredR = baseR * decision.Tp2ExtensionMultiplier;
             double currentR = ctx.Tp2ExtensionMultiplierApplied > 0 ? baseR * ctx.Tp2ExtensionMultiplierApplied : baseR;


### PR DESCRIPTION
### Motivation
- Prevent silent degradation when runtime symbol resolution or market data is unavailable by adding explicit guards and fail-fast logging at all critical runtime-usage points. 
- Keep trading/risk/entry/exit logic unchanged and only add safety guards, explicit fallback policies and diagnostic logging. 
- Improve memory coverage visibility and make rehydrate behavior deterministic when runtime symbol metadata is missing.

### Description
- Implemented safe resolver API in `Core/RuntimeSymbolResolver.cs` with `TryResolveSymbol`, `TryGetBars`, `TryGetPipSize`, `TryGetSymbolMeta` (bool + out pattern, exception-safe) and updated consumers to use them. 
- Entry guard: `Core/Entry/EntryContextBuilder.cs` now blocks entries when bars/pip/meta cannot be resolved and logs `[RESOLVER][ENTRY_BLOCK] ... unresolved_runtime_symbol`; `Core/Entry/EntryContext.cs` adds `RuntimeResolved/MemoryResolved/MemoryUsable` snapshot flags and `Core/Logging/TradeAuditLog.cs` prints these fields in entry snapshots. 
- HTF / bias engines: FX/Crypto/Index/Metal HTF engines now return an explicit neutral/unavailable snapshot on resolver failure and emit `[RESOLVER][HTF_FAIL]` logs (`AllowedDirection=None`, `Confidence01=0`, Reason=`HTF_UNAVAILABLE unresolved_runtime_symbol`). 
- Memory guard: extended `Gemini/Memory/SymbolMemoryState.cs` with `IsResolved`, `IsUsable`, `ResolveFailureReason`; `Gemini/Memory/MarketMemoryEngine.cs` gained `MarkResolved`/`MarkResolveFailure`, usable recomputation and built/resolved/usable coverage reporting; `Core/TradeCore.cs` logs built/resolved/usable coverage and marks memory resolve results during startup/load. 
- Exit guard: added `TryResolveExitSymbol` / `TryGetExitBars` helpers (patterned skip + log `[RESOLVER][EXIT_SKIP] symbol=... positionId=... reason=unresolved_runtime_symbol`) to all instrument-specific ExitManager implementations (all instrument *ExitManager.cs files updated except the common base), and replaced inline `ResolveSymbol`/`GetBars` usages with these guards so exits do not run on unresolved symbols. 
- Rehydrate guard: `Core/Runtime/RehydrateService.cs` now detects unresolved symbol meta and emits `[REHYDRATE][RESOLVER_FAIL]` (creates a low-trust fallback context with `RuntimeSymbolAvailable=false`), while successful resolves log `[REHYDRATE][RESOLVER_OK]`; memory attach runs only when runtime resolution succeeded. 
- Diagnostics / audits: `TradeCore` now runs `AuditResolverCoverage()` each `OnBar` and prints `[RESOLVER][COVERAGE]` and memory coverage is printed in built/resolved/usable form. Minor logging hardening and safe fallbacks for several exit debug prints were also applied. 

### Testing
- Ran repository checks and validations: `git diff --check` (no whitespace/path errors) — passed. 
- Ran automated guard-marker validations (small Python checks) to ensure new resolver/memory/HTF/rehydrate/exit markers and APIs are present and updated files exist — all assertions passed. 
- Manual code inspection and repo-wide search confirmed instrument exit managers, HTF engines, entry builder, rehydrate and memory layers were updated and all critical resolve paths are guarded; no failing compiler-era checks found in the working tree. 

Files touched (high-level): `Core/RuntimeSymbolResolver.cs`, `Core/Entry/*` (EntryContext, EntryContextBuilder), `Core/PositionContext.cs`, `Core/Runtime/RehydrateService.cs`, `Core/TradeCore.cs`, `Core/Logging/TradeAuditLog.cs`, `Core/HtfBias/*HtfBiasEngine.cs`, `Gemini/Memory/*`, and instrument exit managers under `Instruments/*/*ExitManager.cs` (exit guards added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1af972e648328ab42e99a68d080fc)