### PR TITLE
Add side-aware timing snapshot fields to EntryContext

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -292,6 +292,37 @@ namespace GeminiV26.Core.Entry
         public int MemoryTimingPenalty { get; set; }
 
         // =========================
+        // SIDE-AWARE TIMING
+        // =========================
+        // CONTINUATION TIMING
+        public bool HasFreshPullbackLong { get; set; }
+        public bool HasFreshPullbackShort { get; set; }
+        public bool HasEarlyContinuationLong { get; set; }
+        public bool HasEarlyContinuationShort { get; set; }
+        public bool HasLateContinuationLong { get; set; }
+        public bool HasLateContinuationShort { get; set; }
+        public bool IsOverextendedLong { get; set; }
+        public bool IsOverextendedShort { get; set; }
+
+        // STRUCTURE AGE
+        public int BarsSinceStructureBreakLong { get; set; } = -1;
+        public int BarsSinceStructureBreakShort { get; set; } = -1;
+        public int BarsSinceImpulseLong { get; set; } = -1;
+        public int BarsSinceImpulseShort { get; set; } = -1;
+        public int ContinuationAttemptCountLong { get; set; }
+        public int ContinuationAttemptCountShort { get; set; }
+
+        // DISTANCE
+        public double DistanceFromFastStructureAtrLong { get; set; }
+        public double DistanceFromFastStructureAtrShort { get; set; }
+
+        // QUALITY
+        public double ContinuationFreshnessLong { get; set; }
+        public double ContinuationFreshnessShort { get; set; }
+        public double TriggerLateScoreLong { get; set; }
+        public double TriggerLateScoreShort { get; set; }
+
+        // =========================
         // TEMP BACKWARD COMPAT
         // =========================
         [Obsolete("LEGACY – use LogicBiasDirection")]

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -892,12 +892,42 @@ namespace GeminiV26.Core.Entry
             ctx.MemoryContinuationFreshnessScore = state?.ContinuationFreshnessScore ?? 0;
             ctx.MemoryTriggerLateScore = state?.TriggerLateScore ?? 0;
             ctx.MemoryTimingPenalty = assessment?.RecommendedTimingPenalty ?? 0;
+
+            // Side-aware timing snapshot (symmetric mapping until memory is side-specific).
+            ctx.HasFreshPullbackLong = assessment?.IsFirstPullbackWindow ?? false;
+            ctx.HasFreshPullbackShort = assessment?.IsFirstPullbackWindow ?? false;
+            ctx.HasEarlyContinuationLong = assessment?.IsEarlyContinuationWindow ?? false;
+            ctx.HasEarlyContinuationShort = assessment?.IsEarlyContinuationWindow ?? false;
+            ctx.HasLateContinuationLong = assessment?.IsLateContinuation ?? false;
+            ctx.HasLateContinuationShort = assessment?.IsLateContinuation ?? false;
+            ctx.IsOverextendedLong = assessment?.IsOverextendedMove ?? false;
+            ctx.IsOverextendedShort = assessment?.IsOverextendedMove ?? false;
+
+            ctx.BarsSinceStructureBreakLong = state?.BarsSinceBreak ?? -1;
+            ctx.BarsSinceStructureBreakShort = state?.BarsSinceBreak ?? -1;
+            ctx.BarsSinceImpulseLong = state?.BarsSinceImpulse ?? -1;
+            ctx.BarsSinceImpulseShort = state?.BarsSinceImpulse ?? -1;
+            ctx.ContinuationAttemptCountLong = state?.ContinuationAttemptCount ?? 0;
+            ctx.ContinuationAttemptCountShort = state?.ContinuationAttemptCount ?? 0;
+
+            ctx.DistanceFromFastStructureAtrLong = state?.DistanceFromFastStructureAtr ?? 0;
+            ctx.DistanceFromFastStructureAtrShort = state?.DistanceFromFastStructureAtr ?? 0;
+
+            ctx.ContinuationFreshnessLong = state?.ContinuationFreshnessScore ?? 0;
+            ctx.ContinuationFreshnessShort = state?.ContinuationFreshnessScore ?? 0;
+            ctx.TriggerLateScoreLong = state?.TriggerLateScore ?? 0;
+            ctx.TriggerLateScoreShort = state?.TriggerLateScore ?? 0;
         }
 
         private void LogEntryMemorySnapshot(EntryContext ctx, string symbol)
         {
             _bot.Print(
                 $"[ENTRY][SNAPSHOT] symbol={symbol} movePhase={ctx?.MemoryState?.MovePhase ?? MovePhase.Unknown} continuationWindow={ctx?.MemoryContinuationWindow ?? ContinuationWindowState.Unknown} extensionState={ctx?.MemoryMoveExtension ?? MoveExtensionState.Unknown} impulseFreshness={ctx?.MemoryImpulseFreshnessScore ?? 0:0.00} continuationFreshness={ctx?.MemoryContinuationFreshnessScore ?? 0:0.00} triggerLateScore={ctx?.MemoryTriggerLateScore ?? 0:0.00} chaseRisk={ctx?.MemoryAssessment?.IsChaseRisk ?? false} timingPenalty={ctx?.MemoryTimingPenalty ?? 0}");
+
+            _bot.Print(
+                $"[CTX][TIMING][SIDE] symbol={symbol} side=LONG early={ctx?.HasEarlyContinuationLong ?? false} late={ctx?.HasLateContinuationLong ?? false} overextended={ctx?.IsOverextendedLong ?? false} freshness={ctx?.ContinuationFreshnessLong ?? 0:0.00}");
+            _bot.Print(
+                $"[CTX][TIMING][SIDE] symbol={symbol} side=SHORT early={ctx?.HasEarlyContinuationShort ?? false} late={ctx?.HasLateContinuationShort ?? false} overextended={ctx?.IsOverextendedShort ?? false} freshness={ctx?.ContinuationFreshnessShort ?? 0:0.00}");
         }
 
         private string CreateEntryAttemptId(string symbol)


### PR DESCRIPTION
### Motivation

- Provide explicit LONG/SHORT timing information so entry logic can distinguish early vs late continuation and direction-specific exhaustion instead of relying on global timing signals.  
- Keep changes additive and minimal to avoid touching architecture, routing, scoring, or TradeCore/EntryLogic/ExitManager responsibilities.  
- Use existing `MemoryAssessment`/`SymbolMemoryState` values to populate new fields so no new timing logic is introduced.

### Description

- Added side-aware fields to `EntryContext` grouped by CONTINUATION TIMING, STRUCTURE AGE, DISTANCE, and QUALITY (e.g. `HasFreshPullbackLong/Short`, `HasEarlyContinuationLong/Short`, `BarsSinceStructureBreakLong/Short`, `ContinuationAttemptCountLong/Short`, `DistanceFromFastStructureAtrLong/Short`, `ContinuationFreshnessLong/Short`, `TriggerLateScoreLong/Short`).  
- Populated all new fields in `EntryContextBuilder.AttachMemorySnapshot` by mapping existing properties from `MemoryAssessment` and `SymbolMemoryState` symmetrically (e.g. `assessment?.IsFirstPullbackWindow` → both `HasFreshPullbackLong` and `HasFreshPullbackShort`) to avoid introducing new logic.  
- Added debug logging lines using the `[CTX][TIMING][SIDE]` prefix that emit LONG and SHORT records containing early/late flags, overextension, and freshness values.  
- All changes are strictly additive and preserve existing public fields and behavior; no renames, removals, dependency changes, or behavioral logic modifications were made.

### Testing

- Attempted to run a solution build with `dotnet build GeminiV26.sln`, but `dotnet` is not available in the environment so the automated build could not be executed.  
- No automated unit tests were run in this environment; changes were limited to field additions and direct mappings to existing memory values to minimize risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c65aa5ac248328919686e74c71ffb6)