### PR TITLE
Relax XAU impulse rejects into trend-aware penalties

### DIFF
--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -94,12 +94,17 @@ namespace GeminiV26.EntryTypes.METAL
                 score -= 8;
 
             if (!ctx.IsAtrExpanding_M5)
-                return Reject(ctx, $"ATR_NOT_EXPANDING_{dir}");
+                score -= 6;
 
             score += 5;
 
             if (!ctx.HasImpulse_M5)
-                return Reject(ctx, $"NO_M5_IMPULSE_{dir}");
+            {
+                if (ctx.TrendDirection == dir)
+                    score -= 8;
+                else
+                    return Reject(ctx, $"NO_M5_IMPULSE_{dir}");
+            }
 
             score += 5;
 
@@ -112,7 +117,12 @@ namespace GeminiV26.EntryTypes.METAL
             minAdxRequired = System.Math.Max(minAdxRequired, matrix.MinAdx);
 
             if (ctx.Adx_M5 >= 15 && ctx.Adx_M5 < minAdxRequired)
-                return Reject(ctx, $"ADX_TOO_LOW_{dir}({ctx.Adx_M5:F1})");
+            {
+                if (ctx.Adx_M5 < 28 && ctx.TrendDirection == dir && ctx.MarketState?.IsTrend == true)
+                    score -= 8;
+                else
+                    return Reject(ctx, $"ADX_TOO_LOW_{dir}({ctx.Adx_M5:F1})");
+            }
 
             if (ctx.Adx_M5 >= 30)
                 score += 5;


### PR DESCRIPTION
### Motivation
- Relax overly strict hard-reject gates for XAU impulse continuation to allow trades when trend context supports continuation while keeping hard rejects when context is absent.
- Make a minimal, targeted change limited to the XAU impulse entry logic without refactoring or changing global thresholds or other instruments.

### Description
- Modified only `EntryTypes/METAL/XAU_ImpulseEntry.cs` to convert three hard rejects into soft penalties or trend-aware rejects while preserving other logic and thresholds.
- Replaced the `ATR_NOT_EXPANDING` hard reject with a soft penalty by applying `score -= 6` when `!ctx.IsAtrExpanding_M5` instead of returning `Reject`. 
- Replaced the `NO_M5_IMPULSE` hard reject with a trend-aware penalty that does `score -= 8` when `!ctx.HasImpulse_M5` but `ctx.TrendDirection == dir`, and otherwise still returns `Reject`. 
- Replaced the `ADX_TOO_LOW` hard reject with a conditional change that applies `score -= 8` only when `ctx.Adx_M5 < 28` AND `ctx.TrendDirection == dir` AND `ctx.MarketState?.IsTrend == true`, and otherwise keeps the `Reject` path. 

### Testing
- Ran `git diff -- EntryTypes/METAL/XAU_ImpulseEntry.cs` to inspect the patch and it showed only the intended changes, which succeeded. 
- Ran `git show -- EntryTypes/METAL/XAU_ImpulseEntry.cs --pretty=format:` and `git status --short` to verify the committed update to `EntryTypes/METAL/XAU_ImpulseEntry.cs`, and both commands succeeded. 
- No other automated unit or integration tests were run as part of this minimal change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c580b1df1083288b692ed2934db625)