### PR TITLE
Expose raw/final validity and score-flow for entry rejection diagnostics

### DIFF
--- a/Core/Entry/EntryDecisionPolicy.cs
+++ b/Core/Entry/EntryDecisionPolicy.cs
@@ -85,6 +85,8 @@ namespace GeminiV26.Core.Entry
             if (eval == null)
                 return null;
 
+            eval.RawValid = eval.IsValid;
+            eval.FinalValid = eval.IsValid;
             eval.Score = Math.Max(0, Math.Min(100, eval.Score));
             eval.LogicConfidence = PositionContext.ClampRiskConfidence(eval.LogicConfidence);
             eval.State = ResolveState(eval);

--- a/Core/Entry/EntryEvaluation.cs
+++ b/Core/Entry/EntryEvaluation.cs
@@ -5,16 +5,32 @@
         public string Symbol;
         public EntryType Type;
 
+        // Raw validity from entry evaluator (before downstream filters).
+        public bool RawValid;
+
+        // Existing final validity used in routing/decision.
         public bool IsValid;
+        public bool FinalValid
+        {
+            get => IsValid;
+            set => IsValid = value;
+        }
         public TradeDirection Direction;
 
         // 0–100
         public int Score;
 
+        // Score tracing (observability only).
+        public int PreQualityScore;
+        public int PostQualityScore;
+        public int PostCapScore;
+        public bool HasQualityScoreTrace;
+
         // instrument bias
         public int LogicConfidence;
 
         public string Reason;
+        public string RejectReason;
 
         public EntryState State = EntryState.NONE;
 

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -62,9 +62,10 @@ namespace GeminiV26.Core
             foreach (var candidate in signals.Where(e => e != null))
             {
                 string decision;
-                _bot.Print($"[BASELINE CHECK] type={candidate.Type} score={candidate.Score} valid={candidate.IsValid.ToString().ToLowerInvariant()} source=ENTRY_ONLY");
+                candidate.FinalValid = candidate.IsValid;
+                _bot.Print($"[BASELINE CHECK] type={candidate.Type} score={candidate.Score} valid={candidate.FinalValid.ToString().ToLowerInvariant()} source=ENTRY_ONLY");
 
-                if (!candidate.IsValid)
+                if (!candidate.FinalValid)
                 {
                     decision = "REJECT";
                     _bot.Print(TradeLogIdentity.WithTempId($"[BLOCK] type={candidate.Type} dir={candidate.Direction} score={candidate.Score} reason=invalid_candidate", entryContext));
@@ -89,7 +90,27 @@ namespace GeminiV26.Core
                 _bot.Print(TradeLogIdentity.WithTempId(
                     $"[SCORE][DECISION_INPUT] entry={candidate.Score} logic={entryContext?.LogicBiasConfidence ?? 0} final={PositionContext.ComputeFinalConfidenceValue(candidate.Score, entryContext?.LogicBiasConfidence ?? 0)} threshold={EntryDecisionPolicy.MinScoreThreshold}",
                     entryContext));
-                _bot.Print(TradeLogIdentity.WithTempId($"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} score={candidate.Score} threshold={EntryDecisionPolicy.MinScoreThreshold} valid={candidate.IsValid.ToString().ToLowerInvariant()} state={candidate.State} trigger={candidate.TriggerConfirmed.ToString().ToLowerInvariant()} → {decision}", entryContext));
+
+                candidate.RejectReason = ResolveRejectReason(candidate, EntryDecisionPolicy.MinScoreThreshold);
+                _bot.Print(TradeLogIdentity.WithTempId(
+                    $"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} side={candidate.Direction} " +
+                    $"rawValid={candidate.RawValid.ToString().ToLowerInvariant()} finalValid={candidate.FinalValid.ToString().ToLowerInvariant()} " +
+                    $"preScore={(candidate.HasQualityScoreTrace ? candidate.PreQualityScore : candidate.Score)} " +
+                    $"postScore={(candidate.HasQualityScoreTrace ? candidate.PostQualityScore : candidate.Score)} " +
+                    $"cappedScore={(candidate.HasQualityScoreTrace ? candidate.PostCapScore : candidate.Score)} " +
+                    $"threshold={EntryDecisionPolicy.MinScoreThreshold} reason={candidate.RejectReason} " +
+                    $"state={candidate.State} trigger={candidate.TriggerConfirmed.ToString().ToLowerInvariant()} → {decision}",
+                    entryContext));
+
+                if (candidate.RejectReason != "ACCEPTED")
+                {
+                    _bot.Print(TradeLogIdentity.WithTempId(
+                        $"[ENTRY REJECT DETAIL] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} side={candidate.Direction} " +
+                        $"reason={candidate.RejectReason} structureAligned={IsStructureAligned(entryContext, candidate.Direction).ToString().ToLowerInvariant()} " +
+                        $"momentumAligned={IsMomentumAligned(entryContext, candidate.Direction).ToString().ToLowerInvariant()} " +
+                        $"trend={(entryContext?.TrendDirection ?? TradeDirection.None)} adx={(entryContext?.Adx_M5 ?? 0.0):F1}",
+                        entryContext));
+                }
             }
 
             if (winner == null)
@@ -101,6 +122,45 @@ namespace GeminiV26.Core
             _bot.Print(TradeLogIdentity.WithTempId($"[ACCEPT] type={winner.Type} dir={winner.Direction} score={winner.Score} reason={winner.Reason}", entryContext));
             _bot.Print(TradeLogIdentity.WithTempId($"[TR] WINNER: {winner.Type} dir={winner.Direction} score={winner.Score} valid={winner.IsValid} reason={winner.Reason}", entryContext));
             return winner;
+        }
+
+        private static string ResolveRejectReason(EntryEvaluation candidate, int threshold)
+        {
+            if (candidate == null)
+                return "INVALID_STRUCTURE";
+
+            if (!candidate.RawValid)
+                return "INVALID_STRUCTURE";
+
+            if (candidate.Score < threshold)
+                return "BELOW_THRESHOLD";
+
+            if (candidate.Score >= threshold && !candidate.FinalValid)
+                return "INVALID_POST_EVAL";
+
+            return "ACCEPTED";
+        }
+
+        private static bool IsStructureAligned(EntryContext ctx, TradeDirection direction)
+        {
+            if (ctx == null || direction == TradeDirection.None)
+                return false;
+
+            return ctx.BreakoutDirection == direction
+                || ctx.RangeBreakDirection == direction
+                || ctx.ImpulseDirection == direction
+                || (direction == TradeDirection.Buy ? ctx.HasFlagLong_M5 || ctx.HasPullbackLong_M5 : ctx.HasFlagShort_M5 || ctx.HasPullbackShort_M5);
+        }
+
+        private static bool IsMomentumAligned(EntryContext ctx, TradeDirection direction)
+        {
+            if (ctx == null || direction == TradeDirection.None)
+                return false;
+
+            return ctx.BreakoutDirection == direction
+                || ctx.RangeBreakDirection == direction
+                || ctx.ImpulseDirection == direction
+                || (ctx.TrendDirection == direction && ctx.LastClosedBarInTrendDirection);
         }
 
 

--- a/EntryTypes/EntryDirectionQuality.cs
+++ b/EntryTypes/EntryDirectionQuality.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 
@@ -12,6 +13,15 @@ namespace GeminiV26.EntryTypes
 
     internal static class EntryDirectionQuality
     {
+        private sealed class QualityTrace
+        {
+            public int PreQualityScore { get; init; }
+            public int PostQualityScore { get; init; }
+            public int PostCapScore { get; init; }
+        }
+
+        private static readonly ConcurrentDictionary<string, QualityTrace> ScoreTrace = new ConcurrentDictionary<string, QualityTrace>();
+
         public static int Apply(
             EntryContext ctx,
             TradeDirection direction,
@@ -21,6 +31,7 @@ namespace GeminiV26.EntryTypes
             if (ctx == null)
                 return score;
 
+            int preQualityScore = score;
             ResolveHtf(ctx, out var instrumentClass, out var htfDirection, out var htfConfidence);
 
             bool breakoutConfirmed = HasDirectionalBreakout(ctx, direction);
@@ -202,7 +213,7 @@ namespace GeminiV26.EntryTypes
             afterAdxFlow = flowScore;
 
             score = (int)Math.Round(flowScore);
-            int finalScoreBeforeCap = score;
+            int postQualityScore = score;
 
             if (ctx.MarketState != null)
             {
@@ -215,6 +226,7 @@ namespace GeminiV26.EntryTypes
                 if (ctx.MarketState.IsLowVol || !ctx.IsAtrExpanding_M5)
                     score = Math.Min(score, 60);
             }
+            int postCapScore = score;
 
             string structure =
                 breakoutConfirmed ? "BreakoutConfirmed" :
@@ -232,8 +244,15 @@ namespace GeminiV26.EntryTypes
                 $"[ENTRY SCORE FLOW] type={request.TypeTag} side={direction} " +
                 $"baseScore={baseScoreFlow:F1} afterAdditive={afterAdditiveFlow:F1} " +
                 $"afterTrendScaling={afterTrendFlow:F1} afterMomentumScaling={afterMomentumFlow:F1} " +
-                $"afterCombo={afterComboFlow:F1} afterADX={afterAdxFlow:F1} finalScore={finalScoreBeforeCap} finalCappedScore={score} " +
+                $"afterCombo={afterComboFlow:F1} afterADX={afterAdxFlow:F1} preQualityScore={preQualityScore} postQualityScore={postQualityScore} postCapScore={postCapScore} " +
                 $"trendScale={trendScaling:F2} momentumScale={momentumScaling:F2} comboScale={comboScaling:F2} adxScale={adxScaling:F2}");
+
+            ScoreTrace[BuildTraceKey(ctx, request?.TypeTag, direction)] = new QualityTrace
+            {
+                PreQualityScore = preQualityScore,
+                PostQualityScore = postQualityScore,
+                PostCapScore = postCapScore
+            };
 
             return score;
         }
@@ -241,9 +260,22 @@ namespace GeminiV26.EntryTypes
         public static void LogDecision(EntryContext ctx, string typeTag, EntryEvaluation longEval, EntryEvaluation shortEval, TradeDirection selected)
         {
             var eval = longEval ?? shortEval;
+            if (eval != null && TryGetScoreTrace(ctx, typeTag, eval.Direction, out var trace))
+            {
+                eval.PreQualityScore = trace.PreQualityScore;
+                eval.PostQualityScore = trace.PostQualityScore;
+                eval.PostCapScore = trace.PostCapScore;
+                eval.HasQualityScoreTrace = true;
+            }
             ctx?.Log?.Invoke(
                 $"[DIR FLOW] type={typeTag} logicBias={ctx?.LogicBiasDirection ?? TradeDirection.None} evalDir={eval?.Direction ?? TradeDirection.None} score={eval?.Score ?? 0}");
         }
+
+        private static string BuildTraceKey(EntryContext ctx, string typeTag, TradeDirection direction)
+            => $"{ctx?.EntryAttemptId ?? "NA"}|{ctx?.Symbol ?? "NA"}|{typeTag ?? "NA"}|{direction}";
+
+        private static bool TryGetScoreTrace(EntryContext ctx, string typeTag, TradeDirection direction, out QualityTrace trace)
+            => ScoreTrace.TryGetValue(BuildTraceKey(ctx, typeTag, direction), out trace);
 
         private static void ResolveHtf(
             EntryContext ctx,


### PR DESCRIPTION
### Motivation
- Make it explicitly visible why a candidate is rejected in cases where `Score >= threshold` but the final validity is `false`, without changing any decision or trading logic. 
- Add observability for score transformation steps inside the quality layer and preserve pre-/post-filter validity state for more actionable logs.

### Description
- Added new observability fields to `EntryEvaluation`: `RawValid`, `FinalValid` (alias of `IsValid`), `PreQualityScore`, `PostQualityScore`, `PostCapScore`, `HasQualityScoreTrace`, and `RejectReason`, and preserved `RawValid`/`FinalValid` from `Normalize` without changing validity semantics. (file: `Core/Entry/EntryEvaluation.cs`, `Core/Entry/EntryDecisionPolicy.cs`).
- Traced score flow inside the quality layer by capturing `preQualityScore`, `postQualityScore`, and `postCapScore`, caching a snapshot keyed by entry attempt, and attaching the trace in `EntryDirectionQuality.LogDecision` for decision-layer visibility. (file: `EntryTypes/EntryDirectionQuality.cs`).
- Extended decision logging in the router to print `rawValid`, `finalValid`, `preScore`, `postScore`, `cappedScore`, `threshold`, and a computed `RejectReason` tag with values `INVALID_STRUCTURE`, `BELOW_THRESHOLD`, `INVALID_POST_EVAL`, or `ACCEPTED`, and added an optional `[ENTRY REJECT DETAIL]` line with structure/momentum/trend/adx diagnostics; helpers `ResolveRejectReason`, `IsStructureAligned`, and `IsMomentumAligned` were added to keep logs concise. (file: `Core/TradeRouter.cs`).
- Modified files: `Core/Entry/EntryEvaluation.cs`, `Core/Entry/EntryDecisionPolicy.cs`, `EntryTypes/EntryDirectionQuality.cs`, `Core/TradeRouter.cs`.

### Testing
- Attempted to build with `dotnet build -v minimal` in the container, but the build could not be executed because `dotnet` is not installed in this environment (build failed). 
- No automated unit/integration tests were executed in this environment; changes are logging/observability-only and do not alter scoring, thresholds, routing, or acceptance logic, so a full local `dotnet build` and the existing test suite are recommended to validate compilation and runtime logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c430f679bc8328aaeda3d4bc055f82)