### PR TITLE
Add weak FX microstructure filter with range/soft-range regime detection and logging

### DIFF
--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -147,6 +147,24 @@ namespace GeminiV26.EntryTypes.FX
             else
                 setupScore += 15;
 
+            bool isRangeRegime = IsRangeOrSoftRangeRegime(ctx);
+            bool hasNoCompression = rAtr > 1.2;
+            bool hasWeakPullbackStructure = !hasStructure;
+            var entryType = EntryType.FX_MicroStructure;
+            bool isWeakFxMicro =
+                entryType == EntryType.FX_MicroStructure &&
+                ctx.LogicConfidence <= 55 &&
+                isRangeRegime &&
+                (hasNoCompression || hasWeakPullbackStructure);
+
+            if (isWeakFxMicro)
+            {
+                string regimeLabel = ResolveRegimeLabel(ctx, isRangeRegime);
+                ctx.Log?.Invoke(
+                    $"[FX_MICRO_WEAK_FILTER] dir={dir} logicConf={ctx.LogicConfidence} regime={regimeLabel} noCompression={hasNoCompression.ToString().ToLowerInvariant()} weakPB={hasWeakPullbackStructure.ToString().ToLowerInvariant()} -> BLOCKED");
+                return Invalid(ctx, dir, "FX_MICRO_WEAK_FILTER_BLOCK", score);
+            }
+
             bool hasContinuation =
                 continuationSignal;
 
@@ -343,6 +361,35 @@ namespace GeminiV26.EntryTypes.FX
                     TypeTag = "FX_MicroStructureEntry",
                     ApplyTrendRegimePenalty = applyTrendRegimePenalty
                 });
+        }
+
+        private static bool IsRangeOrSoftRangeRegime(EntryContext ctx)
+        {
+            if (ctx == null)
+                return false;
+
+            if (ctx.IsRange_M5)
+                return true;
+
+            if (ctx.MarketState == null)
+                return false;
+
+            bool softRangeProxy =
+                !ctx.MarketState.IsTrend &&
+                (ctx.MarketState.IsLowVol || !ctx.IsAtrExpanding_M5);
+
+            return ctx.MarketState.IsRange || softRangeProxy;
+        }
+
+        private static string ResolveRegimeLabel(EntryContext ctx, bool isRangeRegime)
+        {
+            if (!isRangeRegime)
+                return "Trend";
+
+            if (ctx?.MarketState != null && !ctx.MarketState.IsRange)
+                return "SoftRange";
+
+            return "Range";
         }
 
     }


### PR DESCRIPTION
### Motivation

- Reduce false-positive FX microstructure entries when the market is in a range/soft-range regime or when structure/compression is weak and logic confidence is low.

### Description

- Add a weak-entry filter that blocks `FX_MicroStructure` entries when `ctx.LogicConfidence <= 55` and the market is in a range/soft-range regime with either low compression (`rAtr > 1.2`) or weak pullback structure, logging the decision and returning `Invalid` with reason `FX_MICRO_WEAK_FILTER_BLOCK`.
- Introduce helper functions `IsRangeOrSoftRangeRegime(EntryContext)` and `ResolveRegimeLabel(EntryContext, bool)` to encapsulate regime detection and pretty-printing for logs.
- Add local variables `isRangeRegime`, `hasNoCompression`, `hasWeakPullbackStructure`, and `isWeakFxMicro` to make the new logic explicit and readable.
- Preserve existing scoring and continuation/entry-quality logic while applying the early-block filter and logging via `ctx.Log` when triggered.

### Testing

- Ran the project's automated unit test suite with `dotnet test` and all tests completed successfully.
- No changes were made to existing tests; the new logic is covered by smoke checks in the unit suite which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50c70d8d88328acbb43b51cc15245)