### PR TITLE
Soften crypto restart/early-break penalties and add directional impulse checks

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -272,6 +272,7 @@ namespace GeminiV26.Core
         private bool _isMemoryReady;
         private bool _startupCoverageLogged;
         private const bool DebugStartupTrace = false;
+        private const int CryptoSurvivableScoreFloor = 20;
 
         public TradeCore(Robot bot)
         {
@@ -1753,15 +1754,40 @@ namespace GeminiV26.Core
 
                 if (BotRestartState.IsHardProtectionPhase)
                 {
-                    candidate.IsValid = false;
+                    bool isCryptoCandidate = IsCryptoCandidate(candidate.Type);
+                    bool freshDirectionalContinuation =
+                        isCryptoCandidate &&
+                        ctx.BarsSinceStart <= 1 &&
+                        candidate.Direction != TradeDirection.None &&
+                        restartReason != "StaleImpulse" &&
+                        (ctx.GetBarsSinceImpulse(candidate.Direction) <= 2 || ctx.HasDirectionalPullback(candidate.Direction));
+
+                    if (!freshDirectionalContinuation)
+                    {
+                        candidate.IsValid = false;
+                        candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
+                            ? "[RESTART_DECAY_AFTER_RESTART]"
+                            : $"{candidate.Reason} [RESTART_DECAY_AFTER_RESTART]";
+                        EntryDecisionPolicy.Normalize(candidate);
+
+                        _bot.Print(TradeLogIdentity.WithTempId(
+                            $"[RESTART BLOCK] reason=DECAY_AFTER_RESTART symbol={candidate.Symbol ?? _bot.SymbolName} " +
+                            $"type={candidate.Type} dir={candidate.Direction} barsSinceStart={ctx.BarsSinceStart} state={restartReason}",
+                            ctx));
+                        continue;
+                    }
+
+                    int hardPhaseCryptoPenalty = 12;
+                    int originalScore = candidate.Score;
+                    candidate.Score = Math.Max(CryptoSurvivableScoreFloor, candidate.Score - hardPhaseCryptoPenalty);
                     candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
-                        ? "[RESTART_DECAY_AFTER_RESTART]"
-                        : $"{candidate.Reason} [RESTART_DECAY_AFTER_RESTART]";
+                        ? $"[RESTART_SOFT_AFTER_RESTART_{restartReason}]"
+                        : $"{candidate.Reason} [RESTART_SOFT_AFTER_RESTART_{restartReason}]";
                     EntryDecisionPolicy.Normalize(candidate);
 
                     _bot.Print(TradeLogIdentity.WithTempId(
-                        $"[RESTART BLOCK] reason=DECAY_AFTER_RESTART symbol={candidate.Symbol ?? _bot.SymbolName} " +
-                        $"type={candidate.Type} dir={candidate.Direction} barsSinceStart={ctx.BarsSinceStart} state={restartReason}",
+                        $"[RESTART SOFT-HARDPHASE] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} " +
+                        $"dir={candidate.Direction} score={originalScore}->{candidate.Score} barsSinceStart={ctx.BarsSinceStart} state={restartReason}",
                         ctx));
                     continue;
                 }
@@ -1770,7 +1796,7 @@ namespace GeminiV26.Core
                     continue;
 
                 const int softPenalty = 20;
-                int originalScore = candidate.Score;
+                int originalSoftScore = candidate.Score;
                 candidate.Score = Math.Max(0, candidate.Score - softPenalty);
                 candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
                     ? $"[RESTART_SOFT_{restartReason}]"
@@ -1779,7 +1805,7 @@ namespace GeminiV26.Core
 
                 _bot.Print(TradeLogIdentity.WithTempId(
                     $"[RESTART SOFT] penalty applied symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} " +
-                    $"dir={candidate.Direction} score={originalScore}->{candidate.Score} barsSinceStart={ctx.BarsSinceStart} state={restartReason}",
+                    $"dir={candidate.Direction} score={originalSoftScore}->{candidate.Score} barsSinceStart={ctx.BarsSinceStart} state={restartReason}",
                     ctx));
             }
         }
@@ -2035,7 +2061,16 @@ namespace GeminiV26.Core
                 if (barsSinceBreak == 0)
                 {
                     int originalScore = candidate.Score;
-                    candidate.Score = Math.Max(0, candidate.Score - 15);
+                    int earlyBreakPenalty = 15;
+                    int floor = 0;
+                    if (IsCryptoCandidate(candidate.Type) &&
+                        candidate.IsValid &&
+                        candidate.Score > 0)
+                    {
+                        floor = CryptoSurvivableScoreFloor;
+                    }
+
+                    candidate.Score = Math.Max(floor, candidate.Score - earlyBreakPenalty);
                     candidate.Reason = $"{candidate.Reason} [EARLY_BREAK_PENALTY]";
                     _bot.Print($"[ENTRY][EARLY_PROTECT] symbol={candidate.Symbol} type={candidate.Type} dir={candidate.Direction} score={originalScore}->{candidate.Score} barsSinceBreak={barsSinceBreak}");
                 }
@@ -2170,6 +2205,20 @@ namespace GeminiV26.Core
                 : direction == TradeDirection.Short
                     ? ctx.BarsSinceLowBreak_M5
                     : int.MaxValue;
+        }
+
+        private static bool IsCryptoCandidate(EntryType type)
+        {
+            switch (type)
+            {
+                case EntryType.Crypto_Flag:
+                case EntryType.Crypto_Pullback:
+                case EntryType.Crypto_RangeBreakout:
+                case EntryType.Crypto_Impulse:
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         private void UpsertArmedSetup(EntryEvaluation candidate, int barsSinceBreak)

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -10,7 +10,7 @@ namespace GeminiV26.EntryTypes.Crypto
     {
         public EntryType Type => EntryType.Crypto_Flag;
 
-        private const int MaxBarsSinceImpulse = 14;
+        private const int MaxBarsSinceImpulse = 18;
         private const int MinFlagBars = 3;
         private const int MaxFlagBars = 7;
 
@@ -32,10 +32,19 @@ namespace GeminiV26.EntryTypes.Crypto
             if (ctx.AtrM5 <= 0)
                 return Invalid(ctx, "ATR_ZERO");
 
-            if (!ctx.HasImpulse_M5 && ctx.BarsSinceImpulse_M5 > 12)
+            int directionalBarsSinceImpulse = ctx.LogicBias switch
+            {
+                TradeDirection.Long => ctx.BarsSinceImpulseLong_M5,
+                TradeDirection.Short => ctx.BarsSinceImpulseShort_M5,
+                _ => ctx.BarsSinceImpulse_M5
+            };
+
+            bool hasDirectionalImpulse = directionalBarsSinceImpulse <= MaxBarsSinceImpulse;
+
+            if (!ctx.HasImpulse_M5 && !hasDirectionalImpulse && ctx.BarsSinceImpulse_M5 > 14)
                 return Invalid(ctx, "NO_RECENT_IMPULSE");
 
-            if (ctx.BarsSinceImpulse_M5 > MaxBarsSinceImpulse)
+            if (directionalBarsSinceImpulse > MaxBarsSinceImpulse)
                 return Invalid(ctx, "LATE_FLAG");
 
             var bars = ctx.M5;

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -602,12 +602,13 @@ namespace GeminiV26.EntryTypes.Crypto
             // ======================================
             bool isPullbackSetup = Type == EntryType.Crypto_Pullback;
 
-            // 1) Minimum confidence (only for pullback)
+            // 1) Minimum confidence (soft penalty for crypto pullback)
             if (isPullbackSetup && score < MIN_SCORE)
             {
-                Console.WriteLine($"[BTC FILTER] rejected: pullback low confidence {score}");
-                ctx.Log?.Invoke($"[BTC FILTER] rejected: pullback low confidence {score}");
-                return Block(ctx, "BTC_FILTER_PULLBACK_LOW_CONFIDENCE", score, dir);
+                int prePenalty = score;
+                score = Math.Max(42, score - 6);
+                Console.WriteLine($"[CRYPTO FILTER] pullback low confidence soft-penalty {prePenalty}->{score}");
+                ctx.Log?.Invoke($"[CRYPTO FILTER] pullback low confidence soft-penalty {prePenalty}->{score}");
             }
 
             // 2) Pullback requires impulse reclaim


### PR DESCRIPTION
### Motivation
- Reduce overly aggressive blocking of crypto entry candidates during restart/hard-protection windows by allowing high-confidence directional continuations and preserving a minimum survivable score. 
- Make crypto entry age checks directional-aware so flag entries consider the impulse on the trade direction rather than a global impulse age. 
- Apply softer handling for low-confidence crypto pullbacks instead of hard-rejecting them to retain promising setups with a minimum quality floor.

### Description
- Introduced `CryptoSurvivableScoreFloor = 20` in `TradeCore` and added `IsCryptoCandidate` helper to identify crypto entry types. 
- In `ApplyRestartProtection` updated hard-protection behavior to allow a fresh directional continuation for crypto candidates and otherwise reduce crypto scores by a fixed penalty (`hardPhaseCryptoPenalty = 12`) floored at `CryptoSurvivableScoreFloor`, while preserving logging and normalized reasons; retained the existing soft-protection penalty logic. 
- Modified early-break penalty so crypto candidates are reduced only down to the survivable floor instead of fully zeroing out the score. 
- Updated `BTC_FlagEntry` to use directional bars-since-impulse (`BarsSinceImpulseLong_M5` / `BarsSinceImpulseShort_M5`) and increased `MaxBarsSinceImpulse` from 14 to 18 to allow slightly older directional impulses for flag detection. 
- Changed `BTC_PullbackEntry` low-confidence handling from a hard reject to a soft-penalty that applies `score = Math.Max(42, score - 6)` and logs the adjustment, keeping other pullback validity checks intact.

### Testing
- Built the solution to verify compilation after changes and the build completed successfully. 
- Ran the automated unit test suite and core entry-type tests and they all passed. 
- Executed integration/smoke checks for crypto entry evaluation flows to validate new scoring behavior and logging and those checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3c9f6475c8328b9e563040d45baf3)