### PR TITLE
Normalize memory context attach symbol handling

### DIFF
--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -69,18 +69,19 @@ namespace GeminiV26.Core.Entry
                 Log = message => _bot.Print(message)
             };
 
-            _bot.Print($"[MEMORY][CTX_ATTACH][START] symbol={symbol}");
-            var memory = _memoryEngine.GetState(symbol);
+            string canonicalSymbol = SymbolRouting.NormalizeSymbol(symbol);
+            _bot.Print($"[MEMORY][CTX_ATTACH][START] symbol={canonicalSymbol}");
+            var memory = _memoryEngine.GetState(canonicalSymbol);
 
             if (memory == null)
             {
                 ctx.Memory = null;
-                _bot.Print($"[MEMORY][MISSING] symbol={symbol}");
+                _bot.Print($"[MEMORY][MISSING] symbol={canonicalSymbol}");
             }
             else
             {
                 ctx.Memory = memory;
-                _bot.Print($"[MEMORY][CTX_ATTACH] symbol={symbol} hasMemory=true phase={memory.MovePhase} isBuilt={memory.IsBuilt} isUsable={memory.IsUsable}");
+                _bot.Print($"[MEMORY][CTX_ATTACH] symbol={canonicalSymbol} hasMemory=true phase={memory.MovePhase} isBuilt={memory.IsBuilt} isUsable={memory.IsUsable}");
             }
 
             // -------------------------

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -60,7 +60,6 @@ using GeminiV26.Instruments.CRYPTO;
 using GeminiV26.Instruments.METAL;
 using System;
 using System.Collections.Generic;
-using GeminiV26.Core;
 using GeminiV26.Core.HtfBias;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Core.Context;


### PR DESCRIPTION
### Motivation
- Memory lookups and related logs were using the raw symbol string which can mismatch the memory store key and cause noisy/runtime errors, so the memory attach path should use the canonical symbol key to avoid misrouting.

### Description
- Use `SymbolRouting.NormalizeSymbol(symbol)` in `EntryContextBuilder.Build` for the `MarketMemoryEngine.GetState` call and update the `[MEMORY]` log lines to print the canonical symbol.
- Remove a redundant `using GeminiV26.Core;` from `Core/TradeCore.cs` to clean up the imports.

### Testing
- Ran a structural brace-balance check (script) on `Core/TradeCore.cs`, `Core/Entry/EntryContext.cs`, and `Core/Entry/EntryContextBuilder.cs`, and all files reported balanced braces (success).
- Attempted `dotnet build` but it could not be executed in this environment because `dotnet` is not installed (no full build run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3c07600648328beeda22795499c92)