### PR TITLE
XAU: Soft-score compression for continuation entries on momentum loss + early weakness

### DIFF
--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -183,7 +183,9 @@ namespace GeminiV26.EntryTypes.METAL
                 (dir == TradeDirection.Short && bar.Close < bar.Open);
             bool followThrough = hasConfirmation;
 
+            int scoreBeforeTriggerModel = score;
             score = TriggerScoreModel.Apply(ctx, $"XAU_IMPULSE_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_IMPULSE_TRIGGER");
+            bool earlyWeakness = score < scoreBeforeTriggerModel;
 
 
             score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
@@ -196,6 +198,19 @@ namespace GeminiV26.EntryTypes.METAL
 
             if (setupScore <= 0)
                 score = System.Math.Min(score, MinScore - 10);
+
+            bool noMomentum = !(ctx.MarketState?.IsMomentum ?? false);
+            if (ctx.Symbol == "XAUUSD"
+                && ctx.MarketState != null
+                && ctx.MarketState.IsTrend
+                && noMomentum
+                && earlyWeakness)
+            {
+                int scoreBeforeCompression = score;
+                score = (int)System.Math.Round(score * 0.65);
+                ctx.Log?.Invoke(
+                    $"[XAU CONTINUATION FILTER] score {scoreBeforeCompression}->{score} momentum={ctx.MarketState.IsMomentum} earlyWeakness={earlyWeakness}");
+            }
 
 
             string note =

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -264,7 +264,9 @@ namespace GeminiV26.EntryTypes.METAL
             // =========================
             // FINAL
             // =========================
+            int scoreBeforeTriggerModel = score;
             score = TriggerScoreModel.Apply(ctx, $"XAU_PULLBACK_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_PULLBACK_TRIGGER");
+            bool earlyWeakness = score < scoreBeforeTriggerModel;
 
             score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score += (int)Math.Round(matrix.EntryScoreModifier);
@@ -272,6 +274,19 @@ namespace GeminiV26.EntryTypes.METAL
 
             if (setupScore <= 0)
                 score = Math.Min(score, minScore - 10);
+
+            bool noMomentum = !(ctx.MarketState?.IsMomentum ?? false);
+            if (ctx.Symbol == "XAUUSD"
+                && ctx.MarketState != null
+                && ctx.MarketState.IsTrend
+                && noMomentum
+                && earlyWeakness)
+            {
+                int scoreBeforeCompression = score;
+                score = (int)Math.Round(score * 0.65);
+                ctx.Log?.Invoke(
+                    $"[XAU CONTINUATION FILTER] score {scoreBeforeCompression}->{score} momentum={ctx.MarketState.IsMomentum} earlyWeakness={earlyWeakness}");
+            }
 
             bool valid = score >= minScore;
 


### PR DESCRIPTION
### Motivation
- Reduce confidence for XAU continuation setups that show an early-protect/early-break penalty combined with loss of momentum while trend is still present.  
- Keep entries allowed (do not block or change validity logic) but apply a strong soft degradation to the numeric score to deprioritize these failed continuation setups.  
- Limit scope strictly to XAU continuation entry types so no other instruments, thresholds, or global scoring behavior are affected.

### Description
- Modified only these files: `EntryTypes/METAL/XAU_PullbackEntry.cs` and `EntryTypes/METAL/XAU_ImpulseEntry.cs`.  
- Introduced local early-weakness detection by capturing `score` around the trigger model call: `int scoreBeforeTriggerModel = score;` then `bool earlyWeakness = score < scoreBeforeTriggerModel;`.  
- Added a gated score compression that runs after all existing scoring but before returning the evaluation and only when `ctx.Symbol == "XAUUSD"`, `ctx.MarketState.IsTrend == true`, momentum is false, and `earlyWeakness == true`; compression applies `score = (int)Math.Round(score * 0.65);`.  
- Added a single diagnostic log line emitted only when the filter triggers: `[XAU CONTINUATION FILTER] score {before}->{after} momentum={ctx.MarketState.IsMomentum} earlyWeakness={earlyWeakness}`.  
- Did not change any validity/IsValid logic, thresholds, routing, FX/INDEX/CRYPTO logic, or global scoring mechanisms.

### Testing
- Attempted build with `dotnet build -v minimal`, which failed due to runtime environment missing `dotnet` (exit: `dotnet: command not found`).  
- Verified changes via `git diff` / `git status` and committed the two modified files with the message `Adjust XAU continuation scores on early weakness without momentum`, confirming only the intended files were changed.  
- Ran text searches and file inspections (`rg`, `nl`) to ensure the new logic is localized and the logging/score-only behavior is present; these checks succeeded.

Exact inserted code snippet (applied in both modified files):
```csharp
int scoreBeforeTriggerModel = score;
score = TriggerScoreModel.Apply(ctx, $"XAU_*_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_*_TRIGGER");
bool earlyWeakness = score < scoreBeforeTriggerModel;

bool noMomentum = !(ctx.MarketState?.IsMomentum ?? false);
if (ctx.Symbol == "XAUUSD"
    && ctx.MarketState != null
    && ctx.MarketState.IsTrend
    && noMomentum
    && earlyWeakness)
{
    int scoreBeforeCompression = score;
    score = (int)Math.Round(score * 0.65);
    ctx.Log?.Invoke(
        $"[XAU CONTINUATION FILTER] score {scoreBeforeCompression}->{score} momentum={ctx.MarketState.IsMomentum} earlyWeakness={earlyWeakness}");
}
```

Confirmation
- ✅ Only `EntryTypes/METAL/XAU_PullbackEntry.cs` and `EntryTypes/METAL/XAU_ImpulseEntry.cs` were modified.  
- ✅ No validity flags were set/modified and no other logic outside these files was changed.  
- ✅ Logging is limited to the single conditional message and is only emitted when the filter triggers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c44387085c8328a4051601955184b0)