### PR TITLE
Global market-state scoring: propagate MarketState and add soft trend/momentum penalties

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -762,25 +762,25 @@ namespace GeminiV26.Core
             {
                 fxState = _fxMarketStateDetector.Evaluate();
                 if (fxState != null)
-                    _bot.Print($"[FX MarketState] {rawSym} Trend={fxState.IsTrend}");
+                    _bot.Print($"[FX MarketState] {rawSym} Trend={fxState.IsTrend} Momentum={fxState.IsMomentum} LowVol={fxState.IsLowVol} ADX={fxState.Adx:F1}");
             }
             else if (isCrypto)
             {
                 cryptoState = _cryptoMarketStateDetector.Evaluate();
                 if (cryptoState != null)
-                    _bot.Print($"[CRYPTO MarketState] {rawSym} Trend={cryptoState.IsTrend}");
+                    _bot.Print($"[CRYPTO MarketState] {rawSym} Trend={cryptoState.IsTrend} Momentum={cryptoState.IsMomentum} LowVol={cryptoState.IsLowVol} ADX={cryptoState.Adx:F1}");
             }
             else if (isMetal)
             {
                 xauState = _xauMarketStateDetector.Evaluate();
                 if (xauState != null)
-                    _bot.Print($"[XAU MarketState] {rawSym} Range={xauState.IsRange} Trend={xauState.IsTrend} ADX={xauState.Adx:F1} HardRange={xauState.IsHardRange}");
+                    _bot.Print($"[XAU MarketState] {rawSym} Range={xauState.IsRange} Trend={xauState.IsTrend} Momentum={xauState.IsMomentum} ADX={xauState.Adx:F1} HardRange={xauState.IsHardRange}");
             }
             else if (isIndex)
             {
                 indexState = _indexMarketStateDetector.Evaluate();
                 if (indexState != null)
-                    _bot.Print($"[INDEX MarketState] {rawSym} Trend={indexState.IsTrend}");
+                    _bot.Print($"[INDEX MarketState] {rawSym} Trend={indexState.IsTrend} Momentum={indexState.IsMomentum} LowVol={indexState.IsLowVol} ADX={indexState.Adx:F1}");
             }
             else
             {
@@ -926,30 +926,19 @@ namespace GeminiV26.Core
             {
                 if (xauState == null && _xauMarketStateDetector != null)
                     xauState = _xauMarketStateDetector.Evaluate();
+            }
 
-                if (xauState != null)
-                {
-                    _ctx.MarketState = new IndexMarketState
-                    {
-                        AtrPoints = xauState.AtrPips,
-                        Adx = xauState.Adx,
-                        IsLowVol = xauState.IsLowVol,
-                        IsTrend = xauState.IsTrend,
-                        IsRange = xauState.IsRange,
-                        RangePoints = xauState.RangeWidth
-                    };
-
-                    _bot.Print(
-                        "[XAU STATE ASSIGN] trend={0} adx={1:F1} range={2} hardRange={3}",
-                        xauState.IsTrend,
-                        xauState.Adx,
-                        xauState.IsRange,
-                        xauState.IsHardRange);
-                }
-                else
-                {
-                    _bot.Print("[XAU STATE ASSIGN] trend= adx= range= hardRange=");
-                }
+            _ctx.MarketState = BuildEntryMarketState(fxState, cryptoState, xauState, indexState);
+            if (_ctx.MarketState != null)
+            {
+                _bot.Print(
+                    "[ENTRY MARKETSTATE ASSIGN] sym={0} trend={1} momentum={2} lowVol={3} adx={4:F1} atrPts={5:F2}",
+                    rawSym,
+                    _ctx.MarketState.IsTrend,
+                    _ctx.MarketState.IsMomentum,
+                    _ctx.MarketState.IsLowVol,
+                    _ctx.MarketState.Adx,
+                    _ctx.MarketState.AtrPoints);
             }
 
             _ctx.LastUpdateUtc = DateTime.UtcNow;
@@ -2952,6 +2941,58 @@ namespace GeminiV26.Core
                 return "Trend";
 
             return entryCtx.IsAtrExpanding_M5 ? "HighVol" : "LowVol";
+        }
+
+        private IndexMarketState BuildEntryMarketState(
+            FxMarketState fxState,
+            CryptoMarketState cryptoState,
+            XauMarketState xauState,
+            IndexMarketState indexState)
+        {
+            if (indexState != null)
+                return indexState;
+
+            if (fxState != null)
+            {
+                return new IndexMarketState
+                {
+                    IsTrend = fxState.IsTrend,
+                    IsMomentum = fxState.IsMomentum,
+                    IsLowVol = fxState.IsLowVol,
+                    IsRange = fxState.IsCompression,
+                    Adx = fxState.Adx,
+                    AtrPoints = fxState.AtrPips
+                };
+            }
+
+            if (cryptoState != null)
+            {
+                return new IndexMarketState
+                {
+                    IsTrend = cryptoState.IsTrend,
+                    IsMomentum = cryptoState.IsMomentum,
+                    IsLowVol = cryptoState.IsLowVol,
+                    IsRange = !cryptoState.IsTrend && !cryptoState.IsExpansion,
+                    Adx = cryptoState.Adx,
+                    AtrPoints = cryptoState.AtrPips
+                };
+            }
+
+            if (xauState != null)
+            {
+                return new IndexMarketState
+                {
+                    IsTrend = xauState.IsTrend,
+                    IsMomentum = xauState.IsMomentum,
+                    IsLowVol = xauState.IsLowVol,
+                    IsRange = xauState.IsRange,
+                    Adx = xauState.Adx,
+                    AtrPoints = xauState.AtrPips,
+                    RangePoints = xauState.RangeWidth
+                };
+            }
+
+            return null;
         }
 
         private static double ComputeRMultiple(Position pos, PositionContext? ctx, double pipSize)

--- a/EntryTypes/BR_RangeBreakoutEntry.cs
+++ b/EntryTypes/BR_RangeBreakoutEntry.cs
@@ -341,54 +341,15 @@ namespace GeminiV26.EntryTypes
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "BR_RangeBreakoutEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/EntryDirectionQuality.cs
+++ b/EntryTypes/EntryDirectionQuality.cs
@@ -34,6 +34,7 @@ namespace GeminiV26.EntryTypes
 
             int penalty = 0;
             int bonus = 0;
+            int marketStatePenalty = 0;
 
             if (structureAligned)
             {
@@ -91,6 +92,56 @@ namespace GeminiV26.EntryTypes
             if (!regimeCompatible)
                 penalty += 20;
 
+            if (ctx.MarketState != null)
+            {
+                var style = ResolveStyle(request?.TypeTag);
+                bool noTrend = !ctx.MarketState.IsTrend;
+                bool noMomentum = !ctx.MarketState.IsMomentum;
+
+                int noTrendPenalty = style switch
+                {
+                    EntryStyle.Breakout => 7,
+                    EntryStyle.Pullback => 8,
+                    EntryStyle.Flag => 9,
+                    EntryStyle.Reversal => 4,
+                    EntryStyle.Range => 3,
+                    _ => 8
+                };
+
+                int noMomentumPenalty = style switch
+                {
+                    EntryStyle.Breakout => 9,
+                    EntryStyle.Pullback => 7,
+                    EntryStyle.Flag => 9,
+                    EntryStyle.Reversal => 6,
+                    EntryStyle.Range => 4,
+                    _ => 8
+                };
+
+                int comboPenalty = style switch
+                {
+                    EntryStyle.Reversal => 5,
+                    EntryStyle.Range => 4,
+                    _ => 10
+                };
+
+                if (noTrend)
+                    marketStatePenalty += noTrendPenalty;
+
+                if (noMomentum)
+                    marketStatePenalty += noMomentumPenalty;
+
+                if (noTrend && noMomentum)
+                    marketStatePenalty += comboPenalty;
+
+                if (marketStatePenalty > 0)
+                {
+                    ctx.Log?.Invoke(
+                        $"[ENTRY STATE SCORE] type={request.TypeTag} side={direction} trend={ctx.MarketState.IsTrend} momentum={ctx.MarketState.IsMomentum} " +
+                        $"lowVol={ctx.MarketState.IsLowVol} adx={ctx.MarketState.Adx:F1} penalty={marketStatePenalty}");
+                }
+            }
+
             if (instrumentClass == InstrumentClass.INDEX &&
                 htfDirection != TradeDirection.None &&
                 htfConfidence >= 0.70 &&
@@ -112,6 +163,7 @@ namespace GeminiV26.EntryTypes
 
             score += bonus;
             score -= penalty;
+            score -= marketStatePenalty;
 
             string structure =
                 breakoutConfirmed ? "BreakoutConfirmed" :
@@ -123,7 +175,7 @@ namespace GeminiV26.EntryTypes
             ctx.Log?.Invoke(
                 $"[DIR QUALITY] type={request.TypeTag} side={direction} structure={structure} " +
                 $"logicBias={logicBias} logicConf={logicConfidence} htfDir={htfDirection} htfConf={htfConfidence:F2} " +
-                $"regime={regime} penalty={penalty} bonus={bonus} finalScore={score}");
+                $"regime={regime} penalty={penalty} marketStatePenalty={marketStatePenalty} bonus={bonus} finalScore={score}");
 
             return score;
         }
@@ -266,5 +318,35 @@ namespace GeminiV26.EntryTypes
                 TradeDirection.Short => TradeDirection.Long,
                 _ => TradeDirection.None
             };
+
+        private static EntryStyle ResolveStyle(string typeTag)
+        {
+            if (string.IsNullOrWhiteSpace(typeTag))
+                return EntryStyle.Other;
+
+            string t = typeTag.ToUpperInvariant();
+            if (t.Contains("REVERSAL"))
+                return EntryStyle.Reversal;
+            if (t.Contains("RANGE"))
+                return EntryStyle.Range;
+            if (t.Contains("FLAG"))
+                return EntryStyle.Flag;
+            if (t.Contains("PULLBACK"))
+                return EntryStyle.Pullback;
+            if (t.Contains("BREAKOUT") || t.Contains("IMPULSE") || t.Contains("CONTINUATION"))
+                return EntryStyle.Breakout;
+
+            return EntryStyle.Other;
+        }
+
+        private enum EntryStyle
+        {
+            Other,
+            Breakout,
+            Pullback,
+            Flag,
+            Reversal,
+            Range
+        }
     }
 }

--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -75,7 +75,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 !ctx.IsAtrExpanding_M5;
 
             if (chopZone)
-                score -= 6;
+                score -= 8;
 
             // =====================================================
             // ATR minimum guard (soft)

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -134,7 +134,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 !ctx.IsAtrExpanding_M5;
 
             if (chopZone)
-                score -= 6;
+                score -= 8;
 
             // =====================================================
             // ATR sanity (matrix driven)

--- a/EntryTypes/TC_FlagEntry.cs
+++ b/EntryTypes/TC_FlagEntry.cs
@@ -320,54 +320,15 @@ namespace GeminiV26.EntryTypes
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "TC_FlagEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/TC_PullbackEntry.cs
+++ b/EntryTypes/TC_PullbackEntry.cs
@@ -564,54 +564,15 @@ namespace GeminiV26.EntryTypes
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "TC_PullbackEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/EntryTypes/TR_ReversalEntry.cs
+++ b/EntryTypes/TR_ReversalEntry.cs
@@ -267,54 +267,15 @@ namespace GeminiV26.EntryTypes
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {
-            const int htfPenalty = 30;
-            const int logicPenalty = 12;
-            const int rangePenalty = 25;
-
-            TradeDirection htfDirection = TradeDirection.None;
-            double htfConfidence = 0.0;
-
-            switch (SymbolRouting.ResolveInstrumentClass(ctx.Symbol))
-            {
-                case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
-                    break;
-                case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
-                    break;
-                case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
-                    break;
-                case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
-                    break;
-            }
-
-            if (htfDirection != TradeDirection.None && htfConfidence >= 0.70 && direction != htfDirection)
-            {
-                score -= htfPenalty;
-                ctx.Log?.Invoke($"[ENTRY HTF ALIGN] dir={direction} htf={htfDirection} conf={htfConfidence:0.00} penalty={htfPenalty}");
-            }
-
-            var logicBias = ctx.LogicBiasDirection;
-            var logicConfidence = ctx.LogicBiasConfidence;
-            if (logicBias != TradeDirection.None && logicConfidence >= 60 && direction != logicBias)
-            {
-                score -= logicPenalty;
-                ctx.Log?.Invoke($"[ENTRY LOGIC ALIGN] dir={direction} logic={logicBias} conf={logicConfidence} penalty={logicPenalty}");
-            }
-
-            if (applyTrendRegimePenalty && ctx.Adx_M5 < 15.0)
-            {
-                score -= rangePenalty;
-                ctx.Log?.Invoke($"[ENTRY REGIME] adx={ctx.Adx_M5:0.0} penalty={rangePenalty}");
-            }
-
-            return score;
+            return EntryDirectionQuality.Apply(
+                ctx,
+                direction,
+                score,
+                new DirectionQualityRequest
+                {
+                    TypeTag = "TR_ReversalEntry",
+                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
+                });
         }
 
     }

--- a/Instruments/CRYPTO/CryptoMarketState.cs
+++ b/Instruments/CRYPTO/CryptoMarketState.cs
@@ -18,6 +18,7 @@ namespace GeminiV26.Instruments.CRYPTO
 
         public bool IsLowVol { get; init; }
         public bool IsTrend { get; init; }
+        public bool IsMomentum { get; init; }
         public bool IsExpansion { get; init; }
     }
 }

--- a/Instruments/CRYPTO/CryptoMarketStateDetector.cs
+++ b/Instruments/CRYPTO/CryptoMarketStateDetector.cs
@@ -43,16 +43,18 @@ namespace GeminiV26.Instruments.CRYPTO
             double atr = _atr.Result[i];
             double atrPrev = _atr.Result[i - 5];
             double adx = _dms.ADX[i];
+            double body = Math.Abs(_bars.ClosePrices[i] - _bars.OpenPrices[i]);
 
             bool isHighVol = atr > 100;
             bool isLowVol = atr < 40;
             bool isTrend = adx >= 18;
+            bool isMomentum = atr > 0 && body >= atr * 0.6;
             bool isExpansion = atr > atrPrev * 1.2;
 
             _bot.Print(
                 $"[CRYPTO MSD] {_bot.SymbolName} | " +
                 $"ATR={atr:F1} ADX={adx:F1} " +
-                $"HighVol={isHighVol} LowVol={isLowVol} Trend={isTrend} Expansion={isExpansion}");
+                $"HighVol={isHighVol} LowVol={isLowVol} Trend={isTrend} Momentum={isMomentum} Expansion={isExpansion}");
 
             return new CryptoMarketState
             {
@@ -62,6 +64,7 @@ namespace GeminiV26.Instruments.CRYPTO
                 IsHighVol = isHighVol,
                 IsLowVol = isLowVol,
                 IsTrend = isTrend,
+                IsMomentum = isMomentum,
                 IsExpansion = isExpansion
             };
         }

--- a/Instruments/FX/FxMarketState.cs
+++ b/Instruments/FX/FxMarketState.cs
@@ -18,6 +18,7 @@
         // === Értelmezett állapotjelzők ===
         public bool IsLowVol { get; init; }
         public bool IsTrend { get; init; }
+        public bool IsMomentum { get; init; }
         public bool IsCompression { get; init; }
     }
 }

--- a/Instruments/FX/FxMarketStateDetector.cs
+++ b/Instruments/FX/FxMarketStateDetector.cs
@@ -93,12 +93,14 @@ namespace GeminiV26.Instruments.FX
             bool isLowVol = atrPips < _profile.MinAtrPips;
             bool isTrend = adx >= _profile.MinAdxTrend;
             bool isCompression = emaDistAtr < 0.4;
+            double body = Math.Abs(_bars.ClosePrices[i] - _bars.OpenPrices[i]);
+            bool isMomentum = atrRaw > 0 && body >= atrRaw * 0.55 && !isCompression;
 
             // === DEBUG (szándékosan marad) ===
             _bot.Print(
                 $"[FX MSD] {_bot.SymbolName} | " +
                 $"atrPips={atrPips:F2} adx={adx:F1} | " +
-                $"lowVol={isLowVol} trend={isTrend} compression={isCompression}");
+                $"lowVol={isLowVol} trend={isTrend} momentum={isMomentum} compression={isCompression}");
 
             return new FxMarketState
             {
@@ -106,6 +108,7 @@ namespace GeminiV26.Instruments.FX
                 Adx = adx,
                 IsLowVol = isLowVol,
                 IsTrend = isTrend,
+                IsMomentum = isMomentum,
                 IsCompression = isCompression
             };
         }

--- a/Instruments/METAL/MetalMarketState.cs
+++ b/Instruments/METAL/MetalMarketState.cs
@@ -14,6 +14,7 @@ namespace GeminiV26.Instruments.METAL
 
         public bool IsLowVol { get; set; }
         public bool IsTrend { get; set; }
+        public bool IsMomentum { get; set; }
         public bool IsCompression { get; set; }
         public bool IsHardRange { get; set; }
         public bool IsRange { get; set; }

--- a/Instruments/METAL/MetalMarketStateDetector.cs
+++ b/Instruments/METAL/MetalMarketStateDetector.cs
@@ -73,6 +73,7 @@ namespace GeminiV26.Instruments.METAL
             bool lowVol = atrPips < _minAtrPips;
             bool trend = adx > 30;
             bool compression = emaDistATR < 0.5;
+            bool momentum = atrRaw > 0 && body >= atrRaw * 0.7 && !compression;
             bool hardRange = compression && adx < 25;
             bool isSpike = upperWick > body * 2 || lowerWick > body * 2;
 
@@ -80,12 +81,13 @@ namespace GeminiV26.Instruments.METAL
                 hardRange = false;
 
             _bot.Print(
-                "[XAU MSD] atrPips={0:F1} adx={1:F1} emaDistATR={2:F2} lowVol={3} trend={4} compression={5} hardRange={6} spike={7}",
+                "[XAU MSD] atrPips={0:F1} adx={1:F1} emaDistATR={2:F2} lowVol={3} trend={4} momentum={5} compression={6} hardRange={7} spike={8}",
                 atrPips,
                 adx,
                 emaDistATR,
                 lowVol,
                 trend,
+                momentum,
                 compression,
                 hardRange,
                 isSpike);
@@ -96,6 +98,7 @@ namespace GeminiV26.Instruments.METAL
                 Adx = adx,
                 IsLowVol = lowVol,
                 IsTrend = trend,
+                IsMomentum = momentum,
                 IsCompression = compression,
                 IsHardRange = hardRange,
                 IsRange = lowVol && !trend,

--- a/Instruments/XAUUSD/XauMarketState.cs
+++ b/Instruments/XAUUSD/XauMarketState.cs
@@ -2,7 +2,8 @@ namespace GeminiV26.Instruments.XAUUSD
 {
     public sealed class XauMarketState
     {
-        // === ÚJ MODELL (MEGMARAD) ===
+        public bool IsMomentum { get; set; }
+        // === ÃšJ MODELL (MEGMARAD) ===
         public double AtrPips { get; set; }
         public double Adx { get; set; }
 
@@ -15,20 +16,20 @@ namespace GeminiV26.Instruments.XAUUSD
         public double WickRatioNow { get; set; }
         public bool IsChop { get; set; }
 
-        // === KOMPATIBILITÁSI ALIASOK (TRADECORE MIATT) ===
+        // === KOMPATIBILITÃSI ALIASOK (TRADECORE MIATT) ===
 
-        // régi ATR
+        // rÃ©gi ATR
         public double Atr => AtrPips;
 
-        // régi range logika
+        // rÃ©gi range logika
         public bool IsRange => IsHardRange;
         public bool IsSoftRange => IsLowVol;
         public bool IsBreakout => IsTrend;
-        public bool IsPostBreakout => false; // XAU-nál nincs klasszikus postBO
+        public bool IsPostBreakout => false; // XAU-nÃ¡l nincs klasszikus postBO
 
         public double RangeWidth => RangeWidthAtr;
 
-        // volume proxy (XAU-nál nincs tick volume)
+        // volume proxy (XAU-nÃ¡l nincs tick volume)
         public double VolumeNorm => WickRatioNow;
     }
 }

--- a/Instruments/XAUUSD/XauMarketStateDetector.cs
+++ b/Instruments/XAUUSD/XauMarketStateDetector.cs
@@ -106,10 +106,11 @@ namespace GeminiV26.Instruments.XAUUSD
                 || isCompression;
 
             bool isChop = wickRatio >= _p.MaxWickRatio;
+            bool isMomentum = atrRaw > 0 && body >= atrRaw * 0.7 && !isChop;
 
             _bot.Print(
                 $"[XAU MSD] emaDistATR={emaDistAtr:F2} atrPips={atrPips:F1} adx={adx:F1} widthATR={widthAtr:F2} " +
-                $"lowVol={isLowVol} trend={isTrend} hardRange={isHardRange} wickRatio={wickRatio:F2} chop={isChop}"
+                $"lowVol={isLowVol} trend={isTrend} momentum={isMomentum} hardRange={isHardRange} wickRatio={wickRatio:F2} chop={isChop}"
             );
 
             return new XauMarketState
@@ -119,6 +120,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
                 IsLowVol = hasEnoughData ? isLowVol : true,
                 IsTrend = hasEnoughData ? isTrend : false,
+                IsMomentum = hasEnoughData ? isMomentum : false,
                 RangeWidthAtr = widthAtr,
                 IsHardRange = hasEnoughData ? isHardRange : false,
 


### PR DESCRIPTION
### Motivation
- Provide a single, reliable market-state object inside `EntryContext` for INDEX / FX / CRYPTO / METAL so all entry evaluators can use consistent regime signals.
- Improve entry quality using SOFT, score-only signals based on `IsTrend` / `IsMomentum` and maintain soft ADX handling without introducing new hard vetoes.
- Strengthen weak ADX/chop soft penalties where the logic is already score-based to better reflect low-energy environments.

### Description
- Added a small adapter in `TradeCore` (`BuildEntryMarketState`) that normalizes `FxMarketState`, `CryptoMarketState`, `XauMarketState`, and `IndexMarketState` into `EntryContext.MarketState` and added concise diagnostic logging for trend/momentum/lowVol/ADX. (Core/TradeCore.cs)
- Extended FX / CRYPTO / XAU / METAL market-state models and detectors to emit `IsMomentum` (minimal detector changes and conservative body-vs-ATR tests) and included it in debug prints. (Instruments/FX, Instruments/CRYPTO, Instruments/XAUUSD, Instruments/METAL)
- Implemented a global, score-only market-state layer inside `EntryDirectionQuality.Apply` that applies style-sensitive soft penalties for missing trend and/or momentum and emits `[ENTRY STATE SCORE]` diagnostics; penalties vary by entry style (Breakout / Pullback / Flag / Reversal / Range). (EntryTypes/EntryDirectionQuality.cs)
- Routed legacy/general entry adjustment hooks to the shared quality layer by replacing local mandatory-adjustment implementations with calls to `EntryDirectionQuality.Apply` for TC / BR / TR families, ensuring all routed entries receive the same soft market-state scoring. (EntryTypes/TC_*, EntryTypes/BR_*, EntryTypes/TR_*)
- Increased a few already-soft ADX/chop penalties from `-6` to `-8` where the logic was clearly a weak soft penalty (Index_Breakout, Index_Pullback). (EntryTypes/INDEX/*)
- Kept all changes additive and score-based; no new hard blocks or changes to executors, exits, TVM, or risk sizing were introduced.

### Testing
- Verified presence and propagation with repository searches for `IsMomentum`, `BuildEntryMarketState`, and `TypeTag` usages using `rg`, confirming market-state fields and routing points were updated (succeeded).
- Inspected key files and insertion points via file previews (`sed`/`nl`) to confirm logging and penalty code were added (succeeded).
- Attempted to run `dotnet build` in this environment but `dotnet` is not installed, so a full compile could not be executed here (environmental failure).
- Performed lightweight runtime-safety checks in code (no public API/routing signature changes and all new logic is conservative and additive) and left existing hard ADX gates intact when they appear setup-defining (manual review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40350e2f48328862db38c31dbea2d)