### PR TITLE
Fix missing Symbol namespace imports in exit managers

### DIFF
--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using cAlgo.API.Indicators;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using cAlgo.API.Indicators;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -18,6 +18,7 @@
 // =========================================================
 
 using cAlgo.API;
+using cAlgo.API.Internals;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;


### PR DESCRIPTION
### Motivation

- Recent changes introduced compilation failures in multiple ExitManager files because the `Symbol` type from the runtime API was not resolved due to a missing namespace import. 
- The intent is a minimal, targeted fix that restores compilability without changing any business logic or behavior.

### Description

- Added the missing `using cAlgo.API.Internals;` import to 16 ExitManager source files under `Instruments/*/*ExitManager.cs` so `TryResolveExitSymbol(..., out Symbol symbol)` resolves correctly. 
- The change is purely an import-level edit (one line added per affected file) and does not modify any method bodies, logic, or public APIs. 
- Files modified include the exit managers for AUDNZD, AUDUSD, BTCUSD, ETHUSD, EURJPY, EURUSD, GBPJPY, GBPUSD, GER40, NAS100, NZDUSD, US30, USDCAD, USDCHF, USDJPY and XAUUSD.

### Testing

- Ran `rg -n "using cAlgo.API.Internals;" Instruments/*/*ExitManager.cs` to confirm the import is present in the modified files, and the command returned the expected list of files. 
- Ran a Python check that counts ExitManager files still missing the import (`'out Symbol symbol'` present but missing `using cAlgo.API.Internals;`) and it returned `0`. 
- Verified the git diff/commit: the changes are 16 files with 16 insertions and the commit `Fix missing Symbol namespace imports in exit managers` was created successfully. 
- Note: a full `dotnet build` could not be executed in this environment because no `.sln`/`.csproj` files are available here, so build verification was limited to static checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b5803c388328a5e2405914dc0f15)