### PR TITLE
Fix index symbol resolution; add TP1 post-close guards and TVM per-bar log throttle

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -429,5 +429,9 @@ namespace GeminiV26.Core
         public bool MarketTrend { get; set; }
 
         public double Adx_M5 { get; set; }
+
+        public int LastTvmEvalBar { get; set; } = -1;
+
+        public int LastTvmLogBar { get; set; } = -1;
     }
 }

--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -18,6 +18,8 @@ namespace GeminiV26.Core
     {
         private readonly Robot _bot;
         private readonly Dictionary<string, string> _runtimeNamesByCanonical = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _aliasResolvedLogged = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _aliasFallbackLogged = new(StringComparer.OrdinalIgnoreCase);
 
         public RuntimeSymbolResolver(Robot bot)
         {
@@ -71,6 +73,24 @@ namespace GeminiV26.Core
 
                 if (_runtimeNamesByCanonical.TryGetValue(canonical, out runtimeName) && !string.IsNullOrWhiteSpace(runtimeName))
                     return true;
+
+                string aliasRuntime = SymbolAliasRegistry.Resolve(_bot.Symbols, canonical, out var aliasResolved, out var fallbackUsed);
+                if (!string.IsNullOrWhiteSpace(aliasRuntime))
+                {
+                    if (aliasResolved && _aliasResolvedLogged.Add(canonical))
+                        _bot.Print($"[RESOLVER][ALIAS_RESOLVED] {canonical} → {aliasRuntime}");
+
+                    if (fallbackUsed && _aliasFallbackLogged.Add(canonical))
+                        _bot.Print($"[RESOLVER][ALIAS_FALLBACK] {canonical} → {aliasRuntime} (NOT FOUND)");
+
+                    var aliasSymbol = _bot.Symbols.GetSymbol(aliasRuntime);
+                    if (aliasSymbol != null)
+                    {
+                        runtimeName = aliasSymbol.Name;
+                        RegisterRuntimeName(runtimeName);
+                        return true;
+                    }
+                }
 
                 var directSymbol = _bot.Symbols.GetSymbol(requested);
                 if (directSymbol != null)

--- a/Core/SymbolAliasRegistry.cs
+++ b/Core/SymbolAliasRegistry.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using cAlgo.API.Internals;
+
+namespace GeminiV26.Core
+{
+    public static class SymbolAliasRegistry
+    {
+        private static readonly Dictionary<string, string[]> AliasMap = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "GER40", new[] { "GERMANY 40", "GER40" } },
+            { "NAS100", new[] { "US TECH 100", "NAS100" } },
+            { "US30", new[] { "US 30", "US30" } }
+        };
+
+        private static readonly Dictionary<string, string> Resolved = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, bool> ResolvedViaAlias = new(StringComparer.OrdinalIgnoreCase);
+
+        public static string Resolve(Symbols symbols, string canonical)
+        {
+            ResolveInternal(symbols, canonical, out _, out _);
+            return Resolved.TryGetValue(canonical ?? string.Empty, out var runtime) ? runtime : canonical;
+        }
+
+        public static string Resolve(Symbols symbols, string canonical, out bool aliasResolved, out bool fallbackUsed)
+        {
+            return ResolveInternal(symbols, canonical, out aliasResolved, out fallbackUsed);
+        }
+
+        private static string ResolveInternal(Symbols symbols, string canonical, out bool aliasResolved, out bool fallbackUsed)
+        {
+            aliasResolved = false;
+            fallbackUsed = false;
+
+            if (string.IsNullOrWhiteSpace(canonical))
+                return canonical;
+
+            if (Resolved.TryGetValue(canonical, out var cached))
+            {
+                aliasResolved = ResolvedViaAlias.TryGetValue(canonical, out var viaAlias) && viaAlias;
+                fallbackUsed = !aliasResolved && string.Equals(cached, canonical, StringComparison.OrdinalIgnoreCase);
+                return cached;
+            }
+
+            if (!AliasMap.TryGetValue(canonical, out var candidates))
+            {
+                Resolved[canonical] = canonical;
+                ResolvedViaAlias[canonical] = false;
+                fallbackUsed = true;
+                return canonical;
+            }
+
+            foreach (var candidate in candidates)
+            {
+                if (!symbols.Exists(candidate))
+                    continue;
+
+                Resolved[canonical] = candidate;
+                aliasResolved = !string.Equals(candidate, canonical, StringComparison.OrdinalIgnoreCase);
+                ResolvedViaAlias[canonical] = aliasResolved;
+                fallbackUsed = false;
+                return candidate;
+            }
+
+            Resolved[canonical] = canonical;
+            ResolvedViaAlias[canonical] = false;
+            fallbackUsed = true;
+            return canonical;
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2509,7 +2509,12 @@ namespace GeminiV26.Core
                 RegisterRehydratedContextWithExitManager,
                 _memoryEngine);
 
-            service.Run();
+            var summary = service.Run();
+            int openCount = summary?.TotalOpenPositionsSeen ?? 0;
+            int restored = summary?.SuccessfullyRehydrated ?? 0;
+            int skipped = summary?.Skipped ?? 0;
+            int failed = summary?.Failed ?? 0;
+            _bot.Print($"[BOOT][REHYDRATE_DONE] restored={restored} skipped={skipped} failed={failed} openPositions={openCount}");
         }
 
         // =================================================

--- a/Core/TradeViabilityMonitor.cs
+++ b/Core/TradeViabilityMonitor.cs
@@ -39,11 +39,15 @@ namespace GeminiV26.Core
             int barsSinceEntry = ComputeBarsSinceEntryByIndex(ctx, m5, out currentBarIndex, out entryBarIndex);
             ctx.BarsSinceEntryM5 = barsSinceEntry;
 
-            if (barsSinceEntry <= 12)
-            {
-                _bot.Print(TradeLogIdentity.WithPositionIds(
-                    $"[TVM DBG] barsSinceEntry={barsSinceEntry} currentBarIndex={currentBarIndex} entryBarIndex={entryBarIndex}", ctx));
-            }
+            if (ctx.LastTvmEvalBar == currentBarIndex)
+                return false;
+
+            ctx.LastTvmEvalBar = currentBarIndex;
+
+            LogTvmOncePerBar(
+                ctx,
+                currentBarIndex,
+                $"[TVM] barsSinceEntry={barsSinceEntry} currentBarIndex={currentBarIndex} entryBarIndex={entryBarIndex}");
 
             if (barsSinceEntry <= 0)
                 return false;
@@ -155,9 +159,11 @@ namespace GeminiV26.Core
             bool atrShrinking,
             bool marketTrend)
         {
-            _bot.Print(TradeLogIdentity.WithPositionIds(
+            LogTvmOncePerBar(
+                ctx,
+                ctx.LastTvmEvalBar,
                 $"[TVM PHASE] EARLY bars={barsSinceEntry} mfeR={ctx.MfeR:0.00} maeR={ctx.MaeR:0.00} " +
-                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}", ctx));
+                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}");
 
             if (!ctx.MarketTrend)
             {
@@ -183,11 +189,12 @@ namespace GeminiV26.Core
             bool momentumWeak = ctx.Adx_M5 < 20.0 || atrShrinking;
             bool fastAdverse = ctx.MaeR > 0.25 && barsSinceEntry <= 2;
 
-            _bot.Print(TradeLogIdentity.WithPositionIds(
+            LogTvmOncePerBar(
+                ctx,
+                ctx.LastTvmEvalBar,
                 $"[TVM EARLY] noProgress={noProgress} adverseExpansion={adverseExpansion} " +
-                $"momentumWeak={momentumWeak} atrShrinking={atrShrinking}", ctx));
-            _bot.Print(TradeLogIdentity.WithPositionIds(
-                $"[TVM EARLY] fastAdverse={fastAdverse} maeR={ctx.MaeR:0.00} bars={barsSinceEntry}", ctx));
+                $"momentumWeak={momentumWeak} atrShrinking={atrShrinking} fastAdverse={fastAdverse} " +
+                $"maeR={ctx.MaeR:0.00} bars={barsSinceEntry}");
 
             int dangerCount = 0;
             if (noProgress)
@@ -199,16 +206,17 @@ namespace GeminiV26.Core
             if (fastAdverse)
                 dangerCount++;
 
-            _bot.Print(TradeLogIdentity.WithPositionIds($"[TVM DECISION] phase=EARLY dangerCount={dangerCount} threshold=2", ctx));
+            LogTvmOncePerBar(ctx, ctx.LastTvmEvalBar, $"[TVM DECISION] phase=EARLY dangerCount={dangerCount} threshold=2");
 
             if (dangerCount >= 2)
             {
                 ctx.IsDeadTrade = true;
                 ctx.DeadTradeReason = "EARLY_FAILURE";
 
-                _bot.Print(TradeLogIdentity.WithPositionIds(
-                    $"[TVM EXIT] reason=EARLY_FAILURE mfeR={ctx.MfeR:0.00} " +
-                    $"maeR={ctx.MaeR:0.00} bars={barsSinceEntry}", ctx));
+                LogTvmOncePerBar(
+                    ctx,
+                    ctx.LastTvmEvalBar,
+                    $"[TVM EXIT] reason=EARLY_FAILURE mfeR={ctx.MfeR:0.00} maeR={ctx.MaeR:0.00} bars={barsSinceEntry}");
 
                 return true;
             }
@@ -223,9 +231,11 @@ namespace GeminiV26.Core
             Bars m5,
             TradeType tradeType)
         {
-            _bot.Print(TradeLogIdentity.WithPositionIds(
+            LogTvmOncePerBar(
+                ctx,
+                ctx.LastTvmEvalBar,
                 $"[TVM PHASE] DEVELOPMENT bars={barsSinceEntry} mfeR={ctx.MfeR:0.00} maeR={ctx.MaeR:0.00} " +
-                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}", ctx));
+                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}");
 
             if (!ctx.MarketTrend)
             {
@@ -257,24 +267,27 @@ namespace GeminiV26.Core
             bool structureBreak = ctx.MaeR > 0.60 || IsStructureWeakening(tradeType, m5);
             bool noContinuation = barsSinceEntry >= 4 && ctx.MfeR < 0.20;
 
-            _bot.Print(TradeLogIdentity.WithPositionIds(
-                $"[TVM DEVELOPMENT] momentumDecay={momentumDecay} noContinuation={noContinuation} " +
-                $"structureBreak={structureBreak}", ctx));
+            LogTvmOncePerBar(
+                ctx,
+                ctx.LastTvmEvalBar,
+                $"[TVM DEVELOPMENT] momentumDecay={momentumDecay} noContinuation={noContinuation} structureBreak={structureBreak}");
 
             bool shouldExit = structureBreak || (momentumDecay && noContinuation);
 
-            _bot.Print(TradeLogIdentity.WithPositionIds(
-                $"[TVM DECISION] phase=DEVELOPMENT structureBreak={structureBreak} " +
-                $"combo={(momentumDecay && noContinuation)}", ctx));
+            LogTvmOncePerBar(
+                ctx,
+                ctx.LastTvmEvalBar,
+                $"[TVM DECISION] phase=DEVELOPMENT structureBreak={structureBreak} combo={(momentumDecay && noContinuation)}");
 
             if (shouldExit)
             {
                 ctx.IsDeadTrade = true;
                 ctx.DeadTradeReason = "DEVELOPMENT_FAILURE";
 
-                _bot.Print(TradeLogIdentity.WithPositionIds(
-                    $"[TVM EXIT] reason=DEVELOPMENT_FAILURE mfeR={ctx.MfeR:0.00} " +
-                    $"maeR={ctx.MaeR:0.00} bars={barsSinceEntry}", ctx));
+                LogTvmOncePerBar(
+                    ctx,
+                    ctx.LastTvmEvalBar,
+                    $"[TVM EXIT] reason=DEVELOPMENT_FAILURE mfeR={ctx.MfeR:0.00} maeR={ctx.MaeR:0.00} bars={barsSinceEntry}");
 
                 return true;
             }
@@ -287,9 +300,11 @@ namespace GeminiV26.Core
             int barsSinceEntry,
             bool marketTrend)
         {
-            _bot.Print(TradeLogIdentity.WithPositionIds(
+            LogTvmOncePerBar(
+                ctx,
+                ctx.LastTvmEvalBar,
                 $"[TVM PHASE] MATURE bars={barsSinceEntry} mfeR={ctx.MfeR:0.00} maeR={ctx.MaeR:0.00} " +
-                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}", ctx));
+                $"adx={ctx.Adx_M5:0.0} trend={marketTrend}");
 
             if (!ctx.MarketTrend)
             {
@@ -301,22 +316,27 @@ namespace GeminiV26.Core
             bool maximumAdverseExcursion = ctx.MaeR > 0.80;
             bool weakDevelopment = barsSinceEntry > 12 && ctx.MfeR < 0.30;
 
-            _bot.Print(TradeLogIdentity.WithPositionIds(
-                $"[TVM MATURE] maxAdverse={maximumAdverseExcursion} weakDevelopment={weakDevelopment}", ctx));
+            LogTvmOncePerBar(
+                ctx,
+                ctx.LastTvmEvalBar,
+                $"[TVM MATURE] maxAdverse={maximumAdverseExcursion} weakDevelopment={weakDevelopment}");
 
             bool shouldExit = maximumAdverseExcursion || weakDevelopment;
 
-            _bot.Print(TradeLogIdentity.WithPositionIds(
-                $"[TVM DECISION] phase=MATURE maxAdverse={maximumAdverseExcursion} weakDevelopment={weakDevelopment}", ctx));
+            LogTvmOncePerBar(
+                ctx,
+                ctx.LastTvmEvalBar,
+                $"[TVM DECISION] phase=MATURE maxAdverse={maximumAdverseExcursion} weakDevelopment={weakDevelopment}");
 
             if (shouldExit)
             {
                 ctx.IsDeadTrade = true;
                 ctx.DeadTradeReason = "MATURE_FAILURE";
 
-                _bot.Print(TradeLogIdentity.WithPositionIds(
-                    $"[TVM EXIT] reason=MATURE_FAILURE mfeR={ctx.MfeR:0.00} " +
-                    $"maeR={ctx.MaeR:0.00} bars={barsSinceEntry}", ctx));
+                LogTvmOncePerBar(
+                    ctx,
+                    ctx.LastTvmEvalBar,
+                    $"[TVM EXIT] reason=MATURE_FAILURE mfeR={ctx.MfeR:0.00} maeR={ctx.MaeR:0.00} bars={barsSinceEntry}");
 
                 return true;
             }
@@ -400,6 +420,18 @@ namespace GeminiV26.Core
                 return c0 < c1 && c1 < c2;
 
             return c0 > c1 && c1 > c2;
+        }
+
+        private void LogTvmOncePerBar(PositionContext ctx, int barIndex, string message)
+        {
+            if (ctx == null)
+                return;
+
+            if (ctx.LastTvmLogBar == barIndex)
+                return;
+
+            _bot.Print(TradeLogIdentity.WithPositionIds(message, ctx));
+            ctx.LastTvmLogBar = barIndex;
         }
     }
 }

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.AUDNZD
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.AUDNZD
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.AUDUSD
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.AUDUSD
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -374,7 +374,22 @@ namespace GeminiV26.Instruments.BTCUSD
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             // 3) BE / protective SL after TP1
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         // =========================================================
@@ -546,7 +561,7 @@ namespace GeminiV26.Instruments.BTCUSD
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -342,7 +342,22 @@ namespace GeminiV26.Instruments.ETHUSD
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -445,7 +460,7 @@ namespace GeminiV26.Instruments.ETHUSD
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.EURJPY
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.EURJPY
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.EURUSD
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.EURUSD
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.GBPJPY
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.GBPJPY
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.GBPUSD
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.GBPUSD
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.GER40
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.GER40
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.NAS100
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.NAS100
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.NZDUSD
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.NZDUSD
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.US30
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.US30
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.USDCAD
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.USDCAD
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.USDCHF
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.USDCHF
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -285,7 +285,22 @@ namespace GeminiV26.Instruments.USDJPY
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
         }
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
@@ -382,7 +397,7 @@ namespace GeminiV26.Instruments.USDJPY
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -372,7 +372,22 @@ namespace GeminiV26.Instruments.XAUUSD
                 Math.Max(0, pos.VolumeInUnits - closeVolume);
 
             // BE (profilból)
-            ApplyBreakEven(pos, ctx, rDist);
+            var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
+            if (live == null)
+            {
+                _bot.Print("[EXIT][POST_TP1_NO_POSITION]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            if (live.VolumeInUnits < sym.VolumeInUnitsMin)
+            {
+                _bot.Print("[EXIT][POST_TP1_MIN_VOLUME]");
+                _contexts.Remove(Convert.ToInt64(pos.Id));
+                return;
+            }
+
+            ApplyBreakEven(live, ctx, rDist);
 
             // Log TP1 event (nem loss!)
             _eventLogger.Log(new EventRecord
@@ -633,7 +648,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (livePos == null)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={sl}\ntp={tp}\nerror=POSITION_NOT_FOUND", position.Id, null, position.SymbolName));
-                _bot.Print($"[SAFE_MODIFY][SKIP] Position not found: {position.Id}");
+                _bot.Print($"[SAFE_MODIFY][SKIP_NO_POSITION] pos={position.Id}");
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Index symbols (GER40, NAS100, US30) failed resolution because runtime broker names differ from canonical names. 
- After TP1 partial close the system sometimes attempted to modify or trail a non-existing/live position which caused errors and noisy logs. 
- TradeViabilityMonitor (TVM) and resolver logs were spamming per tick/bar and rehydrate flow lacked a clear completion summary. 

### Description
- Added `Core/SymbolAliasRegistry.cs` as a single-source mapping of canonical→runtime aliases and a cached resolution/fallback implementation. 
- Integrated alias resolution into `Core/RuntimeSymbolResolver` and added one-time resolver debug logs per canonical symbol: `[RESOLVER][ALIAS_RESOLVED]` and `[RESOLVER][ALIAS_FALLBACK]`. 
- Added `LastTvmEvalBar` and `LastTvmLogBar` to `Core/PositionContext` and gated TVM evaluation + logging in `Core/TradeViabilityMonitor` so TVM logic and its logs run at most once per bar per position. 
- After every TP1 partial close, exit managers now re-validate the live position and volume before running BE/trailing, logging `[EXIT][POST_TP1_NO_POSITION]` or `[EXIT][POST_TP1_MIN_VOLUME]` and cleaning up the context when appropriate; applied consistently across instrument exit managers (index, fx, crypto, metal). 
- Rehydrate flow now emits an explicit summary ` [BOOT][REHYDRATE_DONE] restored={...} skipped={...} failed={...} openPositions={...}` at completion. 
- Replaced noisy SAFE_MODIFY skip text with `[SAFE_MODIFY][SKIP_NO_POSITION] pos=...` to reduce log noise while preserving behavior. 

### Testing
- Searched repository to confirm alias integration and one-time resolver log tags with `rg -n "ALIAS_RESOLVED|ALIAS_FALLBACK|SymbolAliasRegistry"` and the pattern was found; check succeeded. 
- Verified TVM throttle fields and invocation gating with `rg -n "LastTvmEvalBar|LastTvmLogBar|LogTvmOncePerBar|ctx.LastTvmEvalBar == currentBarIndex"` and the pattern was found; check succeeded. 
- Verified post-TP1 lifecycle guards and log changes across exit managers with `rg -n "POST_TP1_NO_POSITION|POST_TP1_MIN_VOLUME|SKIP_NO_POSITION"` and the pattern was found; check succeeded. 
- Verified rehydrate completion log presence with `rg -n "REHYDRATE_DONE"` and ran `git diff --check` for whitespace/errors; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ea7e9050832897edfc36e9f31221)