### PR TITLE
Block weak FX_MicroStructure entries in Range/SoftRange regimes

### DIFF
--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -147,6 +147,23 @@ namespace GeminiV26.EntryTypes.FX
             else
                 setupScore += 15;
 
+            bool isRangeRegime = IsRangeOrSoftRangeRegime(ctx);
+            bool hasNoCompression = rAtr > 1.2;
+            bool hasWeakPullbackStructure = !hasStructure;
+            bool isWeakFxMicro =
+                Type == EntryType.FX_MicroStructure &&
+                ctx.LogicConfidence <= 55 &&
+                isRangeRegime &&
+                (hasNoCompression || hasWeakPullbackStructure);
+
+            if (isWeakFxMicro)
+            {
+                string regimeLabel = ResolveRegimeLabel(ctx, isRangeRegime);
+                ctx.Log?.Invoke(
+                    $"[FX_MICRO_WEAK_FILTER] dir={dir} logicConf={ctx.LogicConfidence} regime={regimeLabel} noCompression={hasNoCompression.ToString().ToLowerInvariant()} weakPB={hasWeakPullbackStructure.ToString().ToLowerInvariant()} -> BLOCKED");
+                return Invalid(ctx, dir, "FX_MICRO_WEAK_FILTER_BLOCK", score);
+            }
+
             bool hasContinuation =
                 continuationSignal;
 
@@ -343,6 +360,35 @@ namespace GeminiV26.EntryTypes.FX
                     TypeTag = "FX_MicroStructureEntry",
                     ApplyTrendRegimePenalty = applyTrendRegimePenalty
                 });
+        }
+
+        private static bool IsRangeOrSoftRangeRegime(EntryContext ctx)
+        {
+            if (ctx == null)
+                return false;
+
+            if (ctx.IsRange_M5)
+                return true;
+
+            if (ctx.MarketState == null)
+                return false;
+
+            bool softRangeProxy =
+                !ctx.MarketState.IsTrend &&
+                (ctx.MarketState.IsLowVol || !ctx.IsAtrExpanding_M5);
+
+            return ctx.MarketState.IsRange || softRangeProxy;
+        }
+
+        private static string ResolveRegimeLabel(EntryContext ctx, bool isRangeRegime)
+        {
+            if (!isRangeRegime)
+                return "Trend";
+
+            if (ctx?.MarketState != null && !ctx.MarketState.IsRange)
+                return "SoftRange";
+
+            return "Range";
         }
 
     }


### PR DESCRIPTION
### Motivation
- Reduce low-quality FX MicroStructure trades in ranging or soft-ranging market regimes by filtering setups with weak pre-entry structure and low logic confidence. 
- The change is scoped to the FX microstructure entry evaluation so other entry types, global scoring, and trade core systems remain unchanged.

### Description
- Add a boolean `isWeakFxMicro` inside `EvalForDir` that evaluates: `EntryType == FX_MicroStructure`, `ctx.LogicConfidence <= 55`, regime is Range/SoftRange, and `(no compression || weak pullback structure)`.
- When `isWeakFxMicro` is true the evaluation logs a diagnostic with tag `[FX_MICRO_WEAK_FILTER]` and rejects the entry via `Invalid(..., "FX_MICRO_WEAK_FILTER_BLOCK", score)` to block the trade early. 
- `no compression` is derived from micro compression width via `rAtr > 1.2` and `weak pullback structure` maps to `pullbackDepthR < MinPullbackAtr` (existing `hasStructure` logic). 
- Added `IsRangeOrSoftRangeRegime` and `ResolveRegimeLabel` helpers to detect Range vs SoftRange proxy using `ctx.IsRange_M5` and `ctx.MarketState` without changing other modules, and kept all changes inside `EntryTypes/FX/FX_MicroStructureEntry.cs`.

### Testing
- Attempted to validate with `dotnet build` but the command failed in the current environment because `dotnet` is not installed (build not executed). 
- No automated tests were run in this environment; only static code changes in `EntryTypes/FX/FX_MicroStructureEntry.cs` were applied and committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50c70d8d88328acbb43b51cc15245)