### PR TITLE
Deprecate legacy Core/lista.txt to prevent duplicate compilation

### DIFF
--- a/Core/lista.txt
+++ b/Core/lista.txt
@@ -1,16 +1,12 @@
-C:\Users\orken\Downloads\GeminiV26\Core\BeMode.cs
-C:\Users\orken\Downloads\GeminiV26\Core\ConfidenceTradeModel.cs
-C:\Users\orken\Downloads\GeminiV26\Core\Entry
-C:\Users\orken\Downloads\GeminiV26\Core\lista.txt
-C:\Users\orken\Downloads\GeminiV26\Core\PositionContext.cs
-C:\Users\orken\Downloads\GeminiV26\Core\RiskManager.cs
-C:\Users\orken\Downloads\GeminiV26\Core\TradeCore.cs
-C:\Users\orken\Downloads\GeminiV26\Core\TradeRouter.cs
-C:\Users\orken\Downloads\GeminiV26\Core\TradeViabilityMonitor.cs
-C:\Users\orken\Downloads\GeminiV26\Core\TrailingMode.cs
-C:\Users\orken\Downloads\GeminiV26\Core\Entry\EntryContext.cs
-C:\Users\orken\Downloads\GeminiV26\Core\Entry\EntryContextBuilder.cs
-C:\Users\orken\Downloads\GeminiV26\Core\Entry\EntryEvaluation.cs
-C:\Users\orken\Downloads\GeminiV26\Core\Entry\EntryRouter.cs
-C:\Users\orken\Downloads\GeminiV26\Core\Entry\EntryType.cs
-C:\Users\orken\Downloads\GeminiV26\Core\Entry\TradeDirection.cs
+DEPRECATED
+==========
+
+This file intentionally no longer contains source-file paths.
+
+Reason:
+- Legacy local build flows could read this list and also perform recursive .cs discovery,
+  which resulted in duplicate compilation units (for example duplicate `TradeCore`
+  definitions).
+
+If you maintain external tooling, do not combine explicit path lists with wildcard
+source scanning for the same tree.


### PR DESCRIPTION
### Motivation
- A legacy absolute-path source list in `Core/lista.txt` could be consumed alongside recursive `.cs` discovery by external/local build flows, causing duplicate compilation units and errors such as duplicate `TradeCore` definitions.

### Description
- Replaced the legacy absolute `.cs` path entries in `Core/lista.txt` with a clear `DEPRECATED` notice and explanation so the file cannot be used as a secondary source manifest.
- The file now documents the risk of combining explicit path lists with wildcard source scanning and prevents accidental double-registration of core sources.

### Testing
- Ran repository inspection and search commands including `rg --files -g 'AGENTS.md'` and `rg -n "class TradeCore" -g '*.cs'`, which completed successfully and showed a single tracked `Core/TradeCore.cs`.
- Executed a Python check that scans for duplicate type/namespace declarations (comments stripped) which completed successfully and found no duplicate class definitions.
- Verified the updated file contents with `nl -ba Core/lista.txt` and confirmed it contains only the deprecation notice.
- Performed `git` commit/amend operations to record the change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3be2c541c83288437c998949c1752)