### PR TITLE
Allow early-window structure override when ADX is strong and MAE is low

### DIFF
--- a/Core/TradeViabilityMonitor.cs
+++ b/Core/TradeViabilityMonitor.cs
@@ -462,6 +462,10 @@ namespace GeminiV26.Core
             bool adxHealthy = ctx.Adx_M5 >= 20.0;
             bool volatilitySupport = ctx.MfeR >= 0.20 || ctx.MaeR <= 0.35;
             bool structureIntact = !IsStructureWeakening(tradeType, m5);
+            bool adxStrong = ctx.Adx_M5 >= 35.0;
+            bool earlyWindow = ctx.BarsSinceEntryM5 <= 4;
+            if (!structureIntact && adxStrong && earlyWindow && ctx.MaeR <= 0.20)
+                structureIntact = true;
 
             return adxHealthy && volatilitySupport && structureIntact;
         }


### PR DESCRIPTION
### Motivation
- Reduce premature abandonment of positions when the market trend is strong immediately after entry by allowing a short early-window override of a weakening-structure flag when momentum and execution-quality metrics are excellent.

### Description
- In `TrendPersistenceAlive` added `adxStrong` (`ctx.Adx_M5 >= 35.0`) and `earlyWindow` (`ctx.BarsSinceEntryM5 <= 4`) checks and set `structureIntact = true` when `!structureIntact && adxStrong && earlyWindow && ctx.MaeR <= 0.20`, leaving the rest of the viability checks unchanged.

### Testing
- Ran the `TradeViabilityMonitor` unit tests and the strategy integration/backtest suite after the change, and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58bfbf48083288f55815608074dc2)