### PR TITLE
Reduce ExitManager rehydrate-only log spam for active live positions

### DIFF
--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.AUDNZD
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.AUDNZD
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.AUDNZD
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.AUDNZD
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.AUDNZD
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.AUDNZD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.AUDNZD
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.AUDNZD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.AUDUSD
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.AUDUSD
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.AUDUSD
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.AUDUSD
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.AUDUSD
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.AUDUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.AUDUSD
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.AUDUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -24,6 +24,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
         // PositionId -> context
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private readonly TradeViabilityMonitor _tvm;
         private readonly TrendTradeManager _trendTradeManager;
@@ -76,7 +77,16 @@ namespace GeminiV26.Instruments.BTCUSD
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
@@ -84,7 +94,7 @@ namespace GeminiV26.Instruments.BTCUSD
         // =========================================================
         // BAR-LEVEL EXIT MANAGEMENT
         // =========================================================
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -94,8 +104,32 @@ namespace GeminiV26.Instruments.BTCUSD
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -104,18 +138,37 @@ namespace GeminiV26.Instruments.BTCUSD
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -132,7 +185,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -167,13 +220,14 @@ namespace GeminiV26.Instruments.BTCUSD
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -220,7 +274,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
 
@@ -250,8 +304,8 @@ namespace GeminiV26.Instruments.BTCUSD
 
                         if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                         {
-                            if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                            if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -277,6 +331,7 @@ namespace GeminiV26.Instruments.BTCUSD
                                 ctx.IsFullyClosing = true;
                                 _bot.ClosePosition(pos);
                                 _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                                 continue;
                             }
                         }
@@ -315,7 +370,7 @@ namespace GeminiV26.Instruments.BTCUSD
         // =========================================================
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             // 1) Partial close (crypto-safe)
@@ -529,7 +584,7 @@ namespace GeminiV26.Instruments.BTCUSD
             SafeModify(pos, pos.StopLoss, newTp);
 
             double? currentPrice = null;
-            if (TryResolveExitSymbol(pos, out var sym))
+            if (TryResolveExitSymbol(pos, out var sym, ctx))
                 currentPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -22,6 +22,7 @@ namespace GeminiV26.Instruments.ETHUSD
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.05;
 
@@ -66,12 +67,21 @@ namespace GeminiV26.Instruments.ETHUSD
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -81,8 +91,32 @@ namespace GeminiV26.Instruments.ETHUSD
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -91,18 +125,37 @@ namespace GeminiV26.Instruments.ETHUSD
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -119,7 +172,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -151,13 +204,14 @@ namespace GeminiV26.Instruments.ETHUSD
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -205,7 +259,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
 
@@ -231,8 +285,8 @@ namespace GeminiV26.Instruments.ETHUSD
 
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -257,6 +311,7 @@ namespace GeminiV26.Instruments.ETHUSD
                             _bot.ClosePosition(pos);
 
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
 
                             continue;
                         }
@@ -302,7 +357,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.EURJPY
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.EURJPY
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.EURJPY
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.EURJPY
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.EURJPY
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.EURJPY
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.EURJPY
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.EURJPY
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.EURJPY
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.EURJPY
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.EURUSD
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.EURUSD
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.EURUSD
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.EURUSD
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.EURUSD
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.EURUSD
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.EURUSD
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.EURUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.EURUSD
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.EURUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.GBPJPY
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.GBPJPY
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.GBPJPY
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.GBPJPY
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.GBPJPY
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.GBPJPY
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.GBPJPY
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.GBPJPY
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.GBPUSD
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.GBPUSD
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.GBPUSD
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.GBPUSD
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.GBPUSD
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.GBPUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.GBPUSD
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.GER40
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.GER40
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.GER40
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.GER40
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.GER40
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.GER40
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.GER40
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.GER40
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.GER40
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.GER40
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.NAS100
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.NAS100
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.NAS100
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.NAS100
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.NAS100
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.NAS100
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.NAS100
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.NAS100
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.NAS100
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.NAS100
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.NZDUSD
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.NZDUSD
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.NZDUSD
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.NZDUSD
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.NZDUSD
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.NZDUSD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.NZDUSD
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.NZDUSD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.US30
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.05;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.US30
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.US30
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.US30
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.US30
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.US30
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.US30
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.US30
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.US30
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.US30
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.USDCAD
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.USDCAD
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.USDCAD
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.USDCAD
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.USDCAD
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.USDCAD
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.USDCAD
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.USDCAD
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.USDCAD
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.USDCAD
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.USDCHF
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.USDCHF
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.USDCHF
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.USDCHF
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.USDCHF
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.USDCHF
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.USDCHF
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.USDCHF
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.USDCHF
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.USDCHF
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -20,6 +20,7 @@ namespace GeminiV26.Instruments.USDJPY
         private readonly StructureTracker _structureTracker;
 
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         private const double BeOffsetR = 0.10;
 
@@ -49,12 +50,21 @@ namespace GeminiV26.Instruments.USDJPY
                 return;
             }
 
-            _contexts[Convert.ToInt64(ctx.PositionId)] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
 
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -64,8 +74,32 @@ namespace GeminiV26.Instruments.USDJPY
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -74,18 +108,37 @@ namespace GeminiV26.Instruments.USDJPY
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -102,7 +155,7 @@ namespace GeminiV26.Instruments.USDJPY
 
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(position, out var stateSymbol))
+            if (TryResolveExitSymbol(position, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -134,13 +187,14 @@ namespace GeminiV26.Instruments.USDJPY
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -184,7 +238,7 @@ namespace GeminiV26.Instruments.USDJPY
 
                     if (!reached)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var m1Bar = m1.LastBar;
                             reached = IsLong(ctx)
@@ -204,8 +258,8 @@ namespace GeminiV26.Instruments.USDJPY
                     const int MinBarsBeforeTvm = 4;
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -226,6 +280,7 @@ namespace GeminiV26.Instruments.USDJPY
                             ctx.IsFullyClosing = true;
                             _bot.ClosePosition(pos);
                             _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                             continue;
                         }
                     }
@@ -251,7 +306,7 @@ namespace GeminiV26.Instruments.USDJPY
 
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double frac = ctx.Tp1CloseFraction;

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -51,6 +51,7 @@ namespace GeminiV26.Instruments.XAUUSD
         private readonly StructureTracker _structureTracker;
         // PositionId → Context
         private readonly Dictionary<long, PositionContext> _contexts = new();
+        private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
         public XauExitManager(Robot bot)
         {
@@ -90,7 +91,16 @@ namespace GeminiV26.Instruments.XAUUSD
                 return;
             }
 
-            _contexts[ctx.PositionId] = ctx;
+            long key = Convert.ToInt64(ctx.PositionId);
+            bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
+            bool suppressRehydrateRegistrationLog =
+                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+
+            _contexts[key] = ctx;
+
+            if (suppressRehydrateRegistrationLog)
+                return;
+
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx));
         }
@@ -98,7 +108,7 @@ namespace GeminiV26.Instruments.XAUUSD
         // =====================================================
         // BAR-LEVEL EXIT (jelenleg csak early exit placeholder)
         // =====================================================
-        private bool TryResolveExitSymbol(Position pos, out Symbol symbol)
+        private bool TryResolveExitSymbol(Position pos, out Symbol symbol, PositionContext ctx = null)
         {
             symbol = null;
 
@@ -108,8 +118,32 @@ namespace GeminiV26.Instruments.XAUUSD
                 return false;
             }
 
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+                if (suppressRepeatedRehydrateResolverLog)
+                {
+                    symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
+                    if (symbol != null)
+                    {
+                        _rehydratedResolverSkipLogged.Remove(key);
+                        _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
+            {
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
                 return true;
+            }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
@@ -118,18 +152,37 @@ namespace GeminiV26.Instruments.XAUUSD
                 return true;
             }
 
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
             _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos.SymbolName} positionId={pos.Id} reason=unresolved_runtime_symbol");
             return false;
         }
 
-        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars)
+        private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
+            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool suppressRepeatedRehydrateResolverLog = false;
+            if (isRehydratedContext)
+            {
+                long key = Convert.ToInt64(ctx.PositionId);
+                suppressRepeatedRehydrateResolverLog = _rehydratedResolverSkipLogged.Contains(key);
+            }
+
             if (pos == null || !_runtimeSymbols.TryGetBars(timeFrame, pos.SymbolName, out bars))
             {
-                _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+                if (isRehydratedContext)
+                    _rehydratedResolverSkipLogged.Add(Convert.ToInt64(ctx.PositionId));
+
+                if (!suppressRepeatedRehydrateResolverLog)
+                    _bot.Print($"[RESOLVER][EXIT_SKIP] symbol={pos?.SymbolName ?? "UNKNOWN"} positionId={pos?.Id ?? 0} reason=unresolved_runtime_symbol");
+
                 return false;
             }
+
+            if (isRehydratedContext)
+                _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
 
             return bars != null;
         }
@@ -144,7 +197,7 @@ namespace GeminiV26.Instruments.XAUUSD
             // =====================================================
             ctx.BarsSinceEntryM5++;
 
-            if (TryResolveExitSymbol(pos, out var stateSymbol))
+            if (TryResolveExitSymbol(pos, out var stateSymbol, ctx))
             {
                 string stateFingerprint = $"{ctx.BarsSinceEntryM5}|{ctx.Tp1Hit}|{ctx.BeActivated}|{ctx.TrailingActivated}|{ctx.TrailSteps}";
                 if (ctx.LastStateTraceBarIndex != ctx.BarsSinceEntryM5 || !string.Equals(ctx.LastStateTraceFingerprint, stateFingerprint, StringComparison.Ordinal))
@@ -191,13 +244,14 @@ namespace GeminiV26.Instruments.XAUUSD
 
                     _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][CLEANUP]\nreason=position_not_found", ctx));
                     _contexts.Remove(key);
+                    _rehydratedResolverSkipLogged.Remove(key);
                     continue;
                 }
 
                 if (!pos.StopLoss.HasValue)
                     continue;
 
-                if (!TryResolveExitSymbol(pos, out var sym))
+                if (!TryResolveExitSymbol(pos, out var sym, ctx))
                     continue;
 
                 double rDist = GetRiskDistance(pos, ctx);
@@ -249,7 +303,7 @@ namespace GeminiV26.Instruments.XAUUSD
                                         
                     if (!hit)
                     {
-                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1) && m1.Count > 0)
+                        if (TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) && m1.Count > 0)
                         {
                             var bar = m1.LastBar;
 
@@ -271,8 +325,8 @@ namespace GeminiV26.Instruments.XAUUSD
                     
                     if (ctx.BarsSinceEntryM5 >= MinBarsBeforeTvm)
                     {
-                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5) ||
-                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15))
+                        if (!TryGetExitBars(pos, TimeFrame.Minute5, out var m5, ctx) ||
+                            !TryGetExitBars(pos, TimeFrame.Minute15, out var m15, ctx))
                         {
                             continue;
                         }
@@ -334,7 +388,7 @@ namespace GeminiV26.Instruments.XAUUSD
         // =====================================================
         private void ExecuteTp1(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             // Partial close fraction: ctx-ből (executor beállította)
@@ -406,7 +460,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
         private void ApplyBreakEven(Position pos, PositionContext ctx, double rDist)
         {
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             double beOffsetR = _profile.BeOffsetR;
@@ -443,7 +497,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (!pos.StopLoss.HasValue)
                 return;
 
-            if (!TryResolveExitSymbol(pos, out var sym))
+            if (!TryResolveExitSymbol(pos, out var sym, ctx))
                 return;
 
             // ===== ATR (előre inicializált indikátor!) =====
@@ -599,7 +653,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 return;
 
             double? currentPrice = null;
-            if (TryResolveExitSymbol(pos, out var sym))
+            if (TryResolveExitSymbol(pos, out var sym, ctx))
                 currentPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
 
             double baseR = ctx.Tp2R > 0 ? ctx.Tp2R : 1.0;


### PR DESCRIPTION
### Motivation
- Startup rehydrate + already-live positions caused identical ExitManager logs to repeat every tick, cluttering logs and making diagnostics harder.
- The intent is to suppress only rehydrate-origin, repeated logs without changing entry/exit logic, TP1/trailing/BE behavior, routing, or global logging architecture.
- Fix must rely on existing per-position state where possible (rehydrated flag / context state) and be scoped to ExitManagers only.

### Description
- Suppress duplicate registration logs in `RegisterContext` by skipping the `ContextCreate` / `DirectionSnapshot` prints when both the incoming and existing context for the same position are `IsRehydrated` (per-manager change in each instrument ExitManager). 
- Add a per-manager local guard `private readonly HashSet<long> _rehydratedResolverSkipLogged` to avoid repeating unresolved resolver/bar logs for unchanged rehydrated contexts, and remove that entry on cleanup to avoid stuck suppression. 
- Propagate `PositionContext ctx` into `TryResolveExitSymbol(...)` and `TryGetExitBars(...)` calls and gates the `RESOLVER`/bars `EXIT_SKIP` logs only when `ctx.IsRehydrated` indicates the context is from rehydrate; resolvers still log a single recover event when runtime symbols/bars become available. 
- Applied the same minimal pattern to all instrument ExitManagers (AUDNZD, AUDUSD, BTCUSD, ETHUSD, EURJPY, EURUSD, GBPJPY, GBPUSD, GER40, NAS100, NZDUSD, US30, USDCAD, USDCHF, USDJPY, XAUUSD) without touching entry logic, exit conditions, TP1/trailing/BE, TradeCore, router, or RiskSizer.

### Testing
- Ran repository scans to verify instrumentation presence with `rg` and confirmed new suppression markers exist (counts: `suppressRehydrateRegistrationLog` occurrences and `_rehydratedResolverSkipLogged` occurrences) and found `TryResolveExitSymbol(..., ctx)` call sites updated; these searches completed successfully. 
- Performed a commit of the changes which succeeded and reports `16 files changed` in the working set. 
- No unit/integration test suite was modified or run; automated file-level checks (`rg` + `git commit`) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3b18813e08328a42deb459217aeee)