### PR TITLE
Fix resolver no-fallback behavior and reduce memory log spam

### DIFF
--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -19,7 +19,7 @@ namespace GeminiV26.Core
         private readonly Robot _bot;
         private readonly Dictionary<string, string> _runtimeNamesByCanonical = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _aliasResolvedLogged = new(StringComparer.OrdinalIgnoreCase);
-        private readonly HashSet<string> _aliasFallbackLogged = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _resolveErrorLogged = new(StringComparer.OrdinalIgnoreCase);
 
         public RuntimeSymbolResolver(Robot bot)
         {
@@ -61,6 +61,14 @@ namespace GeminiV26.Core
                 Refresh();
 
                 string requested = symbolReference.Trim();
+                var requestedSymbol = _bot.Symbols.GetSymbol(requested);
+                if (requestedSymbol != null)
+                {
+                    runtimeName = requestedSymbol.Name;
+                    RegisterRuntimeName(runtimeName);
+                    return true;
+                }
+
                 string canonical = SymbolRouting.NormalizeSymbol(requested);
                 if (string.IsNullOrWhiteSpace(canonical))
                     return false;
@@ -74,14 +82,11 @@ namespace GeminiV26.Core
                 if (_runtimeNamesByCanonical.TryGetValue(canonical, out runtimeName) && !string.IsNullOrWhiteSpace(runtimeName))
                     return true;
 
-                string aliasRuntime = SymbolAliasRegistry.Resolve(_bot.Symbols, canonical, out var aliasResolved, out var fallbackUsed);
+                string aliasRuntime = SymbolAliasRegistry.Resolve(_bot.Symbols, canonical, out var aliasResolved, out _);
                 if (!string.IsNullOrWhiteSpace(aliasRuntime))
                 {
                     if (aliasResolved && _aliasResolvedLogged.Add(canonical))
                         _bot.Print($"[RESOLVER][ALIAS_RESOLVED] {canonical} → {aliasRuntime}");
-
-                    if (fallbackUsed && _aliasFallbackLogged.Add(canonical))
-                        _bot.Print($"[RESOLVER][ALIAS_FALLBACK] {canonical} → {aliasRuntime} (NOT FOUND)");
 
                     var aliasSymbol = _bot.Symbols.GetSymbol(aliasRuntime);
                     if (aliasSymbol != null)
@@ -92,13 +97,8 @@ namespace GeminiV26.Core
                     }
                 }
 
-                var directSymbol = _bot.Symbols.GetSymbol(requested);
-                if (directSymbol != null)
-                {
-                    runtimeName = directSymbol.Name;
-                    RegisterRuntimeName(runtimeName);
-                    return true;
-                }
+                if (_resolveErrorLogged.Add(requested))
+                    _bot.Print($"[RESOLVER][ERROR] Symbol not found: {requested}");
             }
             catch
             {

--- a/Core/SymbolAliasRegistry.cs
+++ b/Core/SymbolAliasRegistry.cs
@@ -7,11 +7,24 @@ namespace GeminiV26.Core
 {
     public static class SymbolAliasRegistry
     {
-        private static readonly Dictionary<string, string[]> AliasMap = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, string> AliasMap = new(StringComparer.OrdinalIgnoreCase)
         {
-            { "GER40", new[] { "GERMANY 40", "GER40" } },
-            { "NAS100", new[] { "US TECH 100", "NAS100" } },
-            { "US30", new[] { "US 30", "US30" } }
+            { "AUDNZD", "AUDNZD" },
+            { "AUDUSD", "AUDUSD" },
+            { "BTCUSD", "BTCUSD" },
+            { "ETHUSD", "ETHUSD" },
+            { "EURJPY", "EURJPY" },
+            { "EURUSD", "EURUSD" },
+            { "GBPJPY", "GBPJPY" },
+            { "GBPUSD", "GBPUSD" },
+            { "GER40", "GERMANY 40" },
+            { "NAS100", "US TECH 100" },
+            { "NZDUSD", "NZDUSD" },
+            { "US30", "US 30" },
+            { "USDCAD", "USDCAD" },
+            { "USDCHF", "USDCHF" },
+            { "USDJPY", "USDJPY" },
+            { "XAUUSD", "GOLD" }
         };
 
         private static readonly Dictionary<string, string> Resolved = new(StringComparer.OrdinalIgnoreCase);
@@ -34,39 +47,26 @@ namespace GeminiV26.Core
             fallbackUsed = false;
 
             if (string.IsNullOrWhiteSpace(canonical))
-                return canonical;
+                return null;
 
             if (Resolved.TryGetValue(canonical, out var cached))
             {
                 aliasResolved = ResolvedViaAlias.TryGetValue(canonical, out var viaAlias) && viaAlias;
-                fallbackUsed = !aliasResolved && string.Equals(cached, canonical, StringComparison.OrdinalIgnoreCase);
                 return cached;
             }
 
-            if (!AliasMap.TryGetValue(canonical, out var candidates))
-            {
-                Resolved[canonical] = canonical;
-                ResolvedViaAlias[canonical] = false;
-                fallbackUsed = true;
-                return canonical;
-            }
+            string resolved = AliasMap.TryGetValue(canonical, out var alias)
+                ? alias
+                : canonical;
 
-            foreach (var candidate in candidates)
-            {
-                if (!symbols.Exists(candidate))
-                    continue;
+            var symbol = symbols.GetSymbol(resolved);
+            if (symbol == null)
+                return null;
 
-                Resolved[canonical] = candidate;
-                aliasResolved = !string.Equals(candidate, canonical, StringComparison.OrdinalIgnoreCase);
-                ResolvedViaAlias[canonical] = aliasResolved;
-                fallbackUsed = false;
-                return candidate;
-            }
-
-            Resolved[canonical] = canonical;
-            ResolvedViaAlias[canonical] = false;
-            fallbackUsed = true;
-            return canonical;
+            Resolved[canonical] = symbol.Name;
+            aliasResolved = !string.Equals(resolved, canonical, StringComparison.OrdinalIgnoreCase);
+            ResolvedViaAlias[canonical] = aliasResolved;
+            return symbol.Name;
         }
     }
 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2589,8 +2589,11 @@ namespace GeminiV26.Core
                     continue;
                 }
 
-                _bot.Print(
-                    $"[DEBUG][MEMORY][OK] symbol={symbol} phase={memoryState.MovePhase} age={memoryState.MoveAgeBars} pullbacks={memoryState.PullbackCount} usable={isUsable}");
+                if (MarketMemoryEngine.DebugMemory)
+                {
+                    _bot.Print(
+                        $"[DEBUG][MEMORY][OK] symbol={symbol} phase={memoryState.MovePhase} age={memoryState.MoveAgeBars} pullbacks={memoryState.PullbackCount} usable={isUsable}");
+                }
             }
 
             _bot.Print($"[MEMORY][COVERAGE] built={_memoryEngine.GetBuiltCoverageRatio(symbols)}");
@@ -2618,6 +2621,10 @@ namespace GeminiV26.Core
                 if (isStartupWindow)
                     _bot.Print($"[RESOLVER][CRITICAL] symbol={symbol} missing_after_startup");
             }
+
+            _bot.Print($"[RESOLVER][VALIDATION] resolved={resolved}/{total}");
+            if (resolved < total)
+                _bot.Print($"[RESOLVER][ERROR] validation_failed resolved={resolved}/{total}");
 
             _bot.Print($"[RESOLVER][COVERAGE] resolved={resolved}/{total}");
         }

--- a/Gemini/Memory/MarketMemoryEngine.cs
+++ b/Gemini/Memory/MarketMemoryEngine.cs
@@ -6,6 +6,7 @@ namespace Gemini.Memory
 {
     public sealed class MarketMemoryEngine
     {
+        public static bool DebugMemory = false;
         private const int StaleImpulseThresholdBars = 8;
         private const int ChaseRiskThresholdBars = 4;
         private readonly Action<string> _log;
@@ -92,7 +93,8 @@ namespace Gemini.Memory
             {
                 state.IsBuilt = true;
                 RecomputeUsable(state);
-                _log?.Invoke($"[MEMORY][REPLAY] symbol={state.Symbol} bars=0 reason=no_history");
+                if (DebugMemory)
+                    _log?.Invoke($"[MEMORY][REPLAY] symbol={state.Symbol} bars=0 reason=no_history");
                 _log?.Invoke($"[MEMORY][DONE] symbol={state.Symbol} mode={state.BuildMode} phase={state.MovePhase} age={state.MoveAgeBars}");
                 return;
             }
@@ -223,12 +225,14 @@ namespace Gemini.Memory
         {
             state.MoveAgeBars++;
             state.BarsSinceImpulse++;
-            _log?.Invoke($"[MEMORY][REPLAY] symbol={state.Symbol} age={state.MoveAgeBars} sinceImpulse={state.BarsSinceImpulse}");
+            if (DebugMemory)
+                _log?.Invoke($"[MEMORY][REPLAY] symbol={state.Symbol} age={state.MoveAgeBars} sinceImpulse={state.BarsSinceImpulse}");
 
             if (IsStrongMove(bar))
             {
                 ApplyImpulse(state, bar, "new_impulse");
-                _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
+                if (DebugMemory)
+                    _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
                 return;
             }
 
@@ -238,7 +242,8 @@ namespace Gemini.Memory
                 state.MovePhase = MovePhase.Decay;
                 state.BarsSinceImpulse = 0;
                 state.HasActiveImpulse = false;
-                _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
+                if (DebugMemory)
+                    _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
             }
             else if (HasContinuation(state, bar))
             {
@@ -246,25 +251,29 @@ namespace Gemini.Memory
                 state.MovePhase = MovePhase.Continuation;
                 state.IsImpulseDecay = false;
                 state.IsStaleImpulse = false;
-                _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
+                if (DebugMemory)
+                    _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
             }
             else if (IsEligiblePullback(state, bar))
             {
                 IncrementPullback(state, "retrace_without_new_extreme");
-                _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase} pullbacks={state.PullbackCount}");
+                if (DebugMemory)
+                    _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase} pullbacks={state.PullbackCount}");
             }
             else if (state.BarsSinceImpulse > 1)
             {
                 state.MovePhase = MovePhase.Decay;
                 state.IsImpulseDecay = true;
-                _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
+                if (DebugMemory)
+                    _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
             }
 
             if (state.BarsSinceImpulse > StaleImpulseThresholdBars)
             {
                 state.IsStaleImpulse = true;
                 state.MovePhase = MovePhase.Stale;
-                _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
+                if (DebugMemory)
+                    _log?.Invoke($"[MEMORY][PHASE] symbol={state.Symbol} phase={state.MovePhase}");
             }
         }
 
@@ -312,13 +321,15 @@ namespace Gemini.Memory
             state.PullbackCount = Math.Min(5, state.PullbackCount + 1);
             state.MovePhase = MovePhase.Pullback;
             state.IsImpulseDecay = false;
-            _log?.Invoke($"[MEMORY][PULLBACK] symbol={state.Symbol} count={state.PullbackCount} reason={reason}");
+            if (DebugMemory)
+                _log?.Invoke($"[MEMORY][PULLBACK] symbol={state.Symbol} count={state.PullbackCount} reason={reason}");
         }
 
         private void ResetPullback(SymbolMemoryState state, string reason)
         {
             state.PullbackCount = 0;
-            _log?.Invoke($"[MEMORY][PULLBACK] symbol={state.Symbol} count={state.PullbackCount} reason={reason}");
+            if (DebugMemory)
+                _log?.Invoke($"[MEMORY][PULLBACK] symbol={state.Symbol} count={state.PullbackCount} reason={reason}");
         }
 
         private static bool IsEligiblePullback(SymbolMemoryState state, Bar bar)


### PR DESCRIPTION
### Motivation
- A jelenlegi alias fallback visszaadta az eredeti canonical nevet („fallback”), ami runtime-ban INVALID broker-symbolokat produkált és sok `[RESOLVER][ALIAS_FALLBACK] ... (NOT FOUND)` logot okozott.
- A memória komponens túl sok APRÓ, ismétlődő `[MEMORY][REPLAY|PHASE|PULLBACK]` és `[DEBUG][MEMORY][OK]` logot írt, ami olvashatatlanná tette a naplót.
- Cél: biztos, egyértelmű broker-valid symbol lookup, tiltott automatikus fallback, és a memória spam lecsendesítése debug flag mögé (bugfix, nem viselkedés/logic változtatás). 

### Description
- Core/SymbolAliasRegistry.cs: Alias-táblát egyszerűsítettem explicit map-re az aktív instrumentumokkal (pl. `XAUUSD -> GOLD`) és megváltoztattam a feloldást úgy, hogy az alias csak akkor tér vissza, ha a broker ténylegesen visszaad `Symbol` objektumot; sikertelen feloldás `null`-t ad (nincs tétlen fallback visszaadása). 
- Core/RuntimeSymbolResolver.cs: először mindig próbáljuk a közvetlen broker lookup-ot `Symbols.GetSymbol(requested)`-tel, csak utána használjuk az alias-t; ha semmi nem található, explicit error logot generálok `"[RESOLVER][ERROR] Symbol not found: ..."` (egyszer napi/per-symbol deduplikációval). 
- Core/TradeCore.cs: boot/audit során `AuditResolverCoverage()` most kiírja a validációs summát `"[RESOLVER][VALIDATION] resolved=x/y"` és hibát `"[RESOLVER][ERROR] validation_failed ..."` ha nem teljes a feloldás. 
- Gemini/Memory/MarketMemoryEngine.cs + Core/TradeCore.cs: hozzáadtam `public static bool DebugMemory = false;` és a zajos memória logokat (`[MEMORY][REPLAY]`, `[MEMORY][PHASE]`, `[MEMORY][PULLBACK]` és audit `[DEBUG][MEMORY][OK]`) csak akkor írjuk ki, ha ez a flag `true`, miközben a fontos logok (`[MEMORY][BUILD_START]`, coverage, `[BOOT][MEMORY_READY]` stb.) változatlanul megmaradnak.
- A módosítások szigorúan a resolver és logolás vezérlésére korlátozódnak; nincs módosítás sem az entry/exit/router/direction/trade-decision kódon.

### Testing
- Futtatott keresések a kódbázison validációra: `rg -n "ALIAS_FALLBACK" Core Gemini -g '*.cs' || true` — ellenőrizve, hogy az `ALIAS_FALLBACK` üzenet eltűnt (sikeres).
- Ellenőrzés a hozzáadott validációs/error logokra: `rg -n "\[RESOLVER\]\[ERROR\] Symbol not found|\[RESOLVER\]\[VALIDATION\]" Core -g '*.cs'` — a várt logsorok megtalálhatók (sikeres).
- Build teszt: `dotnet build` — nem futott le a környezetben mert a `dotnet` nincs telepítve (`/bin/bash: dotnet: command not found`) (nem sikerült).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f7ca9c508328950856123538cd9d)