### PR TITLE
Allow FX continuation authority to bypass strict acceptance filters

### DIFF
--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -167,6 +167,11 @@ namespace GeminiV26.Core
         private bool ApplyFxAcceptanceFilters(EntryEvaluation eval, EntryContext entryContext)
         {
             const int HtfMismatchPenalty = 10;
+            bool continuationAuthority =
+                entryContext?.MarketState?.IsTrend == true &&
+                eval?.Direction == entryContext.TrendDirection &&
+                entryContext.HasImpulse_M5 &&
+                entryContext.IsAtrExpanding_M5;
 
             if (eval == null || !eval.IsValid)
                 return false;
@@ -191,7 +196,10 @@ namespace GeminiV26.Core
                     _bot.Print(TradeLogIdentity.WithTempId(
                         $"[HTF][BLOCK] strong opposite HTF + weak LTF type={eval.Type} dir={eval.Direction} " +
                         $"score={eval.Score} htfConf={eval.HtfConfidence01:F2} logicConf={entryContext?.LogicBiasConfidence ?? 0}", entryContext));
-                    return RejectFxCandidate(eval, decisionScore, "HTF_STRONG_OPPOSITE_LTF_WEAK", entryContext);
+                    if (!continuationAuthority)
+                        return RejectFxCandidate(eval, decisionScore, "HTF_STRONG_OPPOSITE_LTF_WEAK", entryContext);
+
+                    eval.Score -= 8;
                 }
 
                 int originalScore = eval.Score;
@@ -209,7 +217,8 @@ namespace GeminiV26.Core
                 if (eval.State == EntryState.SETUP_DETECTED)
                     return RejectFxCandidate(eval, decisionScore, "FX_EARLY_BLOCK", entryContext);
 
-                return RejectFxCandidate(eval, decisionScore, "FX_TRIGGER_REQUIRED", entryContext);
+                if (!continuationAuthority)
+                    return RejectFxCandidate(eval, decisionScore, "FX_TRIGGER_REQUIRED", entryContext);
             }
 
             if (decisionScore < 45)


### PR DESCRIPTION
### Motivation
- Permit strong continuation FX setups to bypass strict FX acceptance filters while keeping all existing filters and logs intact.
- Maintain minimal, targeted change scope: only adjust FX acceptance logic and do not alter entry types or global thresholds.

### Description
- Add `continuationAuthority` at the start of `ApplyFxAcceptanceFilters` in `Core/TradeRouter.cs`, computed from `entryContext.MarketState?.IsTrend`, `eval.Direction == entryContext.TrendDirection`, `entryContext.HasImpulse_M5`, and `entryContext.IsAtrExpanding_M5`.
- Change the strong HTF-opposite path so it only returns `HTF_STRONG_OPPOSITE_LTF_WEAK` when `continuationAuthority` is false, and when true apply `eval.Score -= 8` while preserving all existing logs and subsequent mismatch penalties.
- Change the trigger-required rejection so `FX_TRIGGER_REQUIRED` is only returned when `continuationAuthority` is false, keeping all other FX filters and score checks unchanged.
- Only `Core/TradeRouter.cs` was modified and the changes are confined to `ApplyFxAcceptanceFilters(...)`.

### Testing
- Attempted to run a build with `dotnet build`, but it failed because the `dotnet` executable is not available in the environment.
- No automated unit tests were executed in this environment due to the missing runtime/tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5826df9448328b3ca0c9dc6d16072)