### PR TITLE
Guard rehydrate and post-entry lifecycle flows to run once per position

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -381,6 +381,24 @@ namespace GeminiV26.Core
         public string RehydrateSource { get; set; } = string.Empty;
 
         /// <summary>
+        /// Post-entry lifecycle initialization has been completed for this position.
+        /// Guards one-time post-entry setup/logging in exit lifecycle registration.
+        /// </summary>
+        public bool PostEntryInitializationCompleted { get; set; }
+
+        /// <summary>
+        /// Rehydrate-specific recovery path completed.
+        /// Once true, rehydrate resolver/recovery flow must not re-run on normal ticks.
+        /// </summary>
+        public bool RehydrateRecoveryCompleted { get; set; }
+
+        /// <summary>
+        /// Indicates whether the position still requires rehydrate recovery handling.
+        /// </summary>
+        public bool RequiresRehydrateRecovery => IsRehydrated && !RehydrateRecoveryCompleted;
+
+
+        /// <summary>
         /// Utolsó ismert SL ár (pozíció az igazság).
         /// Trailing restore előkészítés.
         /// </summary>

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.AUDNZD
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.AUDNZD
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.AUDNZD
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.AUDNZD
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.AUDNZD
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.AUDNZD
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.AUDUSD
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.AUDUSD
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.AUDUSD
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.AUDUSD
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.AUDUSD
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.AUDUSD
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -80,11 +80,16 @@ namespace GeminiV26.Instruments.BTCUSD
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -104,7 +109,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -116,6 +121,7 @@ namespace GeminiV26.Instruments.BTCUSD
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -127,13 +133,19 @@ namespace GeminiV26.Instruments.BTCUSD
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -148,7 +160,7 @@ namespace GeminiV26.Instruments.BTCUSD
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -168,7 +180,10 @@ namespace GeminiV26.Instruments.BTCUSD
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -70,11 +70,16 @@ namespace GeminiV26.Instruments.ETHUSD
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -91,7 +96,7 @@ namespace GeminiV26.Instruments.ETHUSD
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -103,6 +108,7 @@ namespace GeminiV26.Instruments.ETHUSD
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -114,13 +120,19 @@ namespace GeminiV26.Instruments.ETHUSD
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -135,7 +147,7 @@ namespace GeminiV26.Instruments.ETHUSD
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -155,7 +167,10 @@ namespace GeminiV26.Instruments.ETHUSD
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.EURJPY
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.EURJPY
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.EURJPY
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.EURJPY
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.EURJPY
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.EURJPY
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.EURUSD
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.EURUSD
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.EURUSD
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.EURUSD
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.EURUSD
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.EURUSD
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.GBPJPY
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.GBPJPY
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.GBPJPY
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.GBPJPY
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.GBPJPY
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.GBPJPY
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.GBPUSD
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.GBPUSD
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.GBPUSD
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.GBPUSD
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.GBPUSD
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.GBPUSD
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.GER40
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.GER40
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.GER40
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.GER40
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.GER40
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.GER40
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.NAS100
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.NAS100
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.NAS100
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.NAS100
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.NAS100
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.NAS100
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.NZDUSD
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.NZDUSD
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.NZDUSD
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.NZDUSD
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.NZDUSD
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.NZDUSD
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.US30
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.US30
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.US30
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.US30
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.US30
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.US30
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.USDCAD
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.USDCAD
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.USDCAD
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.USDCAD
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.USDCAD
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.USDCAD
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.USDCHF
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.USDCHF
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.USDCHF
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.USDCHF
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.USDCHF
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.USDCHF
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -53,11 +53,16 @@ namespace GeminiV26.Instruments.USDJPY
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -74,7 +79,7 @@ namespace GeminiV26.Instruments.USDJPY
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -86,6 +91,7 @@ namespace GeminiV26.Instruments.USDJPY
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -97,13 +103,19 @@ namespace GeminiV26.Instruments.USDJPY
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -118,7 +130,7 @@ namespace GeminiV26.Instruments.USDJPY
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -138,7 +150,10 @@ namespace GeminiV26.Instruments.USDJPY
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -94,11 +94,16 @@ namespace GeminiV26.Instruments.XAUUSD
             long key = Convert.ToInt64(ctx.PositionId);
             bool hasExisting = _contexts.TryGetValue(key, out var existingCtx) && existingCtx != null;
             bool suppressRehydrateRegistrationLog =
-                ctx.IsRehydrated && hasExisting && existingCtx.IsRehydrated;
+                ctx.RequiresRehydrateRecovery && hasExisting && existingCtx.RequiresRehydrateRecovery;
+            bool suppressPostEntryRegistrationLog =
+                hasExisting && existingCtx.PostEntryInitializationCompleted && ctx.PostEntryInitializationCompleted;
 
             _contexts[key] = ctx;
 
-            if (suppressRehydrateRegistrationLog)
+            if (!ctx.PostEntryInitializationCompleted)
+                ctx.PostEntryInitializationCompleted = true;
+
+            if (suppressRehydrateRegistrationLog || suppressPostEntryRegistrationLog)
                 return;
 
             _bot.Print(TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx));
@@ -118,7 +123,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 return false;
             }
 
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -130,6 +135,7 @@ namespace GeminiV26.Instruments.XAUUSD
                     if (symbol != null)
                     {
                         _rehydratedResolverSkipLogged.Remove(key);
+                        ctx.RehydrateRecoveryCompleted = true;
                         _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                         return true;
                     }
@@ -141,13 +147,19 @@ namespace GeminiV26.Instruments.XAUUSD
             if (_runtimeSymbols.TryGetSymbolMeta(pos.SymbolName, out symbol) && symbol != null)
             {
                 if (isRehydratedContext)
+                {
                     _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                    ctx.RehydrateRecoveryCompleted = true;
+                }
                 return true;
             }
 
             symbol = _bot.Symbols.GetSymbol(pos.SymbolName);
             if (symbol != null)
             {
+                if (isRehydratedContext)
+                    ctx.RehydrateRecoveryCompleted = true;
+
                 _bot.Print($"[RESOLVER][EXIT_RECOVER] symbol={pos.SymbolName} positionId={pos.Id} source=platform_symbols");
                 return true;
             }
@@ -162,7 +174,7 @@ namespace GeminiV26.Instruments.XAUUSD
         private bool TryGetExitBars(Position pos, TimeFrame timeFrame, out Bars bars, PositionContext ctx = null)
         {
             bars = null;
-            bool isRehydratedContext = ctx?.IsRehydrated == true;
+            bool isRehydratedContext = ctx?.RequiresRehydrateRecovery == true;
             bool suppressRepeatedRehydrateResolverLog = false;
             if (isRehydratedContext)
             {
@@ -182,7 +194,10 @@ namespace GeminiV26.Instruments.XAUUSD
             }
 
             if (isRehydratedContext)
+            {
                 _rehydratedResolverSkipLogged.Remove(Convert.ToInt64(ctx.PositionId));
+                ctx.RehydrateRecoveryCompleted = true;
+            }
 
             return bars != null;
         }


### PR DESCRIPTION
### Motivation
- Repeated execution of rehydrate/recovery and post-entry initialization on every tick produced continuous log spam and redundant processing for the same position lifecycle. 
- The intent is to ensure rehydrate and post-entry lifecycle logic run exactly once per position lifecycle while keeping the existing context/lifecycle model intact.

### Description
- Added lifecycle flags to `PositionContext`: `PostEntryInitializationCompleted`, `RehydrateRecoveryCompleted`, and computed helper `RequiresRehydrateRecovery` to represent pending rehydrate recovery. 
- Updated all instrument exit managers' `RegisterContext` to mark `PostEntryInitializationCompleted` on first registration and to suppress duplicate registration logs when post-entry initialization or rehydrate registration has already completed. 
- Changed rehydrate/resolver logic in exit managers to consider `RequiresRehydrateRecovery` and to set `RehydrateRecoveryCompleted` on the first successful resolver/bars recovery so rehydrate-related resolver paths do not re-run on subsequent ticks. 
- Changes are local and surgical: they reuse the canonical `PositionContext` state, do not modify entry/routing/risk/exit math, and preserve logging semantics for actual lifecycle transitions only.

### Testing
- Ran repository-wide pattern verification with `rg` to confirm the new `RequiresRehydrateRecovery` usage across exit managers and to count occurrences, which reported the updated matches (search-based validation succeeded). 
- Performed a commit of the change set which updated 17 files and recorded the commit as successful. 
- Attempted a direct build in this environment but did not run `dotnet build` because there was no solution/project file available here, so no full compile was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3b97453a48328a87888bfec3ab67c)