### PR TITLE
Fix cAlgo Symbols type resolution in SymbolAliasRegistry

### DIFF
--- a/Core/SymbolAliasRegistry.cs
+++ b/Core/SymbolAliasRegistry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using cAlgo.API;
 using cAlgo.API.Internals;
 
 namespace GeminiV26.Core


### PR DESCRIPTION
### Motivation
- Resolve a compile/runtime issue where the `Symbols` type used by `SymbolAliasRegistry` was not found and to align the registry with the `_bot.Symbols` (`cAlgo.API.Symbols`) used elsewhere.

### Description
- Added `using cAlgo.API;` to `Core/SymbolAliasRegistry.cs` so the `Resolve` signatures accepting `Symbols` compile and match the runtime symbol collection, with no logic changes to alias resolution.

### Testing
- Ran `git diff --check` and `git status --short` to validate the patch formatting and staging, both succeeded and the change was committed as `Fix Symbols type resolution in alias registry`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ee0c808883289919da3f8491c61d)