### PR TITLE
Refine M5 flag validation with ATR+impulse hybrid thresholds

### DIFF
--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -505,13 +505,49 @@ namespace GeminiV26.Core.Entry
             // 1) COMPRESSION
             // ============================
 
+            double atrForFlag = ctx.AtrM5;
+
+            double impulseRange = 0.0;
+            int impulseIdx = m5Idx - ctx.BarsSinceImpulse_M5;
+
+            if (ctx.HasImpulse_M5 && m5Idx >= 0)
+            {
+                impulseRange = Math.Abs(ctx.M5.HighPrices[m5Idx] - ctx.M5.LowPrices[m5Idx]);
+            }
+            else if (ctx.BarsSinceImpulse_M5 >= 0 && ctx.BarsSinceImpulse_M5 <= 3 && impulseIdx >= 0)
+            {
+                impulseRange = Math.Abs(ctx.M5.HighPrices[impulseIdx] - ctx.M5.LowPrices[impulseIdx]);
+            }
+
+            bool hasValidImpulseRange =
+                impulseRange > 0 &&
+                !double.IsNaN(impulseRange) &&
+                !double.IsInfinity(impulseRange);
+
+            double maxCompression =
+                hasValidImpulseRange
+                    ? Math.Min(0.8 * atrForFlag, 0.35 * impulseRange)
+                    : 0.8 * atrForFlag;
+
+            double maxRetrace =
+                hasValidImpulseRange
+                    ? Math.Min(0.6 * atrForFlag, 0.5 * impulseRange)
+                    : 0.5 * atrForFlag;
+
+            double retraceAmount =
+                atrForFlag > 0
+                    ? ctx.PullbackDepthAtr_M5 * atrForFlag
+                    : 0.0;
+
             bool isTight =
-                ctx.AtrM5 > 0 &&
+                atrForFlag > 0 &&
                 flagRange > 0 &&
-                flagRange < ctx.AtrM5 * 0.8;
+                flagRange <= maxCompression;
 
             bool validRetrace =
-                ctx.PullbackDepthAtr_M5 <= 0.5;
+                atrForFlag > 0
+                    ? retraceAmount <= maxRetrace
+                    : ctx.PullbackDepthAtr_M5 <= 0.5;
 
             // ============================
             // 2) MICRO STRUCTURE
@@ -607,7 +643,8 @@ namespace GeminiV26.Core.Entry
             _bot.Print(
                 $"[FLAG FIX] recentImpulse={hasRecentImpulse} bars={flagBars} retraceOk={validRetrace} " +
                 $"tight={isTight} decel={ctx.IsPullbackDecelerating_M5} " +
-                $"long={ctx.HasFlagLong_M5} short={ctx.HasFlagShort_M5}"
+                $"long={ctx.HasFlagLong_M5} short={ctx.HasFlagShort_M5} " +
+                $"impulse={impulseRange:F2} comp={flagRange:F2}/{maxCompression:F2} retr={retraceAmount:F2}/{maxRetrace:F2}"
             );
 
             // ATR-normalizált méret


### PR DESCRIPTION
### Motivation

- Flag compression/retrace were validated only vs ATR which can misclassify structure during high volatility, so thresholds must consider the recent impulse size as well. 
- Introduce a hybrid ATR+impulse model while preserving existing flag decision structure and providing a safe fallback to ATR-only when impulse data is missing.

### Description

- Compute a defensive `impulseRange` derived from recent impulse bar data using `ctx.HasImpulse_M5` and `ctx.BarsSinceImpulse_M5`, and treat `impulseRange` as invalid when `<= 0`, `NaN`, or `Infinity` to enable fallback behavior. 
- Calculate hybrid thresholds `maxCompression` and `maxRetrace` using the provided formulas (`min(0.8*ATR, 0.35*impulseRange)` and `min(0.6*ATR, 0.5*impulseRange)`), with ATR-only fallbacks (`0.8*ATR` and `0.5*ATR`) when impulse range is not valid. 
- Replace the old ATR-only comparisons for `isTight` and `validRetrace` with checks against `maxCompression` and `maxRetrace`, while keeping `longFlag`/`shortFlag` logic, gating, and surrounding structure unchanged. 
- Extend the existing `[FLAG FIX]` debug log to append `impulse`, `comp`, and `retr` diagnostics without removing prior log fields.

### Testing

- Attempted to compile with `dotnet build`, but the environment does not have `dotnet` installed so compilation could not be verified (failed with `/bin/bash: dotnet: command not found`).
- No automated unit tests were executed in this environment; change is limited to `Core/Entry/EntryContextBuilder.cs` to respect scope and preserve existing behavior when `impulseRange == 0` (ATR-only fallback).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52204e46c8328bca68a0f5104ce98)