### PR TITLE
Rehydrate: skip positions outside bot's canonical symbol

### DIFF
--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -5,6 +5,7 @@ using Gemini.Memory;
 using GeminiV26.Core.Context;
 using GeminiV26.Core.Entry;
 using GeminiV26.Core.Logging;
+using static GeminiV26.Core.SymbolRouting;
 
 namespace GeminiV26.Core.Runtime
 {
@@ -105,6 +106,20 @@ namespace GeminiV26.Core.Runtime
                         $"label={position.Label} reason=ownership_ambiguous");
                 }
 
+                return;
+            }
+
+            string botCanonical = NormalizeSymbol(_bot.Symbol?.Name ?? _bot.SymbolName);
+            string positionCanonical = NormalizeSymbol(position.SymbolName);
+
+            if (!string.IsNullOrWhiteSpace(botCanonical) &&
+                !string.IsNullOrWhiteSpace(positionCanonical) &&
+                !string.Equals(botCanonical, positionCanonical, StringComparison.OrdinalIgnoreCase))
+            {
+                summary.Skipped++;
+                _bot.Print(
+                    $"[REHYDRATE_SKIP] pos={Convert.ToInt64(position.Id)} symbol={position.SymbolName} " +
+                    $"reason=symbol_mismatch_bot_scope botCanonical={botCanonical} positionCanonical={positionCanonical}");
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Prevent rehydrate from attempting to process positions whose canonical symbol does not match the running bot/chart canonical, which caused cross-symbol resolution attempts (e.g. NAS100 run trying to resolve GER40 aliases) and downstream symbol-not-found churn.

### Description
- Add a canonical-scope guard in `RehydrateService.ProcessPosition` that compares `NormalizeSymbol(_bot.Symbol?.Name ?? _bot.SymbolName)` with `NormalizeSymbol(position.SymbolName)` and skips the position with log reason `symbol_mismatch_bot_scope` when they differ, importing `SymbolRouting.NormalizeSymbol` via `using static` and keeping all existing rehydrate logic unchanged.

### Testing
- Ran repository searches with `rg -n "REHYDRATE_WARN|RESOLVER\]|canonical|GER40|GERMANY 40|symbol_not_tradable"` to inspect call sites and confirm the change points (succeeded).
- Verified and committed the modified file `Core/Runtime/RehydrateService.cs` (commit created successfully).
- Attempted `dotnet build -v minimal` to compile, but the environment lacks `dotnet` so the build could not be executed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c563d74f64832890096b6a3b922766)