### PR TITLE
Add per-cycle cache to RuntimeSymbolResolver to suppress duplicate resolves/logs

### DIFF
--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -12,6 +12,7 @@ namespace GeminiV26.Core
     {
         private readonly Robot _bot;
         private readonly Dictionary<string, Symbol> _cache = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Symbol> _cycleCache = new(StringComparer.OrdinalIgnoreCase);
 
         public RuntimeSymbolResolver(Robot bot)
         {
@@ -22,6 +23,12 @@ namespace GeminiV26.Core
         public void Refresh()
         {
             _cache.Clear();
+            _cycleCache.Clear();
+        }
+
+        public void BeginExecutionCycle()
+        {
+            _cycleCache.Clear();
         }
 
         public bool TryResolveRuntimeName(string symbolReference, out string runtimeName)
@@ -42,6 +49,9 @@ namespace GeminiV26.Core
             }
 
             string requested = symbolReference.Trim();
+            if (_cycleCache.TryGetValue(requested, out symbol))
+                return IsUsableSymbol(symbol);
+
             _bot.Print($"[RESOLVER][INPUT] input={requested}");
 
             string canonical = SymbolRouting.NormalizeSymbol(requested);
@@ -52,12 +62,14 @@ namespace GeminiV26.Core
                 CacheAliases(requested, canonical, symbol);
                 _bot.Print($"[RESOLVER][RUNTIME] source=current_bot runtime={symbol.Name}");
                 _bot.Print($"[RESOLVER][SUCCESS] input={requested} canonical={canonical} runtime={symbol.Name}");
+                _cycleCache[requested] = symbol;
                 return true;
             }
 
             if (!IsGeminiSupportedCanonical(canonical))
             {
                 _bot.Print($"[RESOLVER][SKIP] reason=unsupported_canonical canonical={canonical}");
+                _cycleCache[requested] = null;
                 return false;
             }
 
@@ -65,6 +77,7 @@ namespace GeminiV26.Core
             {
                 _bot.Print($"[RESOLVER][RUNTIME] source=cache runtime={symbol.Name}");
                 _bot.Print($"[RESOLVER][SUCCESS] input={requested} canonical={canonical} runtime={symbol.Name}");
+                _cycleCache[requested] = symbol;
                 return true;
             }
 
@@ -74,6 +87,7 @@ namespace GeminiV26.Core
                 CacheAliases(requested, canonical, symbol);
                 _bot.Print($"[RESOLVER][RUNTIME] source=direct runtime={symbol.Name}");
                 _bot.Print($"[RESOLVER][SUCCESS] input={requested} canonical={canonical} runtime={symbol.Name}");
+                _cycleCache[requested] = symbol;
                 return true;
             }
 
@@ -81,11 +95,13 @@ namespace GeminiV26.Core
             {
                 _bot.Print($"[RESOLVER][RUNTIME] source=known_map runtime={symbol.Name}");
                 _bot.Print($"[RESOLVER][SUCCESS] input={requested} canonical={canonical} runtime={symbol.Name}");
+                _cycleCache[requested] = symbol;
                 return true;
             }
 
             _bot.Print("[SYMBOL][SKIP] " + canonical);
             _bot.Print($"[RESOLVER][SKIP] reason=runtime_not_found canonical={canonical}");
+            _cycleCache[requested] = null;
             return false;
         }
 

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -723,6 +723,7 @@ namespace GeminiV26.Core
         public void OnBar()
         {
             EnsureRuntimeResolverInitialized();
+            _runtimeSymbols.BeginExecutionCycle();
             string rawSym = _bot.SymbolName;
             string sym = NormalizeSymbol(rawSym);   // ✅ CANONICAL
 
@@ -2372,6 +2373,7 @@ namespace GeminiV26.Core
         public void OnTick()
         {
             EnsureRuntimeResolverInitialized();
+            _runtimeSymbols.BeginExecutionCycle();
             try
             {
                 // =====================================================


### PR DESCRIPTION
### Motivation
- Reduce repeated `RuntimeSymbolResolver` work and duplicate resolver log lines when the same symbol input is requested multiple times within the same tick/bar execution cycle. 
- Implement a minimal, focused fix that does not change symbol mapping behavior or refactor resolver logic.

### Description
- Added a per-execution-cycle in-memory cache `_cycleCache` to `RuntimeSymbolResolver` and a `BeginExecutionCycle()` method to reset it. 
- Short-circuited `TryResolveSymbol` to return immediately from the cycle cache for repeated identical `requested` inputs before emitting resolver logs. 
- Store both successful `Symbol` results and failed lookups (`null`) into the cycle cache so repeated requests in the same cycle are cheap and silent. 
- Invoked `BeginExecutionCycle()` at the start of `TradeCore.OnBar()` and `TradeCore.OnTick()` so cache scope is per bar/tick execution cycle only.

### Testing
- Ran repository checks and diffs (`git diff` / `git show --stat`) to verify the intended changes were applied and committed, which succeeded. 
- Ran `git diff --check` to ensure no whitespace or diff errors, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58ad70b9c832897234a9417bce285)