### PR TITLE
Fix symbol object handling and ExitManager interface compatibility

### DIFF
--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -63,21 +63,34 @@ namespace GeminiV26.Core
                 }
             }
 
-            symbol = _bot.Symbols.FirstOrDefault(s =>
-                s != null &&
-                s.HasQuotes &&
-                string.Equals(s.Name, requested, StringComparison.OrdinalIgnoreCase));
-            if (IsUsableSymbol(symbol))
+            var symbols = _bot.Symbols;
+            symbol = symbols.GetSymbol(requested);
+            if (IsUsableSymbol(symbol) && IsTradable(symbol))
             {
                 CacheAndLogOk(requested, symbol);
                 return true;
             }
 
-            var fallback = _bot.Symbols.FirstOrDefault(s =>
-                s != null &&
-                s.HasQuotes &&
-                !string.IsNullOrWhiteSpace(s.Name) &&
-                s.Name.StartsWith(requested, StringComparison.OrdinalIgnoreCase));
+            Symbol fallback = null;
+            foreach (var symbolEntry in symbols)
+            {
+                object raw = symbolEntry;
+                string symbolName = raw is Symbol entrySymbol
+                    ? entrySymbol.Name
+                    : raw?.ToString();
+
+                if (string.IsNullOrWhiteSpace(symbolName))
+                    continue;
+
+                var candidate = symbols.GetSymbol(symbolName);
+                if (IsUsableSymbol(candidate) &&
+                    IsTradable(candidate) &&
+                    candidate.Name.StartsWith(requested, StringComparison.OrdinalIgnoreCase))
+                {
+                    fallback = candidate;
+                    break;
+                }
+            }
 
             if (IsUsableSymbol(fallback))
             {
@@ -155,6 +168,11 @@ namespace GeminiV26.Core
         private static bool IsUsableSymbol(Symbol symbol)
         {
             return symbol != null && !string.IsNullOrWhiteSpace(symbol.Name);
+        }
+
+        private static bool IsTradable(Symbol symbol)
+        {
+            return symbol != null && symbol.Bid != 0 && symbol.Ask != 0;
         }
     }
 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2637,11 +2637,29 @@ namespace GeminiV26.Core
 
         private List<string> GetBrokerCanonicalSymbols()
         {
-            return _bot.Symbols
-                .Where(s => s != null && s.HasQuotes)
-                .Select(s => NormalizeSymbol(s.Name))
-                .Where(s => !string.IsNullOrWhiteSpace(s))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
+            var symbols = _bot.Symbols;
+            var canonicalSymbols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var symbolEntry in symbols)
+            {
+                object raw = symbolEntry;
+                string symbolName = raw is Symbol entrySymbol
+                    ? entrySymbol.Name
+                    : raw?.ToString();
+
+                if (string.IsNullOrWhiteSpace(symbolName))
+                    continue;
+
+                var symbol = symbols.GetSymbol(symbolName);
+                if (!IsTradable(symbol))
+                    continue;
+
+                string canonical = NormalizeSymbol(symbol.Name);
+                if (!string.IsNullOrWhiteSpace(canonical))
+                    canonicalSymbols.Add(canonical);
+            }
+
+            return canonicalSymbols
                 .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
@@ -2696,7 +2714,7 @@ namespace GeminiV26.Core
 
         private static bool IsTradable(Symbol symbol)
         {
-            return symbol != null && symbol.HasQuotes;
+            return symbol != null && symbol.Bid != 0 && symbol.Ask != 0;
         }
 
         // =================================================

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.AUDNZD
 {
-    public class AudNzdExitManager
+    public class AudNzdExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.AUDUSD
 {
-    public class AudUsdExitManager
+    public class AudUsdExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -7,6 +7,7 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.BTCUSD
 {
@@ -16,7 +17,7 @@ namespace GeminiV26.Instruments.BTCUSD
     /// - TP1 előtt nincs trailing
     /// - TP1 után: BE + TTM + adaptive trailing + optional TP2 extension
     /// </summary>
-    public class BtcUsdExitManager
+    public class BtcUsdExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -7,10 +7,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.ETHUSD
 {
-    public class EthUsdExitManager
+    public class EthUsdExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.EURJPY
 {
-    public class EurJpyExitManager
+    public class EurJpyExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.EURUSD
 {
-    public class EurUsdExitManager
+    public class EurUsdExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.GBPJPY
 {
-    public class GbpJpyExitManager
+    public class GbpJpyExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.GBPUSD
 {
-    public class GbpUsdExitManager
+    public class GbpUsdExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.GER40
 {
-    public class Ger40ExitManager
+    public class Ger40ExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.NAS100
 {
-    public class NasExitManager
+    public class NasExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.NZDUSD
 {
-    public class NzdUsdExitManager
+    public class NzdUsdExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.US30
 {
-    public class Us30ExitManager
+    public class Us30ExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.USDCAD
 {
-    public class UsdCadExitManager
+    public class UsdCadExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.USDCHF
 {
-    public class UsdChfExitManager
+    public class UsdChfExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -6,10 +6,11 @@ using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.TradeManagement;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.USDJPY
 {
-    public class UsdJpyExitManager
+    public class UsdJpyExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -30,10 +30,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using cAlgo.API.Indicators;
+using GeminiV26.Interfaces;
 
 namespace GeminiV26.Instruments.XAUUSD
 {
-    public class XauExitManager
+    public class XauExitManager : IExitManager
     {
         private readonly Robot _bot;
         private readonly RuntimeSymbolResolver _runtimeSymbols;


### PR DESCRIPTION
### Motivation
- Eliminate string-based symbol handling and ensure the runtime resolver and orchestration use cTrader `Symbol` objects end-to-end to avoid incorrect name-only logic. 
- Use a robust tradability check that reflects platform quote availability rather than the old `HasQuotes` boolean. 
- Align all instrument exit managers with the shared `IExitManager` contract so `TradeCore` can register and call them uniformly. 
- Preserve all trading logic and behavior while only fixing types and interface compatibility.

### Description
- Reworked `Core/RuntimeSymbolResolver.cs` to iterate the platform `Symbols` collection (`var symbols = _bot.Symbols`) and resolve candidates with `symbols.GetSymbol(...)`, keeping `ResolveSymbol(...)` returning `Symbol` and adding a fallback loop that inspects actual `Symbol.Name` values. 
- Replaced tradability checks from `HasQuotes` to `symbol.Bid != 0 && symbol.Ask != 0` and added `IsTradable` helpers in `RuntimeSymbolResolver` and `TradeCore`. 
- Rewrote `Core/TradeCore.cs` broker symbol collection (`GetBrokerCanonicalSymbols`) to enumerate `_bot.Symbols`, resolve `Symbol` objects, filter by `IsTradable`, then normalize `symbol.Name` to canonical strings. 
- Updated all instrument exit manager files under `Instruments/*/*ExitManager.cs` to implement the `GeminiV26.Interfaces.IExitManager` interface and added the `using GeminiV26.Interfaces;` import where needed. 
- No trading logic, entry/exit rules, or architecture refactors were changed; modifications are limited to types, symbol handling, and interface compatibility.

### Testing
- Searched repository for remaining string-based symbol patterns and `HasQuotes` usage with `rg` and confirmed updated occurrences using `rg -n "Bid != 0 && .*Ask != 0|var symbols = _bot.Symbols|private Symbol ResolveSymbol\("` which returned the intended updated locations. 
- Verified all instrument exit managers now declare `: IExitManager` by running `rg -n "public class .*ExitManager : IExitManager" Instruments/*/*ExitManager.cs`. 
- Attempted a build with `dotnet build -nologo`, but the environment lacks the `dotnet` tool so compilation could not be validated here. 
- No automated tests were run beyond the repository searches; runtime compilation and integration verification should be performed in a proper .NET/cTrader build environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c305f7f7e88328a7f541384a102018)