### PR TITLE
Fix runtime memory recovery and TP1 execution guard regressions

### DIFF
--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -444,6 +444,19 @@ namespace GeminiV26.Core.Runtime
             string normalizedSymbol = SymbolRouting.NormalizeSymbol(symbolName);
             SymbolMemoryState memoryState = _memoryEngine.GetState(normalizedSymbol);
 
+            if (memoryState == null || memoryState.BuildMode == MemoryBuildMode.Default || !memoryState.IsBuilt)
+            {
+                if (TryRebuildMemoryState(normalizedSymbol))
+                {
+                    _bot.Print($"[MEMORY][RECOVER] symbol={normalizedSymbol} source=rehydrate");
+                    memoryState = _memoryEngine.GetState(normalizedSymbol);
+                }
+                else
+                {
+                    _bot.Print($"[MEMORY][CRITICAL_MISSING] symbol={normalizedSymbol} source=rehydrate");
+                }
+            }
+
             if (memoryState != null && memoryState.BuildMode != MemoryBuildMode.Default)
             {
                 ctx.MovePhase = memoryState.MovePhase;
@@ -459,6 +472,23 @@ namespace GeminiV26.Core.Runtime
             ctx.ContextTrust = MemoryTrustLevel.Low;
             defaultedLifecycleFields = true;
             _bot.Print($"[REHYDRATE][NO_MEMORY] symbol={normalizedSymbol}");
+        }
+
+        private bool TryRebuildMemoryState(string normalizedSymbol)
+        {
+            if (!_runtimeSymbols.TryGetBars(TimeFrame.Minute5, normalizedSymbol, out Bars bars) || bars == null)
+                return false;
+
+            var history = new List<Bar>();
+            int closedCount = Math.Max(0, bars.Count - 1);
+            for (int i = 0; i < closedCount; i++)
+                history.Add(bars[i]);
+
+            _memoryEngine.MarkResolved(normalizedSymbol);
+            _memoryEngine.BuildFromHistory(normalizedSymbol, history);
+
+            SymbolMemoryState rebuilt = _memoryEngine.GetState(normalizedSymbol);
+            return rebuilt != null && rebuilt.IsBuilt;
         }
 
         private void RebuildTradeExcursions(PositionContext ctx, Position position)

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1835,9 +1835,9 @@ namespace GeminiV26.Core
             SymbolMemoryState state = _memoryEngine.GetState(memorySymbol);
             _memoryEngine.MarkResolved(memorySymbol);
 
-            if (state.BuildMode == MemoryBuildMode.Default)
+            if (state == null || !state.IsBuilt || state.BuildMode == MemoryBuildMode.Default)
             {
-                _memoryEngine.BuildFromHistory(memorySymbol, ToClosedBarList(ctx.M5));
+                state = RecoverMissingMemoryState(memorySymbol, state, "sync");
             }
             else
             {
@@ -1853,6 +1853,29 @@ namespace GeminiV26.Core
             ctx.MemoryResolved = state.IsResolved;
             ctx.MemoryUsable = state.IsUsable;
             ctx.MemoryAssessment = _memoryEngine.GetAssessment(memorySymbol);
+        }
+
+        private SymbolMemoryState RecoverMissingMemoryState(string symbol, SymbolMemoryState currentState, string source)
+        {
+            string normalized = NormalizeSymbol(symbol);
+            bool resolverOk = _runtimeSymbols.TryResolveSymbol(normalized, out _);
+
+            if (!resolverOk)
+            {
+                _memoryEngine.MarkResolveFailure(normalized, "unresolved_runtime_symbol");
+                return currentState ?? _memoryEngine.GetState(normalized);
+            }
+
+            _bot.Print($"[MEMORY][RECOVER] symbol={normalized} source={source}");
+            _memoryEngine.BuildFromHistory(normalized, LoadMemoryHistory(normalized));
+
+            SymbolMemoryState rebuiltState = _memoryEngine.GetState(normalized);
+            if (rebuiltState == null || !rebuiltState.IsBuilt)
+            {
+                _bot.Print($"[MEMORY][CRITICAL_MISSING] symbol={normalized} source={source}");
+            }
+
+            return rebuiltState;
         }
 
         private static List<Bar> ToClosedBarList(Bars bars)
@@ -2512,6 +2535,15 @@ namespace GeminiV26.Core
 
                 if (isNull || !isBuilt)
                 {
+                    memoryState = RecoverMissingMemoryState(symbol, memoryState, "audit");
+                    isNull = memoryState == null;
+                    isBuilt = memoryState?.IsBuilt == true;
+                    isResolved = memoryState?.IsResolved == true;
+                    isUsable = memoryState?.IsUsable == true;
+
+                    if (isBuilt)
+                        continue;
+
                     _bot.Print($"[MEMORY][MISSING] symbol={symbol} built={isBuilt} stateNull={isNull}");
 
                     if (isStartupWindow)

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.AUDNZD
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.AUDNZD
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.AUDUSD
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.AUDUSD
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -86,13 +86,25 @@ namespace GeminiV26.Instruments.BTCUSD
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -203,7 +215,7 @@ namespace GeminiV26.Instruments.BTCUSD
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -219,6 +231,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
 

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -73,13 +73,25 @@ namespace GeminiV26.Instruments.ETHUSD
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -188,7 +200,7 @@ namespace GeminiV26.Instruments.ETHUSD
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -204,6 +216,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.EURJPY
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.EURJPY
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.EURJPY
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.EURUSD
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.EURUSD
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.EURUSD
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.GBPJPY
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.GBPJPY
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.GBPUSD
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.GBPUSD
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.GER40
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.GER40
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.GER40
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.NAS100
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.NAS100
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.NAS100
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.NZDUSD
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.NZDUSD
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.US30
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.US30
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.US30
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.USDCAD
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.USDCAD
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.USDCAD
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.USDCHF
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.USDCHF
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.USDCHF
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -56,13 +56,25 @@ namespace GeminiV26.Instruments.USDJPY
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -167,7 +179,7 @@ namespace GeminiV26.Instruments.USDJPY
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
 
                     if (!reached)
                     {
@@ -182,6 +194,7 @@ namespace GeminiV26.Instruments.USDJPY
 
                     if (reached)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -100,13 +100,25 @@ namespace GeminiV26.Instruments.XAUUSD
         private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
         {
             symbol = null;
-            if (pos == null || !_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol))
+
+            if (pos == null)
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                _bot.Print("[RESOLVER][EXIT_SKIP] symbol=UNKNOWN positionId=0 reason=position_null");
                 return false;
             }
 
-            return true;
+            if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+                return true;
+
+            symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+            if (symbol != null)
+            {
+                _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                return true;
+            }
+
+            _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
+            return false;
         }
 
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
@@ -232,7 +244,7 @@ namespace GeminiV26.Instruments.XAUUSD
                     bool hit =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
-                            : sym.Bid <= tp1Price;
+                            : sym.Ask <= tp1Price;
                                         
                     if (!hit)
                     {
@@ -248,6 +260,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
                     if (hit)
                     {
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;


### PR DESCRIPTION
### Motivation
- Reduce excessive `[MEMORY][MISSING]` noise by ensuring memory state is rebuilt when a previously-buildable symbol appears missing at runtime.  
- Restore TP1 detection so SELL TP1s are evaluated correctly and resolver guards do not erroneously block price-based TP1 checks.  
- Keep the fix strictly as bugfixes (no changes to entry/exit policy, sizing, TP1 R, trailing, or major refactors). 

### Description
- Added targeted recovery logic in `Core/TradeCore.cs`: `RecoverMissingMemoryState(...)` is invoked from `SyncMemoryState` when a state is `null` / not built / default, and emits `[MEMORY][RECOVER]` or `[MEMORY][CRITICAL_MISSING]` logs after attempting a one-shot rebuild from history.  
- Extended `AuditMemoryCoverage()` to call the same recovery helper so audits try a lazy rebuild before continuing to report missing states.  
- Added rehydrate-time recovery in `Core/Runtime/RehydrateService.cs`: `TryRebuildMemoryState(...)` attempts to rebuild from M5 history during rehydrate and logs recovery outcomes.  
- Unblocked TP1 flows in all instrument `ExitManager` implementations by: (a) improving `TryResolveExitSymbol` to attempt a platform-symbol fallback and log `[RESOLVER][EXIT_RECOVER]` when runtime resolver misses, and (b) fixing SELL TP1 detection to use `Ask <= tp1Price` (BUY remains `Bid >= tp1Price`), and emitting the required `[EXIT][TP1] symbol=... positionId=... price=...` log immediately when TP1 is detected.  
- Changes were made only to memory recovery and exit-check guarding/logging paths across the listed files; no entry logic, exit policy values (TP1 R, BE offset, SL), risk/sizing, or method signatures (except minimal safe helpers) were altered. 

### Testing
- Static validation: ran repository-wide pattern checks to ensure SELL TP1 checks use `sym.Ask <= tp1Price` and that `[EXIT][TP1]` and resolver-recovery logs are present across modified `ExitManager` files; these checks passed.  
- Memory recovery checks: searched for `RecoverMissingMemoryState`, `[MEMORY][RECOVER]`, `[MEMORY][CRITICAL_MISSING]`, and `TryRebuildMemoryState` and verified the hooks exist in `TradeCore` and `RehydrateService`; validation succeeded.  
- No unit/integration test framework run in this rollout; only automated static/code-level verifications were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2439d7e308328985e84d4eefeee14)