### PR TITLE
Remove broker symbol scanning loops from resolver and startup

### DIFF
--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -77,33 +77,14 @@ namespace GeminiV26.Core
                 return true;
             }
 
-            foreach (var symbolEntry in _bot.Symbols)
+            if (TryResolveKnownRuntimeMapping(requested, canonical, out symbol))
             {
-                object raw = symbolEntry;
-                string runtimeName = raw is Symbol runtimeSymbol
-                    ? runtimeSymbol.Name
-                    : raw?.ToString();
-
-                if (string.IsNullOrWhiteSpace(runtimeName))
-                    continue;
-
-                string runtimeCanonical = SymbolRouting.NormalizeSymbol(runtimeName);
-                if (!IsGeminiSupportedCanonical(runtimeCanonical))
-                    continue;
-
-                if (!string.Equals(runtimeCanonical, canonical, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                symbol = _bot.Symbols.GetSymbol(runtimeName);
-                if (!IsUsableSymbol(symbol))
-                    continue;
-
-                CacheAliases(requested, canonical, symbol);
-                _bot.Print($"[RESOLVER][RUNTIME] source=scan runtime={symbol.Name}");
+                _bot.Print($"[RESOLVER][RUNTIME] source=known_map runtime={symbol.Name}");
                 _bot.Print($"[RESOLVER][SUCCESS] input={requested} canonical={canonical} runtime={symbol.Name}");
                 return true;
             }
 
+            _bot.Print("[SYMBOL][SKIP] " + canonical);
             _bot.Print($"[RESOLVER][SKIP] reason=runtime_not_found canonical={canonical}");
             return false;
         }
@@ -201,6 +182,29 @@ namespace GeminiV26.Core
 
             return string.Equals(canonical, botCanonicalFromName, StringComparison.OrdinalIgnoreCase)
                    || string.Equals(canonical, botCanonicalFromSymbol, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private bool TryResolveKnownRuntimeMapping(string requested, string canonical, out Symbol symbol)
+        {
+            symbol = null;
+
+            var candidates = SymbolRouting.GetKnownRuntimeCandidates(canonical);
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                string candidate = candidates[i];
+                if (string.IsNullOrWhiteSpace(candidate))
+                    continue;
+
+                var mapped = _bot.Symbols.GetSymbol(candidate);
+                if (!IsUsableSymbol(mapped))
+                    continue;
+
+                CacheAliases(requested, canonical, mapped);
+                symbol = mapped;
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/Core/SymbolRouting.cs
+++ b/Core/SymbolRouting.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace GeminiV26.Core
 {
@@ -12,6 +13,16 @@ namespace GeminiV26.Core
 
     public static class SymbolRouting
     {
+        private static readonly Dictionary<string, string[]> KnownRuntimeSymbolMap = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["NAS100"] = new[] { "NAS100", "US100", "USTECH100", "USTECH" },
+            ["GER40"] = new[] { "GER40", "DE40", "DAX40", "DAX", "GERMANY40", "GER" },
+            ["US30"] = new[] { "US30", "DJ30", "DOW" },
+            ["BTCUSD"] = new[] { "BTCUSD", "XBTUSD" },
+            ["XAUUSD"] = new[] { "XAUUSD", "GOLD" },
+            ["XAGUSD"] = new[] { "XAGUSD", "SILVER" }
+        };
+
         public static string NormalizeSymbol(string symbol)
         {
             var s = (symbol ?? string.Empty)
@@ -50,6 +61,15 @@ namespace GeminiV26.Core
                 return InstrumentClass.INDEX;
 
             return InstrumentClass.FX;
+        }
+
+        public static IReadOnlyList<string> GetKnownRuntimeCandidates(string canonical)
+        {
+            var normalized = NormalizeSymbol(canonical);
+            if (KnownRuntimeSymbolMap.TryGetValue(normalized, out var known))
+                return known;
+
+            return new[] { normalized };
         }
     }
 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1937,7 +1937,7 @@ namespace GeminiV26.Core
             }
 
             _bot.Print("STEP 1: before symbol loop");
-            var symbols = GetBrokerCanonicalSymbols();
+            var symbols = GetTrackedCanonicalSymbols();
 
             foreach (var symbol in symbols)
             {
@@ -2608,7 +2608,7 @@ namespace GeminiV26.Core
 
         private void AuditMemoryCoverage()
         {
-            var symbols = GetBrokerCanonicalSymbols();
+            var symbols = GetTrackedCanonicalSymbols();
             bool isStartupWindow = BotRestartState.BarsSinceStart <= 5;
 
             foreach (var symbol in symbols)
@@ -2658,7 +2658,7 @@ namespace GeminiV26.Core
 
         private void AuditResolverCoverage()
         {
-            var symbols = GetBrokerCanonicalSymbols();
+            var symbols = GetTrackedCanonicalSymbols();
             int resolved = 0;
             int total = 0;
             bool isStartupWindow = BotRestartState.BarsSinceStart <= 5;
@@ -2684,29 +2684,17 @@ namespace GeminiV26.Core
             _bot.Print($"[RESOLVER][COVERAGE] resolved={resolved}/{total}");
         }
 
-        private List<string> GetBrokerCanonicalSymbols()
+        private List<string> GetTrackedCanonicalSymbols()
         {
-            var symbols = _bot.Symbols;
             var canonicalSymbols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            string symbolName = _bot.Symbol?.Name;
+            string chartSymbolName = _bot.SymbolName;
 
-            foreach (var symbolEntry in symbols)
-            {
-                object raw = symbolEntry;
-                string symbolName = raw is Symbol entrySymbol
-                    ? entrySymbol.Name
-                    : raw?.ToString();
+            if (!string.IsNullOrWhiteSpace(symbolName))
+                canonicalSymbols.Add(NormalizeSymbol(symbolName));
 
-                if (string.IsNullOrWhiteSpace(symbolName))
-                    continue;
-
-                var symbol = symbols.GetSymbol(symbolName);
-                if (!IsTradable(symbol))
-                    continue;
-
-                string canonical = NormalizeSymbol(symbol.Name);
-                if (!string.IsNullOrWhiteSpace(canonical))
-                    canonicalSymbols.Add(canonical);
-            }
+            if (!string.IsNullOrWhiteSpace(chartSymbolName))
+                canonicalSymbols.Add(NormalizeSymbol(chartSymbolName));
 
             return canonicalSymbols
                 .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
### Motivation
- Eliminate blocking full broker symbol scans that caused the bot to freeze on startup and be terminated. 
- Ensure symbol resolution is deterministic and bounded by using only the current chart symbol and a fixed canonical→runtime mapping instead of discovery loops. 
- Add a clear skip path and logging for unresolved symbols to avoid expensive fallback scans.

### Description
- Added a predefined canonical→runtime alias map `KnownRuntimeSymbolMap` and `GetKnownRuntimeCandidates()` in `Core/SymbolRouting.cs` for deterministic candidate lists. 
- Replaced the `_bot.Symbols` enumeration in `Core/RuntimeSymbolResolver.cs` with `TryResolveKnownRuntimeMapping()` which tries known runtime candidates via direct `GetSymbol(...)` lookups and removed the scanning `foreach` loop. 
- Added the safety log `Print("[SYMBOL][SKIP] " + canonical)` on resolver failure and kept the existing cache/direct lookup/code paths intact. 
- Replaced `GetBrokerCanonicalSymbols()` in `Core/TradeCore.cs` with `GetTrackedCanonicalSymbols()` and updated startup/audit callers to only use `_bot.Symbol?.Name` and `_bot.SymbolName`, removing broker-wide discovery loops.

### Testing
- Ran targeted `rg` searches for `foreach (... in ...Symbols)` and `_bot.Symbols` to confirm the scanning loops were removed and only direct `GetSymbol(...)` lookups remain, and these checks succeeded. 
- Inspected the modified files (`Core/RuntimeSymbolResolver.cs`, `Core/SymbolRouting.cs`, `Core/TradeCore.cs`) to verify the new mapping and resolver flow were applied as intended. 
- Created the PR payload via the repository tooling and validated that the code no longer contains broker symbol enumeration in `Core` (search-based validation passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c31cf0fbe48328a84ceaffb4a738f4)