### PR TITLE
Add post-breakout momentum validation to Index_BreakoutEntry

### DIFF
--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -197,6 +197,72 @@ namespace GeminiV26.EntryTypes.INDEX
 
             int lastClosed = ctx.M5.Count - 2;
             var bar = ctx.M5[lastClosed];
+
+            // =====================================================
+            // POST-BREAKOUT MOMENTUM VALIDATION (quality filter only)
+            // =====================================================
+            const double strongBodyRatioThreshold = 0.60;
+            const double closeNearExtremeThreshold = 0.20;
+            const double velocityAtrThreshold = 0.25;
+
+            double barRange = Math.Max(0, bar.High - bar.Low);
+            double barBody = Math.Abs(bar.Close - bar.Open);
+            double bodyRatio = barRange > 0 ? barBody / barRange : 0;
+
+            bool closeNearExtreme =
+                dir == TradeDirection.Long
+                    ? (barRange > 0 && (bar.High - bar.Close) <= barRange * closeNearExtremeThreshold)
+                    : (barRange > 0 && (bar.Close - bar.Low) <= barRange * closeNearExtremeThreshold);
+
+            bool breakoutBodyDirectionOk =
+                (dir == TradeDirection.Long && bar.Close > bar.Open) ||
+                (dir == TradeDirection.Short && bar.Close < bar.Open);
+
+            bool strongBreakoutCandle =
+                breakoutBodyDirectionOk &&
+                bodyRatio >= strongBodyRatioThreshold &&
+                closeNearExtreme;
+
+            bool rangeExpansion = false;
+            if (lastClosed >= 3)
+            {
+                double prevRange1 = Math.Max(0, ctx.M5[lastClosed - 1].High - ctx.M5[lastClosed - 1].Low);
+                double prevRange2 = Math.Max(0, ctx.M5[lastClosed - 2].High - ctx.M5[lastClosed - 2].Low);
+                double prevRange3 = Math.Max(0, ctx.M5[lastClosed - 3].High - ctx.M5[lastClosed - 3].Low);
+                double avgPrevRange = (prevRange1 + prevRange2 + prevRange3) / 3.0;
+                rangeExpansion = barRange > avgPrevRange;
+            }
+
+            bool immediateVelocity = false;
+            if (ctx.AtrM5 > 0 && lastClosed >= 2)
+            {
+                double velocityNow =
+                    dir == TradeDirection.Long
+                        ? (ctx.M5[lastClosed].Close - ctx.M5[lastClosed - 1].Close)
+                        : (ctx.M5[lastClosed - 1].Close - ctx.M5[lastClosed].Close);
+
+                double velocityPrev =
+                    dir == TradeDirection.Long
+                        ? (ctx.M5[lastClosed - 1].Close - ctx.M5[lastClosed - 2].Close)
+                        : (ctx.M5[lastClosed - 2].Close - ctx.M5[lastClosed - 1].Close);
+
+                double bestVelocity = Math.Max(velocityNow, velocityPrev);
+                immediateVelocity = bestVelocity >= (ctx.AtrM5 * velocityAtrThreshold);
+            }
+
+            string momentumType = null;
+            if (strongBreakoutCandle) momentumType = "body";
+            else if (rangeExpansion) momentumType = "range";
+            else if (immediateVelocity) momentumType = "velocity";
+
+            if (momentumType == null)
+            {
+                Console.WriteLine($"[BREAKOUT][REJECT][NO_MOMENTUM] symbol={ctx.Symbol} dir={dir} reason=dead_breakout");
+                return Reject(ctx, "IDX_NO_MOMENTUM_DEAD_BREAKOUT", score, dir);
+            }
+
+            Console.WriteLine($"[BREAKOUT][MOMENTUM_OK] symbol={ctx.Symbol} dir={dir} type={momentumType}");
+
             bool strongCandle =
                 (dir == TradeDirection.Long && bar.Close > bar.Open) ||
                 (dir == TradeDirection.Short && bar.Close < bar.Open);


### PR DESCRIPTION
### Motivation
- Index breakouts were sometimes accepted despite lacking immediate follow-through, producing dead breakouts and quick TVM exits. 
- The intent is to apply a lightweight, non-lagging quality filter to Index breakouts so only breakouts with immediate momentum are allowed. 

### Description
- Added a dedicated POST-BREAKOUT MOMENTUM VALIDATION block inside `EntryTypes/INDEX/Index_BreakoutEntry.cs` that requires at least one momentum path to pass before continuing evaluation. 
- Implemented three momentum checks: a strong breakout candle (`body >= 60%` + close near the high/low), range expansion versus the prior 3 M5 candle average, and immediate directional velocity (best of last 1–2 bar move >= `0.25 * ATR`). 
- If none of the momentum checks pass the entry is rejected via the existing `Reject` flow with reason `IDX_NO_MOMENTUM_DEAD_BREAKOUT` and a log line `[BREAKOUT][REJECT][NO_MOMENTUM] ...`; if one passes a log line `[BREAKOUT][MOMENTUM_OK] ... type=body|range|velocity` is written. 
- Scope-limited change: only `Index_BreakoutEntry` was modified and no architecture, cross-module, or exit/TradeCore changes were made. 

### Testing
- Ran repository static checks using `git diff --check` and observed no whitespace or diff-check issues. 
- Verified working tree status with `git status --short` to ensure only the intended file changed. 
- No new dependencies were introduced and the change is implemented as an early quality-reject filter that preserves existing timing and scoring logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c513e3c7648328b05928ec2f572efe)