### PR TITLE
Relax XAU pullback impulse hard rejects in trend context

### DIFF
--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -71,7 +71,12 @@ namespace GeminiV26.EntryTypes.METAL
                     : ctx.HasImpulseShort_M5;
 
             if (!hasImpulse)
-                return InvalidDir(ctx, dir, "NO_IMPULSE", score);
+            {
+                if (ctx.MarketState?.IsTrend == true)
+                    score -= 8;
+                else
+                    return InvalidDir(ctx, dir, "NO_IMPULSE", score);
+            }
 
             int barsSinceImpulse =
                 dir == TradeDirection.Long
@@ -83,7 +88,15 @@ namespace GeminiV26.EntryTypes.METAL
 
             if (barsSinceImpulse == 0)
             {
-                return InvalidDir(ctx, dir, "IMPULSE_TOO_FRESH", score);
+                if (ctx.MarketState?.IsTrend == true)
+                {
+                    score -= 4;
+                    reasons.Add("IMPULSE_TOO_FRESH_SOFT");
+                }
+                else
+                {
+                    return InvalidDir(ctx, dir, "IMPULSE_TOO_FRESH", score);
+                }
             }
 
             // =========================


### PR DESCRIPTION
### Motivation
- The XAU pullback entry currently hard-rejects candidates when impulse checks fail, which is overly strict during clear trending market context.
- The change makes impulse-related hard rejects conditional so that trend context can convert some hard rejects into softer score penalties without altering global scoring rules.

### Description
- Modified only `EntryTypes/METAL/XAU_PullbackEntry.cs` to change the `NO_IMPULSE` hard reject into a trend-aware soft penalty by replacing `if (!hasImpulse) return InvalidDir(ctx, dir, "NO_IMPULSE", score);` with a block that subtracts `8` from `score` when `ctx.MarketState?.IsTrend == true` and otherwise returns the original hard reject. 
- Modified only the `IMPULSE_TOO_FRESH` case by replacing `if (barsSinceImpulse == 0) return InvalidDir(ctx, dir, "IMPULSE_TOO_FRESH", score);` with a block that subtracts `4` from `score` and adds `reasons.Add("IMPULSE_TOO_FRESH_SOFT")` when `ctx.MarketState?.IsTrend == true` and otherwise returns the original hard reject. 
- Did not change any other reject paths, scoring weights outside these lines, threshold logic, or behavior for other instruments.

### Testing
- Ran `rg -n "NO_IMPULSE|IMPULSE_TOO_FRESH|hasImpulse|barsSinceImpulse == 0" EntryTypes/METAL/XAU_PullbackEntry.cs` to locate and verify the modified occurrences and it succeeded. 
- Inspected the applied changes with `git diff -- EntryTypes/METAL/XAU_PullbackEntry.cs` and reviewed the file segment with `nl -ba EntryTypes/METAL/XAU_PullbackEntry.cs | sed -n '60,120p'` to confirm the exact replacements were applied. 
- Verified working tree shows only `EntryTypes/METAL/XAU_PullbackEntry.cs` as modified which confirms scope was limited to the requested two blocks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58178c14883288911a0bb3fbcc356)