### PR TITLE
Defer RuntimeSymbolResolver initialization to runtime Init()

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -74,7 +74,7 @@ namespace GeminiV26.Core
     public class TradeCore
     {
         private readonly Robot _bot;
-        private readonly RuntimeSymbolResolver _runtimeSymbols;
+        private RuntimeSymbolResolver _runtimeSymbols;
         private readonly TradeRouter _router;
 
         private readonly EntryRouter _entryRouter;
@@ -275,7 +275,6 @@ namespace GeminiV26.Core
         public TradeCore(Robot bot)
         {
             _bot = bot;
-            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
             _router = new TradeRouter(_bot);
             _symbolCanonical = SymbolRouting.NormalizeSymbol(_bot.SymbolName);
             _instrumentClass = SymbolRouting.ResolveInstrumentClass(_symbolCanonical);
@@ -704,8 +703,24 @@ namespace GeminiV26.Core
             _bot.Positions.Closed += OnPositionClosed;
         }
 
+
+        public void Init()
+        {
+            EnsureRuntimeResolverInitialized();
+        }
+
+        private void EnsureRuntimeResolverInitialized()
+        {
+            if (_runtimeSymbols != null)
+                return;
+
+            _runtimeSymbols = new RuntimeSymbolResolver(_bot);
+            _bot.Print("[RESOLVER][INIT] mode=runtime_only phase=OnStart");
+        }
+
         public void OnBar()
         {
+            EnsureRuntimeResolverInitialized();
             _bot.Print("🔥 TRACE: CORE ENTRY (OnBar)");
             string rawSym = _bot.SymbolName;
             string sym = NormalizeSymbol(rawSym);   // ✅ CANONICAL
@@ -2201,6 +2216,7 @@ namespace GeminiV26.Core
         // =========================================================
         public void OnTick()
         {
+            EnsureRuntimeResolverInitialized();
             try
             {
                 _bot.Print("🔥 TRACE: CORE ENTRY (OnTick)");
@@ -2554,6 +2570,7 @@ namespace GeminiV26.Core
 
         public void RehydrateOpenPositions()
         {
+            EnsureRuntimeResolverInitialized();
             EnsureStartupMemoryReady();
             AuditMemoryCoverage();
             AuditResolverCoverage();

--- a/GeminiV26Bot.cs
+++ b/GeminiV26Bot.cs
@@ -45,6 +45,7 @@ namespace GeminiV26
             // 🔹 CORE
             // =========================
             _core = new TradeCore(this);
+            _core.Init();
 
             // =========================
             // 🔹 LOGGERS


### PR DESCRIPTION
### Motivation
- Prevent type-load / field-initialization execution of symbol resolver so no symbol/system logic runs before `OnStart` and avoid the type-load crash that removed logs.

### Description
- Removed eager creation of the resolver from the `TradeCore` constructor by deleting ` _runtimeSymbols = new RuntimeSymbolResolver(_bot);` and changed the field from `readonly` to runtime-initialized (`private RuntimeSymbolResolver _runtimeSymbols;`).
- Added explicit runtime initializer `TradeCore.Init()` and an idempotent helper `EnsureRuntimeResolverInitialized()` which constructs `RuntimeSymbolResolver` and logs `[RESOLVER][INIT] mode=runtime_only phase=OnStart`.
- Added guarded calls to `EnsureRuntimeResolverInitialized()` at the start of `OnBar`, `OnTick`, and `RehydrateOpenPositions` so resolver code never runs before runtime entrypoints.
- Updated bot startup flow to call `_core.Init()` from `GeminiV26Bot.OnStart()` immediately after creating `TradeCore()` to ensure resolver creation happens during `OnStart` only.

### Testing
- Ran targeted static checks with ripgrep to verify no `static` or field-initializer instantiations remain and that `Init()` and `EnsureRuntimeResolverInitialized()` appear; these pattern searches succeeded (found the new `Init` and no eager `new RuntimeSymbolResolver` in constructors).
- Verified presence of `_core.Init()` insertion in `GeminiV26Bot.OnStart()` and guard calls in `Core/TradeCore.cs` via file diff inspection; the diffs matched the intended changes.
- Performed additional `rg` searches for resolver-related patterns (`RuntimeSymbolResolver` instantiations and `_core.Init` usage) which returned the expected results indicating the resolver is now runtime-only; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c319af012c8328a4d7fef6eeb844bb)