### PR TITLE
Fix runtime symbol resolver API compatibility regressions

### DIFF
--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -28,7 +28,7 @@ namespace GeminiV26.Core
             _resolverOkLogged.Clear();
             _resolverErrorLogged.Clear();
 
-            if (_bot.Symbol != null && _bot.Symbol.HasQuotes && !string.IsNullOrWhiteSpace(_bot.Symbol.Name))
+            if (IsUsableSymbol(_bot.Symbol))
                 _cache[_bot.Symbol.Name] = _bot.Symbol;
         }
 
@@ -56,7 +56,7 @@ namespace GeminiV26.Core
             if (string.Equals(requested, _bot.Symbol?.Name, StringComparison.OrdinalIgnoreCase))
             {
                 symbol = _bot.Symbol;
-                if (symbol != null && symbol.HasQuotes)
+                if (IsUsableSymbol(symbol))
                 {
                     CacheAndLogOk(requested, symbol);
                     return true;
@@ -64,16 +64,17 @@ namespace GeminiV26.Core
             }
 
             symbol = _bot.Symbols.GetSymbol(requested);
-            if (symbol != null && symbol.HasQuotes)
+            if (IsUsableSymbol(symbol))
             {
                 CacheAndLogOk(requested, symbol);
                 return true;
             }
 
-            var fallback = _bot.Symbols
-                .FirstOrDefault(s => s != null && s.Name.StartsWith(requested, StringComparison.OrdinalIgnoreCase) && s.HasQuotes);
+            string fallbackName = _bot.Symbols
+                .FirstOrDefault(s => !string.IsNullOrWhiteSpace(s) && s.StartsWith(requested, StringComparison.OrdinalIgnoreCase));
+            var fallback = string.IsNullOrWhiteSpace(fallbackName) ? null : _bot.Symbols.GetSymbol(fallbackName);
 
-            if (fallback != null)
+            if (IsUsableSymbol(fallback))
             {
                 if (_resolverOkLogged.Add($"FALLBACK:{requested}:{fallback.Name}"))
                     _bot.Print($"[RESOLVER][FALLBACK] {requested} → {fallback.Name}");
@@ -136,7 +137,7 @@ namespace GeminiV26.Core
 
         private void CacheAndLogOk(string requested, Symbol symbol)
         {
-            if (symbol == null)
+            if (!IsUsableSymbol(symbol))
                 return;
 
             _cache[requested] = symbol;
@@ -144,6 +145,11 @@ namespace GeminiV26.Core
 
             if (_resolverOkLogged.Add($"OK:{requested}:{symbol.Name}"))
                 _bot.Print($"[RESOLVER][OK] {requested} → {symbol.Name}");
+        }
+
+        private static bool IsUsableSymbol(Symbol symbol)
+        {
+            return symbol != null && !string.IsNullOrWhiteSpace(symbol.Name);
         }
     }
 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1911,9 +1911,6 @@ namespace GeminiV26.Core
                 if (runtimeSymbol == null)
                     continue;
 
-                if (!runtimeSymbol.HasQuotes)
-                    continue;
-
                 _memoryEngine.Initialize(symbol);
                 _memoryEngine.BuildFromHistory(symbol, LoadMemoryHistory(symbol));
             }


### PR DESCRIPTION
### Motivation
- A recent change introduced references to a non-existent `HasQuotes` member and assumed `_bot.Symbols` enumerates `Symbol` objects, which produced compile errors and broke runtime symbol resolution.
- The goal is to restore compatibility with the current cTrader `Symbol` API and make symbol validation robust against different `_bot.Symbols` implementations.

### Description
- Replaced all `HasQuotes` usages with a shared `IsUsableSymbol(Symbol)` helper that validates `symbol != null` and non-empty `Name` in `Core/RuntimeSymbolResolver.cs`.
- Reworked fallback resolution to iterate symbol names from `_bot.Symbols` and call `_bot.Symbols.GetSymbol(...)` to obtain a `Symbol` instance before validating it.
- Updated cache and logging paths to use the new helper and added `IsUsableSymbol` to centralize usability checks.
- Removed the redundant `HasQuotes`-based guard in `Core/TradeCore.cs` startup memory initialization to avoid referencing the missing member.

### Testing
- Ran `rg -n "HasQuotes" Core` to verify no remaining `HasQuotes` references and it returned no matches, indicating the incompatible member usage was removed (success).
- Attempted `dotnet build -v minimal` but the environment lacks the `dotnet` CLI, so a full build could not be executed (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ffa36230832896fcdf2c035d3197)