### PR TITLE
Resolver: alias-first lookup, per-request cache, and boot-only validation

### DIFF
--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -18,8 +18,8 @@ namespace GeminiV26.Core
     {
         private readonly Robot _bot;
         private readonly Dictionary<string, string> _runtimeNamesByCanonical = new(StringComparer.OrdinalIgnoreCase);
-        private readonly HashSet<string> _aliasResolvedLogged = new(StringComparer.OrdinalIgnoreCase);
-        private readonly HashSet<string> _resolveErrorLogged = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Symbol> _resolvedSymbols = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _resolverOkLogged = new(StringComparer.OrdinalIgnoreCase);
 
         public RuntimeSymbolResolver(Robot bot)
         {
@@ -58,17 +58,7 @@ namespace GeminiV26.Core
                 if (string.IsNullOrWhiteSpace(symbolReference))
                     return false;
 
-                Refresh();
-
                 string requested = symbolReference.Trim();
-                var requestedSymbol = _bot.Symbols.GetSymbol(requested);
-                if (requestedSymbol != null)
-                {
-                    runtimeName = requestedSymbol.Name;
-                    RegisterRuntimeName(runtimeName);
-                    return true;
-                }
-
                 string canonical = SymbolRouting.NormalizeSymbol(requested);
                 if (string.IsNullOrWhiteSpace(canonical))
                     return false;
@@ -85,8 +75,8 @@ namespace GeminiV26.Core
                 string aliasRuntime = SymbolAliasRegistry.Resolve(_bot.Symbols, canonical, out var aliasResolved, out _);
                 if (!string.IsNullOrWhiteSpace(aliasRuntime))
                 {
-                    if (aliasResolved && _aliasResolvedLogged.Add(canonical))
-                        _bot.Print($"[RESOLVER][ALIAS_RESOLVED] {canonical} → {aliasRuntime}");
+                    if ((_resolverOkLogged.Add(requested) || _resolverOkLogged.Add(canonical)) && aliasResolved)
+                        _bot.Print($"[RESOLVER][OK] {requested} → {aliasRuntime}");
 
                     var aliasSymbol = _bot.Symbols.GetSymbol(aliasRuntime);
                     if (aliasSymbol != null)
@@ -96,9 +86,6 @@ namespace GeminiV26.Core
                         return true;
                     }
                 }
-
-                if (_resolveErrorLogged.Add(requested))
-                    _bot.Print($"[RESOLVER][ERROR] Symbol not found: {requested}");
             }
             catch
             {
@@ -119,9 +106,15 @@ namespace GeminiV26.Core
                 if (string.IsNullOrWhiteSpace(symbolReference))
                     return false;
 
+                string requested = symbolReference.Trim();
+                if (_resolvedSymbols.TryGetValue(requested, out symbol) && symbol != null)
+                    return true;
+
                 if (SymbolRouting.NormalizeSymbol(symbolReference) == SymbolRouting.NormalizeSymbol(_bot.SymbolName))
                 {
                     symbol = _bot.Symbol;
+                    if (symbol != null)
+                        _resolvedSymbols[requested] = symbol;
                     return symbol != null;
                 }
 
@@ -129,6 +122,8 @@ namespace GeminiV26.Core
                     return false;
 
                 symbol = _bot.Symbols.GetSymbol(runtimeName);
+                if (symbol != null)
+                    _resolvedSymbols[requested] = symbol;
                 return symbol != null;
             }
             catch

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -714,7 +714,6 @@ namespace GeminiV26.Core
 
             EnsureStartupMemoryReady();
             AuditMemoryCoverage();
-            AuditResolverCoverage();
 
             bool isFx = _fxMarketStateDetector != null && SymbolRouting.ResolveInstrumentClass(sym) == InstrumentClass.FX;
 
@@ -2519,6 +2518,7 @@ namespace GeminiV26.Core
         public void RehydrateOpenPositions()
         {
             EnsureStartupMemoryReady();
+            AuditResolverCoverage();
 
             if (!_isMemoryReady)
             {


### PR DESCRIPTION
### Motivation
- Ensure alias mappings are applied before any platform lookup so canonical aliases (e.g. GER40 → GERMANY 40) never get bypassed by direct `GetSymbol(requested)` calls.
- Reduce resolver spam and remove forbidden error logging emitted during OnBar execution.
- Avoid repeated symbol platform lookups by caching resolved `Symbol` instances per requested name.
- Enforce that resolver validation runs only during boot/startup (not per-bar) to prevent runtime validation overhead.

### Description
- Reworked `RuntimeSymbolResolver` to resolve canonical → alias first via `SymbolAliasRegistry.Resolve` and print a single success log line in the form `[RESOLVER][OK] {requested} → {resolved}` when alias resolution occurs.
- Added `_resolvedSymbols : Dictionary<string, Symbol>` to cache resolved `Symbol` objects and reuse them on subsequent lookups, and updated `TryResolveSymbol` to consult and populate this cache.
- Removed the resolver error log path that previously printed failures like `Symbol not found: {requested}`.
- Moved `AuditResolverCoverage()` out of `OnBar()` and invoked it during `RehydrateOpenPositions()` so resolver validation runs during the boot/rehydrate sequence only.

### Testing
- Ran `rg -n` searches for removed log patterns (for example `Failed to get symbol`, `\[RESOLVER\]\[ERROR\] Symbol not found`, and old alias-resolved token) and confirmed no matches remain.
- Inspected diffs to verify alias-first resolution, cache usage, and relocation of `AuditResolverCoverage()` were implemented as intended.
- Applied the patches successfully and validated the modified files contain the expected changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2fbf417448328be40324005c1751c)