### PR TITLE
Add write-only trade memory layer and log on position close

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -65,6 +65,7 @@ using GeminiV26.Core.HtfBias;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Core.Context;
 using GeminiV26.Core.Analytics;
+using GeminiV26.Core.Memory;
 using GeminiV26.Core.Runtime;
 using System.Linq;
 
@@ -88,6 +89,8 @@ namespace GeminiV26.Core
         private readonly Dictionary<string, ArmedSetup> _armedSetups = new();
         private readonly TradeMetaStore _tradeMetaStore = new();
         private readonly TradeStatsTracker _statsTracker;
+        private readonly TradeMemoryStore _tradeMemoryStore;
+        private readonly MemoryLogger _memoryLogger;
         private readonly MarketMemoryEngine _memoryEngine;
         private readonly string _symbolCanonical;
         private readonly InstrumentClass _instrumentClass;
@@ -294,6 +297,8 @@ namespace GeminiV26.Core
             _router = new TradeRouter(_bot);
             _symbolCanonical = SymbolRouting.NormalizeSymbol(_bot.SymbolName);
             _instrumentClass = SymbolRouting.ResolveInstrumentClass(_symbolCanonical);
+            _tradeMemoryStore = new TradeMemoryStore();
+            _memoryLogger = new MemoryLogger(_bot);
             var symbol = _symbolCanonical;
 
             // =========================
@@ -2451,6 +2456,27 @@ namespace GeminiV26.Core
                         ? entryCtx.Transition?.QualityScore ?? 0.0
                         : 0.0
                 });
+
+            var memoryRecord = new TradeMemoryRecord
+            {
+                Instrument = pos.SymbolName ?? string.Empty,
+                EntryType = meta?.EntryType ?? ctx?.EntryType ?? string.Empty,
+                SetupType = ResolveSetupType(meta?.EntryType ?? ctx?.EntryType),
+                Direction = pos.TradeType == TradeType.Buy ? "Long" : "Short",
+                RMultiple = ComputeRMultiple(pos, ctx, sym.PipSize),
+                MFE = ctx?.MfeR ?? 0.0,
+                MAE = ctx != null ? -Math.Abs(ctx.MaeR) : 0.0,
+                MarketRegime = ResolveMarketRegime(entryCtx),
+                TransitionQuality = entryCtx?.TransitionValid == true
+                    ? entryCtx.Transition?.QualityScore ?? 0.0
+                    : 0.0,
+                Confidence = ctx?.FinalConfidence ?? meta?.Confidence ?? 0.0,
+                EntryTime = ctx?.EntryTime ?? pos.EntryTime,
+                ExitTime = _bot.Server.Time
+            };
+
+            _tradeMemoryStore.AddRecord(memoryRecord);
+            _memoryLogger.LogWrite(memoryRecord);
 
             _positionContexts.Remove(pos.Id);
             _contextRegistry.RemovePosition(pos.Id);

--- a/core/memory/MemoryLogger.cs
+++ b/core/memory/MemoryLogger.cs
@@ -1,0 +1,29 @@
+using cAlgo.API;
+
+namespace GeminiV26.Core.Memory
+{
+    public class MemoryLogger
+    {
+        private readonly Robot _bot;
+
+        public MemoryLogger(Robot bot)
+        {
+            _bot = bot;
+        }
+
+        public void LogWrite(TradeMemoryRecord record)
+        {
+            if (record == null)
+                return;
+
+            _bot.Print(
+                "[MEM][WRITE]\n" +
+                $"Instrument={record.Instrument}\n" +
+                $"EntryType={record.EntryType}\n" +
+                $"R={record.RMultiple:F2}\n" +
+                $"MFE={record.MFE:F2}\n" +
+                $"MAE={record.MAE:F2}\n" +
+                $"Regime={record.MarketRegime}");
+        }
+    }
+}

--- a/core/memory/TradeMemoryRecord.cs
+++ b/core/memory/TradeMemoryRecord.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace GeminiV26.Core.Memory
+{
+    public class TradeMemoryRecord
+    {
+        public string Instrument { get; set; } = string.Empty;
+
+        public string EntryType { get; set; } = string.Empty;
+
+        public string SetupType { get; set; } = string.Empty;
+
+        public string Direction { get; set; } = string.Empty;
+
+        public double RMultiple { get; set; }
+
+        public double MFE { get; set; }
+
+        public double MAE { get; set; }
+
+        public string MarketRegime { get; set; } = string.Empty;
+
+        public double TransitionQuality { get; set; }
+
+        public double Confidence { get; set; }
+
+        public DateTime EntryTime { get; set; }
+
+        public DateTime ExitTime { get; set; }
+    }
+}

--- a/core/memory/TradeMemoryStore.cs
+++ b/core/memory/TradeMemoryStore.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace GeminiV26.Core.Memory
+{
+    public class TradeMemoryStore
+    {
+        private readonly List<TradeMemoryRecord> _records = new();
+
+        public void AddRecord(TradeMemoryRecord record)
+        {
+            if (record == null)
+                return;
+
+            _records.Add(record);
+        }
+
+        public IReadOnlyList<TradeMemoryRecord> GetAll()
+        {
+            return _records;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Implement a Phase Day3 write-only memory layer to collect trade context and outcomes at final trade close for future analytics without affecting any trading logic.
- Ensure every memory write is traceable via mandatory `[MEM][WRITE]` logs while keeping the store append-only and side-effect free.

### Description

- Added a new memory module under `core/memory` with three new files: `TradeMemoryRecord.cs`, `TradeMemoryStore.cs`, and `MemoryLogger.cs` implementing the required schema, an append-only `List<TradeMemoryRecord>`, and the structured `[MEM][WRITE]` logger respectively.
- Integrated memory write in `Core/TradeCore.cs` inside `private void OnPositionClosed(PositionClosedEventArgs args)` immediately after the `_statsTracker.RegisterTradeClose(...)` call, where a `TradeMemoryRecord` is built, appended via `_tradeMemoryStore.AddRecord(...)`, and logged via `_memoryLogger.LogWrite(...)`.
- Added private members `_tradeMemoryStore` and `_memoryLogger` to `TradeCore` and initialized them in the `TradeCore(Robot bot)` constructor using `new TradeMemoryStore()` and `new MemoryLogger(_bot)`.
- The logged content follows the mandated format and includes `Instrument`, `EntryType`, `R`, `MFE`, `MAE`, and `Regime` fields in the `[MEM][WRITE]` printout.

### Testing

- Verified files added and integration points via `rg` searches and `git status`, and committed the changes successfully with `git commit` (commit message: "Add write-only trade memory layer on trade close").
- Ran `rg -n "TradeMemoryStore|MemoryLogger|TradeMemoryRecord|\[MEM\]\[WRITE\]"` to confirm symbols and log strings appear in the codebase and found the expected occurrences.
- Attempted a build with `dotnet build`, but the environment lacks the `dotnet` tool, so compilation could not be validated here (`/bin/bash: dotnet: command not found`).
- No automated unit tests were modified or added as this change is a write-only data capture feature and does not alter existing logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f563c0548328b67c44e0593cb91d)