### PR TITLE
Tighten M5 flag validation rules in EntryContextBuilder

### DIFF
--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -490,7 +490,16 @@ namespace GeminiV26.Core.Entry
                 flagLo = Math.Min(flagLo, ctx.M5.LowPrices[i]);
             }
 
+            int flagBars = m5Idx - start + 1;
             double flagRange = flagHi - flagLo;
+
+            bool hasRecentImpulse =
+                ctx.HasImpulse_M5 ||
+                ctx.BarsSinceImpulse_M5 <= 3;
+
+            bool validFlagBars =
+                flagBars >= 2 &&
+                flagBars <= 5;
 
             // ============================
             // 1) COMPRESSION
@@ -499,7 +508,10 @@ namespace GeminiV26.Core.Entry
             bool isTight =
                 ctx.AtrM5 > 0 &&
                 flagRange > 0 &&
-                flagRange < ctx.AtrM5 * 1.5;
+                flagRange < ctx.AtrM5 * 0.8;
+
+            bool validRetrace =
+                ctx.PullbackDepthAtr_M5 <= 0.5;
 
             // ============================
             // 2) MICRO STRUCTURE
@@ -527,26 +539,27 @@ namespace GeminiV26.Core.Entry
             // 3) DECELERATION (MÁR KISZÁMOLT)
             // ============================
 
-            bool decelerating =
-                ctx.IsPullbackDecelerating_M5 ||
-                (ctx.HasEarlyPullback_M5 && ctx.PullbackBars_M5 <= 2);
-            bool allowWithoutDecel =
-                ctx.HasEarlyPullback_M5 &&
-                ctx.PullbackBars_M5 <= 2;
+            bool decelerating = ctx.IsPullbackDecelerating_M5;
 
             // ============================
             // 4) FINAL FLAG DECISION
             // ============================
 
             bool shortFlag =
+                hasRecentImpulse &&
+                validFlagBars &&
                 isTight &&
+                validRetrace &&
                 hasLowerHighs &&
-                (decelerating || allowWithoutDecel);
+                decelerating;
 
             bool longFlag =
+                hasRecentImpulse &&
+                validFlagBars &&
                 isTight &&
+                validRetrace &&
                 hasHigherLows &&
-                (decelerating || allowWithoutDecel);
+                decelerating;
 
             // ============================
             // 5) ASSIGN
@@ -573,6 +586,30 @@ namespace GeminiV26.Core.Entry
                 ctx.HasFlagLong_M5 = false;
             }
 
+            if (!hasRecentImpulse)
+            {
+                ctx.HasFlagLong_M5 = false;
+                ctx.HasFlagShort_M5 = false;
+            }
+
+            if (!validFlagBars)
+            {
+                ctx.HasFlagLong_M5 = false;
+                ctx.HasFlagShort_M5 = false;
+            }
+
+            if (!validRetrace)
+            {
+                ctx.HasFlagLong_M5 = false;
+                ctx.HasFlagShort_M5 = false;
+            }
+
+            _bot.Print(
+                $"[FLAG FIX] recentImpulse={hasRecentImpulse} bars={flagBars} retraceOk={validRetrace} " +
+                $"tight={isTight} decel={ctx.IsPullbackDecelerating_M5} " +
+                $"long={ctx.HasFlagLong_M5} short={ctx.HasFlagShort_M5}"
+            );
+
             // ATR-normalizált méret
             ctx.FlagAtr_M5 = flagRange;
 
@@ -595,7 +632,7 @@ namespace GeminiV26.Core.Entry
             // ============================
 
             _bot.Print(
-                $"[FLAG V2.22] tight={isTight} decel={decelerating} allowNoDecel={allowWithoutDecel} " +
+                $"[FLAG V2.22] tight={isTight} decel={decelerating} allowNoDecel=false " +
                 $"LH={hasLowerHighs} HL={hasHigherLows} " +
                 $"short={ctx.HasFlagShort_M5} long={ctx.HasFlagLong_M5} " +
                 $"range={flagRange} atr={ctx.AtrM5}"


### PR DESCRIPTION
### Motivation
- Reduce false-positive M5 FLAG detections by enforcing stricter continuation and compression rules. 
- Ensure flags are only emitted after a recent impulse and for short, well-compressed micro-structures. 
- Apply minimal, targeted changes inside `EntryContextBuilder.cs` without touching architecture, public interfaces, or breakout logic.

### Description
- Require a recent impulse by gating flags with `hasRecentImpulse = ctx.HasImpulse_M5 || ctx.BarsSinceImpulse_M5 <= 3` and force-disable flags when false. 
- Enforce strict flag length with `int flagBars = m5Idx - start + 1` and require `flagBars >= 2 && flagBars <= 5`. 
- Strengthen compression: replace `flagRange < ctx.AtrM5 * 1.5` with `flagRange < ctx.AtrM5 * 0.8`, and add retracement check `validRetrace = ctx.PullbackDepthAtr_M5 <= 0.5`. 
- Remove the weak deceleration fallback and require `ctx.IsPullbackDecelerating_M5` for both long and short flags, require all conditions (impulse + bars + compression + retrace + microstructure + deceleration) for final flag decisions, preserve conflict handling where both sides true disables both, and add a new debug log `"[FLAG FIX] ..."` showing `recentImpulse`, `bars`, `retraceOk`, `tight`, `decel`, `long`, and `short`.

### Testing
- Attempted `dotnet build` in this environment but it failed because `dotnet` is not installed, so a full compile/test run could not be executed. 
- No automated unit or integration tests were run here due to the environment limitation; only static edits and local file inspections were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c520bf99008328909c0bb0e8fa5c47)