### PR TITLE
Add diagnostic tracing for TradeCore flow blockers

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -706,6 +706,7 @@ namespace GeminiV26.Core
 
         public void OnBar()
         {
+            _bot.Print("🔥 TRACE: CORE ENTRY (OnBar)");
             string rawSym = _bot.SymbolName;
             string sym = NormalizeSymbol(rawSym);   // ✅ CANONICAL
 
@@ -775,6 +776,7 @@ namespace GeminiV26.Core
             // =========================
             if (_positionContexts == null)
             {
+                _bot.Print("BLOCK: _positionContexts == null");
                 _bot.Print("[TC] WARN: _positionContexts is NULL (skip exit+entry pipeline this bar)");
                 return;
             }
@@ -862,6 +864,7 @@ namespace GeminiV26.Core
             if (HasOpenGeminiPosition())
             {
                 _bot.Print("[DEBUG] HasOpenGeminiPosition = TRUE");
+                _bot.Print("BLOCK: existing Gemini position open");
                 return;
             }
 
@@ -870,16 +873,19 @@ namespace GeminiV26.Core
             // =========================
             if (_contextBuilder == null)
             {
+                _bot.Print("BLOCK: _contextBuilder == null");
                 _bot.Print("[TC] ERROR: _contextBuilder is NULL (cannot build entry context)");
                 return;
             }
             if (_globalSessionGate == null)
             {
+                _bot.Print("BLOCK: _globalSessionGate == null");
                 _bot.Print("[TC] ERROR: _globalSessionGate is NULL (cannot gate entries)");
                 return;
             }
             if (_entryRouter == null)
             {
+                _bot.Print("BLOCK: _entryRouter == null");
                 _bot.Print("[TC] ERROR: _entryRouter is NULL (cannot evaluate entries)");
                 return;
             }
@@ -892,6 +898,7 @@ namespace GeminiV26.Core
             
             if (_ctx == null || !_ctx.IsReady)
             {
+                _bot.Print("BLOCK: EntryContext not ready");
                 _bot.Print("[TC] BLOCKED: EntryContext not ready");
                 return;
             }
@@ -944,8 +951,10 @@ namespace GeminiV26.Core
             // GLOBAL SESSION GATE + SESSION MATRIX
             // =========================
             SessionDecision sessionDecision = _globalSessionGate.GetDecision(_bot.SymbolName, _bot.TimeFrame);
+            _bot.Print($"[SESSION CHECK] time={_bot.Server.Time:O} symbol={_bot.SymbolName} bucket={sessionDecision.Bucket} allow={sessionDecision.Allow}");
             if (!sessionDecision.Allow)
             {
+                _bot.Print("BLOCK: session gate");
                 _bot.Print("[TC] BLOCKED: Global SessionGate");
                 return;
             }
@@ -1214,6 +1223,7 @@ namespace GeminiV26.Core
 
                 if (selected == null)
                 {
+                    _bot.Print("BLOCK: entry gate");
                     _bot.Print("[TC] NO SELECTED ENTRY (all invalid)");
                     return;
                 }
@@ -1274,6 +1284,7 @@ namespace GeminiV26.Core
 
                 if (_ctx.FinalDirection == TradeDirection.None)
                 {
+                    _bot.Print("BLOCK: direction/entry failed");
                     _bot.Print($"[TC] ENTRY DROPPED: Direction=None (type={selected.Type} score={selected.Score} reason={selected.Reason})");
                     return;
                 }
@@ -1283,6 +1294,7 @@ namespace GeminiV26.Core
 
                 if (!ValidateDirectionConsistency(_ctx, selected))
                 {
+                    _bot.Print("BLOCK: direction/entry failed");
                     return;
                 }
 
@@ -1293,18 +1305,22 @@ namespace GeminiV26.Core
                     _bot.Print(TradeLogIdentity.WithTempId($"[DIR][TRACE_INCOMPLETE] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}", _ctx));
 
                 var gateDir = ToTradeTypeStrict(_ctx.FinalDirection);
+                _bot.Print("CHECK: direction gate");
+                _bot.Print("CHECK: entry gate");
 
             // === GATES ONLY ===
             if (IsSymbol("XAUUSD"))
             {
                 if (!(_xauSessionGate?.AllowEntry(gateDir) ?? false))
                 {
+                    _bot.Print("BLOCK: session gate");
                     _bot.Print("[TC] BLOCKED: XAU SessionGate");
                     return;
                 }
 
                 if (!(_xauImpulseGate?.AllowEntry(gateDir) ?? false))
                 {
+                    _bot.Print("BLOCK: direction/entry failed");
                     _bot.Print("[TC] BLOCKED: XAU ImpulseGate");
                     return;
                 }
@@ -1316,12 +1332,14 @@ namespace GeminiV26.Core
             {
                 if (!(_nasSessionGate?.AllowEntry(gateDir) ?? false))
                 {
+                    _bot.Print("BLOCK: session gate");
                     _bot.Print("[TC] BLOCKED: NAS SessionGate");
                     return;
                 }
 
                 if (!(_nasImpulseGate?.AllowEntry(gateDir) ?? false))
                 {
+                    _bot.Print("BLOCK: direction/entry failed");
                     _bot.Print("[TC] BLOCKED: NAS ImpulseGate");
                     return;
                 }
@@ -1898,19 +1916,29 @@ namespace GeminiV26.Core
         private void EnsureStartupMemoryReady()
         {
             if (_isMemoryReady)
+            {
+                _bot.Print("BLOCK: startup memory already ready");
                 return;
+            }
 
+            _bot.Print("STEP 1: before symbol loop");
             var symbols = GetBrokerCanonicalSymbols();
 
             foreach (var symbol in symbols)
             {
+                _bot.Print($"STEP 2: inside symbol loop symbol={symbol}");
+                _bot.Print($"STEP 3: before ResolveSymbol symbol={symbol}");
                 var runtimeSymbol = ResolveSymbol(symbol);
+                _bot.Print($"STEP 4: after ResolveSymbol symbol={symbol} resolved={(runtimeSymbol != null)}");
+                _bot.Print("STEP 5: before tradable check");
                 if (!IsTradable(runtimeSymbol))
                 {
+                    _bot.Print("BLOCK: not tradable");
                     _bot.Print($"[MEMORY][SKIP] {symbol}");
                     continue;
                 }
 
+                _bot.Print($"STEP 6: before Entry/Exit logic symbol={symbol}");
                 _memoryEngine.Initialize(symbol);
                 _memoryEngine.BuildFromHistory(symbol, LoadMemoryHistory(symbol));
             }
@@ -2175,11 +2203,15 @@ namespace GeminiV26.Core
         {
             try
             {
+                _bot.Print("🔥 TRACE: CORE ENTRY (OnTick)");
                 // =====================================================
                 // HARD LOSS GUARD – GLOBAL SAFETY
                 // =====================================================
                 if (CheckHardLoss())
+                {
+                    _bot.Print("BLOCK: hard loss guard");
                     return;
+                }
 
                 if (IsSymbol("XAUUSD"))
                 {


### PR DESCRIPTION
### Motivation
- The TradeCore pipeline could return early in multiple places and produce no visible runtime logs, making it hard to diagnose silent runs.  
- Add unobtrusive diagnostics that reveal exactly which early-return or gating condition stops execution without changing trading logic.  
- Preserve all original behavior while exposing the flow so operators can see the last emitted trace before a silent stop.  

### Description
- Added unconditional core-entry traces at the top of `TradeCore.OnBar()` and `TradeCore.OnTick()` (`"🔥 TRACE: CORE ENTRY (OnBar)"` and `"🔥 TRACE: CORE ENTRY (OnTick)"`).  
- Inserted `BLOCK:` diagnostic prints immediately before key early `return` points in the OnBar pipeline including `_positionContexts == null`, open-position guard (`HasOpenGeminiPosition()`), missing core components guards (`_contextBuilder`, `_globalSessionGate`, `_entryRouter`), context readiness (`_ctx.IsReady`), and global session gate denial.  
- Added step-by-step startup-memory loop tracing in `EnsureStartupMemoryReady()` with `STEP 1..6` prints, `ResolveSymbol` resolution reporting, and explicit `BLOCK: not tradable` on `continue` paths.  
- Added entry/direction gate diagnostics around router selection and gate checks including `BLOCK: entry gate`, `BLOCK: direction/entry failed`, and `CHECK: direction gate` / `CHECK: entry gate` before the session/impulse checks for instrument branches (e.g., XAU/NAS).  

### Testing
- Performed focused static verification of the modified file using file inspection commands (`sed`, `nl`) to confirm the expected `Print()` insertions appear in `Core/TradeCore.cs`, and reviewed the resulting diff to ensure only logging additions were made.  
- Verified runtime gating points and diagnostic strings were added adjacent to the original early-return logic and that no conditional logic or business behavior was modified.  
- Attempted to run a standard build but the workspace contains no `.sln`/`.csproj`, so an automated build (`dotnet build`) was not executed in this environment and no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c309921b9c83288f41e3a124d162ac)