### PR TITLE
Unify score/confidence to 0..100; normalize TransitionQuality and add score tracing

### DIFF
--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -367,14 +367,19 @@ namespace GeminiV26.Core.Entry
 
             if (hasImpulse)
             {
-                qualityScore =
+                double qualityScore01 =
                     (impulseStrength * 0.4) +
                     (compressionScore * 0.3) +
                     (pullbackQuality * 0.3);
 
+                qualityScore = Math.Max(0.0, Math.Min(100.0, qualityScore01 * 100.0));
+
                 bonus = isTradable
-                    ? Clamp((int)(qualityScore * 10.0), 5, 18)
+                    ? Clamp((int)(qualityScore01 * 10.0), 5, 18)
                     : 0;
+
+                ctx.Log?.Invoke(
+                    $"[SCORE][TRANSITION] raw={qualityScore01:0.0000} normalized={qualityScore:0.00}");
             }
 
             string reason = BuildReason(

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1823,12 +1823,24 @@ namespace GeminiV26.Core
             if (ctx == null || selected == null)
                 return;
 
+            int normalizedEntryScore = PositionContext.ClampRiskConfidence(selected.Score);
             int logicConfidence = Math.Max(0, ctx.LogicBiasConfidence);
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(selected.Score, logicConfidence);
+            int normalizedLogicConfidence = PositionContext.ClampRiskConfidence(logicConfidence);
+            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(normalizedEntryScore, normalizedLogicConfidence);
             int riskFinal = PositionContext.ClampRiskConfidence(finalConfidence);
 
             _bot.Print(TradeLogIdentity.WithTempId(
-                TradeAuditLog.BuildEntrySnapshot(_bot, ctx, selected, logicConfidence, finalConfidence, 0, riskFinal),
+                $"[SCORE][PRODUCER] source=EntryScore raw={selected.Score} normalized={normalizedEntryScore}",
+                ctx));
+            _bot.Print(TradeLogIdentity.WithTempId(
+                $"[SCORE][PRODUCER] source=LogicConfidence raw={logicConfidence} normalized={normalizedLogicConfidence}",
+                ctx));
+            _bot.Print(TradeLogIdentity.WithTempId(
+                $"[SCORE][BLEND] entry={normalizedEntryScore} logic={normalizedLogicConfidence} final={finalConfidence}",
+                ctx));
+
+            _bot.Print(TradeLogIdentity.WithTempId(
+                TradeAuditLog.BuildEntrySnapshot(_bot, ctx, selected, normalizedLogicConfidence, finalConfidence, 0, riskFinal),
                 ctx));
             _bot.Print(TradeLogIdentity.WithTempId(
                 TradeAuditLog.BuildDirectionSnapshot(ctx, selected),

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -86,6 +86,9 @@ namespace GeminiV26.Core
                     }
                 }
 
+                _bot.Print(TradeLogIdentity.WithTempId(
+                    $"[SCORE][DECISION_INPUT] entry={candidate.Score} logic={entryContext?.LogicBiasConfidence ?? 0} final={PositionContext.ComputeFinalConfidenceValue(candidate.Score, entryContext?.LogicBiasConfidence ?? 0)} threshold={EntryDecisionPolicy.MinScoreThreshold}",
+                    entryContext));
                 _bot.Print(TradeLogIdentity.WithTempId($"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} score={candidate.Score} threshold={EntryDecisionPolicy.MinScoreThreshold} valid={candidate.IsValid.ToString().ToLowerInvariant()} state={candidate.State} trigger={candidate.TriggerConfirmed.ToString().ToLowerInvariant()} → {decision}", entryContext));
             }
 


### PR DESCRIPTION
### Motivation
- Fix a mixed-scale bug where transition quality was produced on a 0..1 scale while the rest of the pipeline (scores, thresholds, FinalConfidence) expects 0..100, which produced misleading telemetry like `score = 0.40` instead of `40`.

### Description
- Normalized the transition producer so `TransitionDetector` now converts the internal `qualityScore01` (0..1) to a canonical `qualityScore` on `0..100` at the producer boundary while keeping bonus computation on the original `0..1` value to preserve business semantics; file changed: `Core/Entry/TransitionDetector.cs`.
- Added explicit score boundary tracing logs at production and blend points: `[SCORE][TRANSITION] raw=... normalized=...` in `TransitionDetector`, `[SCORE][PRODUCER] source=EntryScore raw=... normalized=...` and `[SCORE][PRODUCER] source=LogicConfidence raw=... normalized=...` plus `[SCORE][BLEND] entry=... logic=... final=...` in `Core/TradeCore.cs` to show inputs and the computed `FinalConfidence` used for risk.
- Added a router-level trace `[SCORE][DECISION_INPUT] entry=... logic=... final=... threshold=...` in `Core/TradeRouter.cs` so decision inputs can be audited at the routing boundary.
- Files changed: `Core/Entry/TransitionDetector.cs`, `Core/TradeCore.cs`, `Core/TradeRouter.cs`, and all edits are limited to score/confidence scaling and the required trace logs; no entry/exit/routing/business logic or thresholds were modified.

### Testing
- Attempted build with `dotnet build -nologo`, but the environment lacks the `dotnet` SDK so the build could not be executed (`/bin/bash: dotnet: command not found`).
- Static inspection and repository-wide searches (`rg`) were used to identify producers and consumers and to verify the single-point normalization approach, and no other code paths were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a4574e808328947887242495a6c5)