### PR TITLE
Tighten XAU post-router range veto to require non-trend

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1242,7 +1242,7 @@ namespace GeminiV26.Core
                 {
                     xauState = _xauMarketStateDetector.Evaluate();
 
-                    if (xauState != null && xauState.IsRange)
+                    if (xauState != null && xauState.IsRange && !xauState.IsTrend)
                     {
                         _bot.Print(
                             $"[TC] ENTRY BLOCKED: XAU RANGE REGIME" +


### PR DESCRIPTION
### Motivation
- Prevent valid XAU-selected entries from being dropped solely because `IsRange` is true when XAU trend (`IsTrend`) is still active.

### Description
- In `Core/TradeCore.cs` changed `if (xauState != null && xauState.IsRange)` to `if (xauState != null && xauState.IsRange && !xauState.IsTrend)` so entries are blocked only when range is active and trend is not active; this is the only line changed.

### Testing
- Attempted `dotnet build` but `dotnet` is not installed in this environment so a local compile could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c589dfbaec8328b76aa75ee5dcef7d)