### PR TITLE
Add side-aware continuation timing snapshot to EntryContext and populate from memory

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -292,6 +292,37 @@ namespace GeminiV26.Core.Entry
         public int MemoryTimingPenalty { get; set; }
 
         // =========================
+        // SIDE-AWARE TIMING
+        // =========================
+        // CONTINUATION TIMING
+        public bool HasFreshPullbackLong { get; set; }
+        public bool HasFreshPullbackShort { get; set; }
+        public bool HasEarlyContinuationLong { get; set; }
+        public bool HasEarlyContinuationShort { get; set; }
+        public bool HasLateContinuationLong { get; set; }
+        public bool HasLateContinuationShort { get; set; }
+        public bool IsOverextendedLong { get; set; }
+        public bool IsOverextendedShort { get; set; }
+
+        // STRUCTURE AGE
+        public int BarsSinceStructureBreakLong { get; set; } = -1;
+        public int BarsSinceStructureBreakShort { get; set; } = -1;
+        public int BarsSinceImpulseLong { get; set; } = -1;
+        public int BarsSinceImpulseShort { get; set; } = -1;
+        public int ContinuationAttemptCountLong { get; set; }
+        public int ContinuationAttemptCountShort { get; set; }
+
+        // DISTANCE
+        public double DistanceFromFastStructureAtrLong { get; set; }
+        public double DistanceFromFastStructureAtrShort { get; set; }
+
+        // QUALITY
+        public double ContinuationFreshnessLong { get; set; }
+        public double ContinuationFreshnessShort { get; set; }
+        public double TriggerLateScoreLong { get; set; }
+        public double TriggerLateScoreShort { get; set; }
+
+        // =========================
         // TEMP BACKWARD COMPAT
         // =========================
         [Obsolete("LEGACY – use LogicBiasDirection")]

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -892,12 +892,45 @@ namespace GeminiV26.Core.Entry
             ctx.MemoryContinuationFreshnessScore = state?.ContinuationFreshnessScore ?? 0;
             ctx.MemoryTriggerLateScore = state?.TriggerLateScore ?? 0;
             ctx.MemoryTimingPenalty = assessment?.RecommendedTimingPenalty ?? 0;
+
+            bool hasLongTiming = state?.ImpulseDirection > 0;
+            bool hasShortTiming = state?.ImpulseDirection < 0;
+
+            // Side-aware timing snapshot from directional memory impulse side.
+            ctx.HasFreshPullbackLong = hasLongTiming && (assessment?.IsFirstPullbackWindow ?? false);
+            ctx.HasFreshPullbackShort = hasShortTiming && (assessment?.IsFirstPullbackWindow ?? false);
+            ctx.HasEarlyContinuationLong = hasLongTiming && (assessment?.IsEarlyContinuationWindow ?? false);
+            ctx.HasEarlyContinuationShort = hasShortTiming && (assessment?.IsEarlyContinuationWindow ?? false);
+            ctx.HasLateContinuationLong = hasLongTiming && (assessment?.IsLateContinuation ?? false);
+            ctx.HasLateContinuationShort = hasShortTiming && (assessment?.IsLateContinuation ?? false);
+            ctx.IsOverextendedLong = hasLongTiming && (assessment?.IsOverextendedMove ?? false);
+            ctx.IsOverextendedShort = hasShortTiming && (assessment?.IsOverextendedMove ?? false);
+
+            ctx.BarsSinceStructureBreakLong = hasLongTiming ? (state?.BarsSinceBreak ?? -1) : -1;
+            ctx.BarsSinceStructureBreakShort = hasShortTiming ? (state?.BarsSinceBreak ?? -1) : -1;
+            ctx.BarsSinceImpulseLong = hasLongTiming ? (state?.BarsSinceImpulse ?? -1) : -1;
+            ctx.BarsSinceImpulseShort = hasShortTiming ? (state?.BarsSinceImpulse ?? -1) : -1;
+            ctx.ContinuationAttemptCountLong = hasLongTiming ? (state?.ContinuationAttemptCount ?? 0) : 0;
+            ctx.ContinuationAttemptCountShort = hasShortTiming ? (state?.ContinuationAttemptCount ?? 0) : 0;
+
+            ctx.DistanceFromFastStructureAtrLong = hasLongTiming ? (state?.DistanceFromFastStructureAtr ?? 0) : 0;
+            ctx.DistanceFromFastStructureAtrShort = hasShortTiming ? (state?.DistanceFromFastStructureAtr ?? 0) : 0;
+
+            ctx.ContinuationFreshnessLong = hasLongTiming ? (state?.ContinuationFreshnessScore ?? 0) : 0;
+            ctx.ContinuationFreshnessShort = hasShortTiming ? (state?.ContinuationFreshnessScore ?? 0) : 0;
+            ctx.TriggerLateScoreLong = hasLongTiming ? (state?.TriggerLateScore ?? 0) : 0;
+            ctx.TriggerLateScoreShort = hasShortTiming ? (state?.TriggerLateScore ?? 0) : 0;
         }
 
         private void LogEntryMemorySnapshot(EntryContext ctx, string symbol)
         {
             _bot.Print(
                 $"[ENTRY][SNAPSHOT] symbol={symbol} movePhase={ctx?.MemoryState?.MovePhase ?? MovePhase.Unknown} continuationWindow={ctx?.MemoryContinuationWindow ?? ContinuationWindowState.Unknown} extensionState={ctx?.MemoryMoveExtension ?? MoveExtensionState.Unknown} impulseFreshness={ctx?.MemoryImpulseFreshnessScore ?? 0:0.00} continuationFreshness={ctx?.MemoryContinuationFreshnessScore ?? 0:0.00} triggerLateScore={ctx?.MemoryTriggerLateScore ?? 0:0.00} chaseRisk={ctx?.MemoryAssessment?.IsChaseRisk ?? false} timingPenalty={ctx?.MemoryTimingPenalty ?? 0}");
+
+            _bot.Print(
+                $"[CTX][TIMING][SIDE] symbol={symbol} side=LONG early={ctx?.HasEarlyContinuationLong ?? false} late={ctx?.HasLateContinuationLong ?? false} overextended={ctx?.IsOverextendedLong ?? false} freshness={ctx?.ContinuationFreshnessLong ?? 0:0.00}");
+            _bot.Print(
+                $"[CTX][TIMING][SIDE] symbol={symbol} side=SHORT early={ctx?.HasEarlyContinuationShort ?? false} late={ctx?.HasLateContinuationShort ?? false} overextended={ctx?.IsOverextendedShort ?? false} freshness={ctx?.ContinuationFreshnessShort ?? 0:0.00}");
         }
 
         private string CreateEntryAttemptId(string symbol)


### PR DESCRIPTION
### Motivation
- Enhance the `EntryContext` with side-specific timing and quality metrics so entry logic can reason separately about long vs short continuation conditions.
- Populate those new fields from the memory engine snapshot so decision code can use a single context object containing both generic and side-aware timing state.

### Description
- Added multiple side-aware properties to `EntryContext` such as `HasFreshPullbackLong`, `HasFreshPullbackShort`, `HasEarlyContinuationLong`, `HasEarlyContinuationShort`, `IsOverextendedLong`, `IsOverextendedShort`, `BarsSinceStructureBreakLong`, `BarsSinceStructureBreakShort`, `BarsSinceImpulseLong`, `BarsSinceImpulseShort`, `ContinuationAttemptCountLong`, `ContinuationAttemptCountShort`, `DistanceFromFastStructureAtrLong`, `DistanceFromFastStructureAtrShort`, `ContinuationFreshnessLong`, `ContinuationFreshnessShort`, `TriggerLateScoreLong`, and `TriggerLateScoreShort`.
- Updated `AttachMemorySnapshot` in `EntryContextBuilder` to derive `hasLongTiming`/`hasShortTiming` from `state?.ImpulseDirection` and populate the new side-specific fields from `state` and `assessment`, with sensible defaults when values are absent.
- Added side-specific logging lines to `LogEntryMemorySnapshot` to emit `LONG`/`SHORT` timing diagnostics for easier debugging.

### Testing
- Built the solution using `dotnet build` and verified the project compiled successfully with the new fields and assignments.
- Ran the automated test suite using `dotnet test` and confirmed all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c65aa5ac248328919686e74c71ffb6)