### PR TITLE
Add mid-trend softening for restart and reduce early-break stacking

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1745,6 +1745,9 @@ namespace GeminiV26.Core
                 {
                     bool isCryptoCandidate = IsCryptoCandidate(candidate.Type);
                     bool continuationAuthority = HasContinuationAuthority(ctx, candidate);
+                    bool midTrend =
+                        ctx.TrendDirection == candidate.Direction &&
+                        ctx.MarketState?.IsTrend == true;
                     _bot.Print(TradeLogIdentity.WithTempId(
                         $"[ENTRY][AUTH] source=RESTART_PROTECT symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} dir={candidate.Direction} authority={continuationAuthority}",
                         ctx));
@@ -1771,6 +1774,27 @@ namespace GeminiV26.Core
                             _bot.Print(TradeLogIdentity.WithTempId(
                                 $"[ENTRY][PROTECT_SUPPRESSED] source=RESTART_PROTECT symbol={candidate.Symbol ?? _bot.SymbolName} " +
                                 $"type={candidate.Type} dir={candidate.Direction} score={protectedOriginalScore}->{candidate.Score} state={restartReason}",
+                                ctx));
+                            continue;
+                        }
+                        else if (midTrend)
+                        {
+                            int restartPenalty = 14;
+                            restartPenalty = Math.Min(restartPenalty, 8);
+                            int midTrendOriginalScore = candidate.Score;
+                            candidate.Score = Math.Max(EntryDecisionPolicy.MinScoreThreshold, candidate.Score - restartPenalty);
+                            candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
+                                ? $"[RESTART_MID_TREND_SOFT_{restartReason}]"
+                                : $"{candidate.Reason} [RESTART_MID_TREND_SOFT_{restartReason}]";
+                            candidate.IsValid = true;
+                            EntryDecisionPolicy.Normalize(candidate);
+
+                            _bot.Print(TradeLogIdentity.WithTempId(
+                                $"[ENTRY][MID_TREND] active=true restartPenalty={restartPenalty} earlyBreakPenalty=0 symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} dir={candidate.Direction}",
+                                ctx));
+                            _bot.Print(TradeLogIdentity.WithTempId(
+                                $"[ENTRY][PROTECT] source=RESTART_PROTECT action=MID_TREND_SOFT symbol={candidate.Symbol ?? _bot.SymbolName} " +
+                                $"type={candidate.Type} dir={candidate.Direction} score={midTrendOriginalScore}->{candidate.Score} state={restartReason}",
                                 ctx));
                             continue;
                         }
@@ -2073,8 +2097,22 @@ namespace GeminiV26.Core
                 return;
 
             int originalScore = candidate.Score;
-            const int earlyBreakPenalty = 15;
+            int earlyBreakPenalty = 15;
             bool continuationAuthority = HasContinuationAuthority(ctx, candidate);
+            bool midTrend =
+                ctx.TrendDirection == candidate.Direction &&
+                ctx.MarketState?.IsTrend == true;
+            bool hasRestartPenalty = ContainsAny(candidate.Reason, "RESTART_");
+            bool hasEarlyBreakPenalty = earlyBreakPenalty > 0;
+
+            if (!continuationAuthority && midTrend && hasRestartPenalty && hasEarlyBreakPenalty)
+            {
+                earlyBreakPenalty = (int)(earlyBreakPenalty * 0.5);
+                _bot.Print(TradeLogIdentity.WithTempId(
+                    $"[ENTRY][MID_TREND] active=true restartPenalty=carried earlyBreakPenalty={earlyBreakPenalty} symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} dir={candidate.Direction}",
+                    ctx));
+            }
+
             int appliedPenalty = earlyBreakPenalty;
 
             if (continuationAuthority)


### PR DESCRIPTION
### Motivation
- Introduce a minimal mid-trend softening layer between strong `continuationAuthority` and default strict restart decay to improve FX/XAU behavior without refactoring or changing architecture. 
- Reduce harsh stacking when a restart penalty and an early-break penalty would both apply mid-trend to avoid over-penalizing valid continuation setups.

### Description
- Added a `midTrend` boolean immediately after `continuationAuthority` in `ApplyRestartProtection` (`midTrend = ctx.TrendDirection == candidate.Direction && ctx.MarketState?.IsTrend == true;`).
- Inserted an `else if (midTrend)` branch in `ApplyRestartProtection` that applies a softened restart decay by capping `restartPenalty` to `8`, preserves `candidate.IsValid = true`, and emits `[ENTRY][MID_TREND]` logs.
- In `ApplyManagedEarlyBreakTriggers` added `midTrend`, `hasRestartPenalty`, and `hasEarlyBreakPenalty` checks and, when `!continuationAuthority && midTrend && hasRestartPenalty && hasEarlyBreakPenalty`, reduced the `earlyBreakPenalty` by half and emitted `[ENTRY][MID_TREND]` logs.
- Kept `HasContinuationAuthority` logic unchanged, did not add methods, did not change method signatures, and only modified restart/early-break interaction in `Core/TradeCore.cs` (no TVM or index-specific changes).

### Testing
- Attempted `dotnet build` but it failed due to environment limitation (`/bin/bash: dotnet: command not found`).
- Inspected changes with `git diff -- Core/TradeCore.cs` and `git show -- Core/TradeCore.cs` to verify the exact diff and confirm only intended areas were modified, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c57f497a34832882bd288bbe3d2641)