### PR TITLE
Attach read-only MarketMemoryEngine state to EntryContext during build

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -280,6 +280,8 @@ namespace GeminiV26.Core.Entry
         public bool RuntimeResolved { get; set; }
         public bool MemoryResolved { get; set; }
         public bool MemoryUsable { get; set; }
+        public SymbolMemoryState Memory { get; set; }
+        public bool HasMemory => Memory != null;
         public SymbolMemoryState MemoryState { get; set; }
         public MemoryAssessment MemoryAssessment { get; set; }
 

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -7,6 +7,7 @@ using GeminiV26.Instruments.METAL;
 using GeminiV26.Core.HtfBias;
 using GeminiV26.EntryTypes.METAL;
 using GeminiV26.Core;
+using Gemini.Memory;
 
 namespace GeminiV26.Core.Entry
 {
@@ -18,8 +19,9 @@ namespace GeminiV26.Core.Entry
         private readonly FxHtfBiasEngine _fxHtf;
         private readonly IndexHtfBiasEngine _indexHtf;
         private readonly MetalHtfBiasEngine _metalHtf;
+        private readonly MarketMemoryEngine _memoryEngine;
 
-        public EntryContextBuilder(Robot bot)
+        public EntryContextBuilder(Robot bot, MarketMemoryEngine memoryEngine)
         {
             _bot = bot;
             _runtimeSymbols = new RuntimeSymbolResolver(_bot);
@@ -27,6 +29,7 @@ namespace GeminiV26.Core.Entry
             _fxHtf = new FxHtfBiasEngine(_bot);
             _indexHtf = new IndexHtfBiasEngine(_bot);
             _metalHtf = new MetalHtfBiasEngine(_bot);
+            _memoryEngine = memoryEngine;
         }
 
         public static bool GetHasEarlyPullback_M5(EntryContext ctx)
@@ -66,6 +69,20 @@ namespace GeminiV26.Core.Entry
                 Log = message => _bot.Print(message)
             };
 
+            _bot.Print($"[MEMORY][CTX_ATTACH][START] symbol={symbol}");
+            var memory = _memoryEngine.GetState(symbol);
+
+            if (memory == null)
+            {
+                ctx.Memory = null;
+                _bot.Print($"[MEMORY][MISSING] symbol={symbol}");
+            }
+            else
+            {
+                ctx.Memory = memory;
+                _bot.Print($"[MEMORY][CTX_ATTACH] symbol={symbol} hasMemory=true phase={memory.MovePhase} isBuilt={memory.IsBuilt} isUsable={memory.IsUsable}");
+            }
+
             // -------------------------
             // BAR DATA
             // -------------------------
@@ -74,6 +91,8 @@ namespace GeminiV26.Core.Entry
                 !_runtimeSymbols.TryGetBars(TimeFrame.Minute15, symbol, out var m15))
             {
                 _bot.Print($"[RESOLVER][ENTRY_BLOCK] symbol={symbol} reason=unresolved_runtime_symbol");
+                _bot.Print($"[CTX][EARLY_RETURN] symbol={symbol} reason=unresolved_runtime_symbol");
+                _bot.Print($"[CTX][MEMORY_READY] symbol={symbol} hasMemory={ctx.HasMemory}");
                 return ctx;
             }
 
@@ -83,7 +102,11 @@ namespace GeminiV26.Core.Entry
             ctx.RuntimeResolved = true;
 
             if (ctx.M1.Count < 10 || ctx.M5.Count < 30 || ctx.M15.Count < 30)
+            {
+                _bot.Print($"[CTX][EARLY_RETURN] symbol={symbol} reason=insufficient_bars");
+                _bot.Print($"[CTX][MEMORY_READY] symbol={symbol} hasMemory={ctx.HasMemory}");
                 return ctx;
+            }
 
             int m1Idx = ctx.M1.Count - 2;
             int m5Idx = ctx.M5.Count - 2;
@@ -114,6 +137,8 @@ namespace GeminiV26.Core.Entry
             {
                 ctx.RuntimeResolved = false;
                 _bot.Print($"[RESOLVER][ENTRY_BLOCK] symbol={symbol} reason=unresolved_runtime_symbol");
+                _bot.Print($"[CTX][EARLY_RETURN] symbol={symbol} reason=unresolved_runtime_symbol");
+                _bot.Print($"[CTX][MEMORY_READY] symbol={symbol} hasMemory={ctx.HasMemory}");
                 return ctx;
             }
 
@@ -752,6 +777,7 @@ namespace GeminiV26.Core.Entry
             }
 
             ctx.IsReady = true;
+            _bot.Print($"[CTX][MEMORY_READY] symbol={symbol} hasMemory={ctx.HasMemory}");
             return ctx;
         }
 

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -374,7 +374,6 @@ namespace GeminiV26.Core
         
 
             _entryRouter = new EntryRouter(_entryTypes);
-            _contextBuilder = new EntryContextBuilder(bot);
             _transitionDetector = new TransitionDetector();
             Action<string> safePrint = msg => _bot.BeginInvokeOnMainThread(() => _bot.Print(msg));
             _flagBreakoutDetector = new FlagBreakoutDetector(safePrint);
@@ -384,6 +383,7 @@ namespace GeminiV26.Core
                 new CsvAnalyticsLogger(_logWriter, safePrint));
             _statsTracker = new TradeStatsTracker(safePrint);
             _memoryEngine = new MarketMemoryEngine(safePrint);
+            _contextBuilder = new EntryContextBuilder(bot, _memoryEngine);
             _globalSessionGate = new GlobalSessionGate(_bot);
             _sessionMatrix = new SessionMatrix(new SessionMatrixProvider());
 


### PR DESCRIPTION
### Motivation
- Integrate the existing MarketMemoryEngine into the EntryContext pipeline as read-only data so instruments can observe memory state without changing entry logic or scoring.
- Ensure memory attachment runs deterministically at context creation time (before the entry pipeline and before any early returns) and is null-safe.

### Description
- Added `SymbolMemoryState Memory` and helper `bool HasMemory => Memory != null` to `EntryContext` to carry the memory snapshot. (modified `Core/Entry/EntryContext.cs`)
- Injected `MarketMemoryEngine` into `EntryContextBuilder` via constructor and wired the existing `_memoryEngine` from `TradeCore` into the builder. (modified `Core/Entry/EntryContextBuilder.cs` and `Core/TradeCore.cs`)
- Performed the memory attach immediately after `ctx` creation inside `EntryContextBuilder.Build(symbol)` with null-safe assignment (`ctx.Memory = memory` or `null`) and without altering any entry decision, scoring, routing, or exit logic. (inserted code at top of `Build`) 
- Added required debug logs to cover lifecycle: `[MEMORY][CTX_ATTACH][START]`, `[MEMORY][CTX_ATTACH] ... phase=... isBuilt=... isUsable=...`, `[MEMORY][MISSING]`, and `[CTX][MEMORY_READY] symbol=... hasMemory=...` placed on normal completion and all early-return paths. (modified `Core/Entry/EntryContextBuilder.cs`)

### Testing
- Ran repository checks `git diff --check` which completed with no issues (success).
- Verified workspace state with `git status --short` showing no uncommitted changes and created a commit for the change (commit created successfully).
- Confirmed constructor call site update via code search to ensure the builder is constructed with the `MarketMemoryEngine` instance (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3bc6c065083289194ab17f73f3b50)