### PR TITLE
Implement context-aware early vs late continuation timing gate

### DIFF
--- a/Core/Entry/ContinuationTimingGate.cs
+++ b/Core/Entry/ContinuationTimingGate.cs
@@ -1,0 +1,125 @@
+using System;
+
+namespace GeminiV26.Core.Entry
+{
+    internal enum ContinuationTimingDecision
+    {
+        None = 0,
+        Early = 1,
+        LateValid = 2,
+        LateReject = 3,
+        OverextendedReject = 4,
+        SideInactiveReject = 5
+    }
+
+    internal readonly struct ContinuationTimingResult
+    {
+        public ContinuationTimingResult(
+            ContinuationTimingDecision decision,
+            bool isAllowed,
+            int scoreAdjustment,
+            int minScoreAdjustment,
+            bool requireStrongTrigger,
+            bool requireStrongStructure,
+            string reason)
+        {
+            Decision = decision;
+            IsAllowed = isAllowed;
+            ScoreAdjustment = scoreAdjustment;
+            MinScoreAdjustment = minScoreAdjustment;
+            RequireStrongTrigger = requireStrongTrigger;
+            RequireStrongStructure = requireStrongStructure;
+            Reason = reason;
+        }
+
+        public ContinuationTimingDecision Decision { get; }
+        public bool IsAllowed { get; }
+        public int ScoreAdjustment { get; }
+        public int MinScoreAdjustment { get; }
+        public bool RequireStrongTrigger { get; }
+        public bool RequireStrongStructure { get; }
+        public string Reason { get; }
+    }
+
+    internal static class ContinuationTimingGate
+    {
+        private const int MissedLateBarsThreshold = 6;
+        private const double MissedLateFreshnessThreshold = 0.45;
+
+        public static ContinuationTimingResult Evaluate(EntryContext ctx, TradeDirection direction, string entryType)
+        {
+            bool isLong = direction == TradeDirection.Long;
+            bool isSideActive = isLong ? ctx.IsTimingLongActive : ctx.IsTimingShortActive;
+
+            bool hasFreshPullback = isLong ? ctx.HasFreshPullbackLong : ctx.HasFreshPullbackShort;
+            bool hasEarlyContinuation = isLong ? ctx.HasEarlyContinuationLong : ctx.HasEarlyContinuationShort;
+            bool hasLateContinuation = isLong ? ctx.HasLateContinuationLong : ctx.HasLateContinuationShort;
+            bool isOverextended = isLong ? ctx.IsOverextendedLong : ctx.IsOverextendedShort;
+
+            int continuationAttempts = isLong ? ctx.ContinuationAttemptCountLong : ctx.ContinuationAttemptCountShort;
+            int barsSinceImpulse = isLong ? ctx.BarsSinceImpulseLong : ctx.BarsSinceImpulseShort;
+            double freshness = isLong ? ctx.ContinuationFreshnessLong : ctx.ContinuationFreshnessShort;
+
+            if (!isSideActive)
+            {
+                Log(ctx, "LATE_REJECT", direction, entryType, isSideActive, hasFreshPullback, hasEarlyContinuation, hasLateContinuation, continuationAttempts, barsSinceImpulse, freshness, "TIMING_SIDE_INACTIVE");
+                return new ContinuationTimingResult(ContinuationTimingDecision.SideInactiveReject, false, 0, 0, false, false, "TIMING_SIDE_INACTIVE");
+            }
+
+            barsSinceImpulse = Math.Max(0, barsSinceImpulse);
+            continuationAttempts = Math.Max(0, continuationAttempts);
+
+            if (isOverextended)
+            {
+                Log(ctx, "OVEREXTENDED", direction, entryType, isSideActive, hasFreshPullback, hasEarlyContinuation, hasLateContinuation, continuationAttempts, barsSinceImpulse, freshness, "OVEREXTENDED_HARD_REJECT");
+                return new ContinuationTimingResult(ContinuationTimingDecision.OverextendedReject, false, 0, 0, false, false, "OVEREXTENDED_HARD_REJECT");
+            }
+
+            if (hasFreshPullback || hasEarlyContinuation)
+            {
+                Log(ctx, "EARLY", direction, entryType, isSideActive, hasFreshPullback, hasEarlyContinuation, hasLateContinuation, continuationAttempts, barsSinceImpulse, freshness, "EARLY_CONTINUATION_WINDOW");
+                return new ContinuationTimingResult(ContinuationTimingDecision.Early, true, 6, -4, false, false, "EARLY_CONTINUATION_WINDOW");
+            }
+
+            if (hasLateContinuation)
+            {
+                bool likelyMissed =
+                    continuationAttempts > 1 ||
+                    barsSinceImpulse > MissedLateBarsThreshold ||
+                    freshness < MissedLateFreshnessThreshold;
+
+                if (likelyMissed)
+                {
+                    Log(ctx, "LATE_REJECT", direction, entryType, isSideActive, hasFreshPullback, hasEarlyContinuation, hasLateContinuation, continuationAttempts, barsSinceImpulse, freshness, "LATE_MISSED_EARLY_CHASING");
+                    return new ContinuationTimingResult(ContinuationTimingDecision.LateReject, false, 0, 0, false, false, "LATE_MISSED_EARLY_CHASING");
+                }
+
+                Log(ctx, "LATE_VALID", direction, entryType, isSideActive, hasFreshPullback, hasEarlyContinuation, hasLateContinuation, continuationAttempts, barsSinceImpulse, freshness, "LATE_VALID_NO_MISSED_EARLY");
+                return new ContinuationTimingResult(ContinuationTimingDecision.LateValid, true, -6, 4, true, true, "LATE_VALID_NO_MISSED_EARLY");
+            }
+
+            return new ContinuationTimingResult(ContinuationTimingDecision.None, true, 0, 0, false, false, "NO_TIMING_WINDOW");
+        }
+
+        private static void Log(
+            EntryContext ctx,
+            string tag,
+            TradeDirection direction,
+            string entryType,
+            bool isSideActive,
+            bool hasFreshPullback,
+            bool hasEarlyContinuation,
+            bool hasLateContinuation,
+            int continuationAttempts,
+            int barsSinceImpulse,
+            double freshness,
+            string reason)
+        {
+            ctx.Log?.Invoke(
+                $"[ENTRY][TIMING][{tag}] symbol={ctx.Symbol} direction={direction} entryType={entryType} " +
+                $"isTimingSideActive={isSideActive.ToString().ToLowerInvariant()} freshPullback={hasFreshPullback.ToString().ToLowerInvariant()} " +
+                $"early={hasEarlyContinuation.ToString().ToLowerInvariant()} late={hasLateContinuation.ToString().ToLowerInvariant()} " +
+                $"attempts={continuationAttempts} barsSinceImpulse={barsSinceImpulse} freshness={freshness:0.00} reason={reason}");
+        }
+    }
+}

--- a/EntryTypes/BR_RangeBreakoutEntry.cs
+++ b/EntryTypes/BR_RangeBreakoutEntry.cs
@@ -80,8 +80,18 @@ namespace GeminiV26.EntryTypes
                 Reason = ""
             };
 
+            int minScore = MIN_SCORE;
             int score = 0;
             int setupScore = 0;
+            bool hasStructureForTiming = false;
+            bool strongTriggerForTiming = false;
+
+            var timing = ContinuationTimingGate.Evaluate(ctx, dir, Type.ToString());
+            if (!timing.IsAllowed)
+            {
+                eval.Reason += $"{timing.Reason};";
+                return eval;
+            }
 
             // =========================================================
             // 1️⃣ RANGE KÖRNYEZET (HARD + SOFT MINŐSÉG)
@@ -129,6 +139,7 @@ namespace GeminiV26.EntryTypes
                     ctx.IsValidFlagStructure_M5
                     || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5)
                     || ctx.HasEarlyPullback_M5;
+                hasStructureForTiming = hasStructure;
 
                 if (!hasStructure)
                     setupScore -= 40;
@@ -145,6 +156,7 @@ namespace GeminiV26.EntryTypes
 
                 bool hasStructure =
                     ctx.HasPullbackLong_M5 || ctx.HasPullbackShort_M5;
+                hasStructureForTiming = hasStructure;
 
                 if (hasStructure)
                     setupScore += 10;
@@ -157,6 +169,7 @@ namespace GeminiV26.EntryTypes
                 bool hasStructure =
                     ctx.IsValidFlagStructure_M5 ||
                     (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5);
+                hasStructureForTiming = hasStructure;
 
                 if (!hasStructure)
                     setupScore -= 30;
@@ -172,6 +185,7 @@ namespace GeminiV26.EntryTypes
 
                 bool hasStructure =
                     pullbackDepthR >= 0.15;
+                hasStructureForTiming = hasStructure;
 
                 if (!hasStructure)
                     setupScore -= 35;
@@ -224,6 +238,7 @@ namespace GeminiV26.EntryTypes
                 score -= 8;
                 eval.Reason += "NoM1Trigger;";
             }
+            strongTriggerForTiming = ctx.M1TriggerInTrendDirection || ctx.RangeBreakDirection == dir;
 
             // =========================================================
             // 5️⃣ KONFIRMÁLÓ PLUSZOK
@@ -285,14 +300,28 @@ namespace GeminiV26.EntryTypes
             // =========================================================
             // MIN SCORE – ENTRYTYPE SZINTEN
             // =========================================================
+            if (timing.RequireStrongStructure && !hasStructureForTiming)
+            {
+                eval.Reason += "TIMING_LATE_NEEDS_STRONG_STRUCTURE;";
+                return eval;
+            }
+
+            if (timing.RequireStrongTrigger && !strongTriggerForTiming)
+            {
+                eval.Reason += "TIMING_LATE_NEEDS_STRONG_TRIGGER;";
+                return eval;
+            }
+
+            score += timing.ScoreAdjustment;
+            minScore += timing.MinScoreAdjustment;
             score += setupScore;
 
             if (setupScore <= 0)
-                score = Math.Min(score, MIN_SCORE - 10);
+                score = Math.Min(score, minScore - 10);
             score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
 
             eval.Score = score;
-            eval.IsValid = score >= MIN_SCORE;
+            eval.IsValid = score >= minScore;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";

--- a/EntryTypes/FX/FX_MicroContinuationEntry.cs
+++ b/EntryTypes/FX/FX_MicroContinuationEntry.cs
@@ -59,6 +59,10 @@ namespace GeminiV26.EntryTypes.FX
             int minScore = EntryDecisionPolicy.MinScoreThreshold;
             int setupScore = 0;
 
+            var timing = ContinuationTimingGate.Evaluate(ctx, dir, Type.ToString());
+            if (!timing.IsAllowed)
+                return Invalid(ctx, dir, timing.Reason, 0);
+
             double pullbackDepthR =
                 dir == TradeDirection.Long ? ctx.PullbackDepthRLong_M5 : ctx.PullbackDepthRShort_M5;
 
@@ -103,6 +107,12 @@ namespace GeminiV26.EntryTypes.FX
             if (hasContinuation)
                 setupScore += 20;
 
+            if (timing.RequireStrongStructure && pullbackDepthR < 0.35)
+                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_STRUCTURE", 0);
+
+            if (timing.RequireStrongTrigger && !m1Aligned)
+                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_TRIGGER", 0);
+
             int score = 50;
 
             if (!ctx.PullbackTouchedEma21_M5)
@@ -139,6 +149,8 @@ namespace GeminiV26.EntryTypes.FX
 
 
             score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
+            score += timing.ScoreAdjustment;
+            minScore += timing.MinScoreAdjustment;
             score += setupScore;
 
             if (setupScore <= 0)

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -57,6 +57,11 @@ namespace GeminiV26.EntryTypes.FX
             int score = 54;
             int setupScore = 0;
             double triggerScore = 0;
+            int minScore = EntryDecisionPolicy.MinScoreThreshold;
+
+            var timing = ContinuationTimingGate.Evaluate(ctx, dir, EntryType.FX_MicroStructure.ToString());
+            if (!timing.IsAllowed)
+                return Invalid(ctx, dir, timing.Reason, score);
 
             ctx.Log?.Invoke(
                 $"[FX_MICRO START] sym={ctx.Symbol} dir={dir} " +
@@ -166,6 +171,12 @@ namespace GeminiV26.EntryTypes.FX
             if (hasContinuation)
                 setupScore += 20;
 
+            if (timing.RequireStrongStructure && !(hasStructure && rAtr <= 1.2))
+                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_STRUCTURE", score);
+
+            if (timing.RequireStrongTrigger && !breakout)
+                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_TRIGGER", score);
+
             score += 6;
 
             // -----------------------------------------------------
@@ -227,9 +238,9 @@ namespace GeminiV26.EntryTypes.FX
             // -----------------------------------------------------
             // FINAL SCORE GATE
             // -----------------------------------------------------
-            int minScore = EntryDecisionPolicy.MinScoreThreshold;
-
             score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
+            score += timing.ScoreAdjustment;
+            minScore += timing.MinScoreAdjustment;
             score += setupScore;
             score += (int)Math.Round(triggerScore * 5);
 

--- a/EntryTypes/TC_FlagEntry.cs
+++ b/EntryTypes/TC_FlagEntry.cs
@@ -90,8 +90,18 @@ namespace GeminiV26.EntryTypes
                 Reason = ""
             };
 
+            int minScore = MIN_SCORE;
             int score = 0;
             int setupScore = 0;
+            bool hasStructureForTiming = false;
+            bool strongTriggerForTiming = false;
+
+            var timing = ContinuationTimingGate.Evaluate(ctx, dir, Type.ToString());
+            if (!timing.IsAllowed)
+            {
+                eval.Reason += $"{timing.Reason};";
+                return eval;
+            }
 
             TradeDirection impulseDirection =
                 impulseMove > 0 ? TradeDirection.Long : TradeDirection.Short;
@@ -149,6 +159,7 @@ namespace GeminiV26.EntryTypes
                     ctx.IsValidFlagStructure_M5
                     || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5)
                     || ctx.HasEarlyPullback_M5;
+                hasStructureForTiming = hasStructure;
 
                 if (!hasStructure)
                     setupScore -= 40;
@@ -157,6 +168,7 @@ namespace GeminiV26.EntryTypes
 
                 bool hasConfirmation =
                     ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
+                strongTriggerForTiming = hasConfirmation;
 
                 if (hasConfirmation)
                     setupScore += 20;
@@ -171,6 +183,7 @@ namespace GeminiV26.EntryTypes
 
                 bool hasStructure =
                     ctx.HasPullbackLong_M5 || ctx.HasPullbackShort_M5 || ctx.IsValidFlagStructure_M5;
+                hasStructureForTiming = hasStructure;
 
                 if (hasStructure)
                     setupScore += 10;
@@ -178,6 +191,7 @@ namespace GeminiV26.EntryTypes
                 bool continuationSignal =
                     ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
                 bool breakoutConfirmed = continuationSignal;
+                strongTriggerForTiming = continuationSignal || breakoutConfirmed;
 
                 if (continuationSignal || breakoutConfirmed)
                     setupScore += 20;
@@ -190,6 +204,7 @@ namespace GeminiV26.EntryTypes
                 bool hasStructure =
                     ctx.IsValidFlagStructure_M5 ||
                     (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5);
+                hasStructureForTiming = hasStructure;
 
                 if (!hasStructure)
                     setupScore -= 30;
@@ -198,6 +213,7 @@ namespace GeminiV26.EntryTypes
 
                 bool continuationSignal =
                     ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
+                strongTriggerForTiming = continuationSignal;
 
                 if (continuationSignal)
                     setupScore += 20;
@@ -211,6 +227,7 @@ namespace GeminiV26.EntryTypes
 
                 bool hasStructure =
                     pullbackDepthR >= 0.15;
+                hasStructureForTiming = hasStructure;
 
                 if (!hasStructure)
                     setupScore -= 35;
@@ -219,9 +236,22 @@ namespace GeminiV26.EntryTypes
 
                 bool continuationSignal =
                     ctx.M1FlagBreakTrigger || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
+                strongTriggerForTiming = continuationSignal;
 
                 if (continuationSignal)
                     setupScore += 20;
+            }
+
+            if (timing.RequireStrongStructure && !hasStructureForTiming)
+            {
+                eval.Reason += "TIMING_LATE_NEEDS_STRONG_STRUCTURE;";
+                return eval;
+            }
+
+            if (timing.RequireStrongTrigger && !strongTriggerForTiming)
+            {
+                eval.Reason += "TIMING_LATE_NEEDS_STRONG_TRIGGER;";
+                return eval;
             }
 
             // =========================================================
@@ -249,13 +279,15 @@ namespace GeminiV26.EntryTypes
             // =========================================================
             // 6️⃣ MIN SCORE – ENTRYTYPE SZINT
             // =========================================================
+            score += timing.ScoreAdjustment;
+            minScore += timing.MinScoreAdjustment;
             score += setupScore;
 
             if (setupScore <= 0)
-                score = Math.Min(score, MIN_SCORE - 10);
+                score = Math.Min(score, minScore - 10);
 
             eval.Score = score;
-            eval.IsValid = score >= MIN_SCORE;
+            eval.IsValid = score >= minScore;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";

--- a/EntryTypes/TC_PullbackEntry.cs
+++ b/EntryTypes/TC_PullbackEntry.cs
@@ -78,6 +78,16 @@ namespace GeminiV26.EntryTypes
 
             int score = 0;
             int setupScore = 0;
+            int minScore = MIN_SCORE;
+            bool hasStructureForTiming = false;
+            bool strongTriggerForTiming = false;
+
+            var timing = ContinuationTimingGate.Evaluate(ctx, forcedDirection, Type.ToString());
+            if (!timing.IsAllowed)
+            {
+                eval.Reason += $"{timing.Reason};";
+                return FinalizeEval();
+            }
 
             var instrumentClass = SymbolRouting.ResolveInstrumentClass(ctx.Symbol);
             string symbolCanonical = SymbolRouting.NormalizeSymbol(ctx.Symbol);
@@ -161,6 +171,7 @@ namespace GeminiV26.EntryTypes
             // =========================================================
             if (!noM1Trigger) score += 10;
             else eval.Reason += "NoM1Trigger;";
+            strongTriggerForTiming = !noM1Trigger;
 
             // =========================================================
             // 🛑 XAU – PROFIT-ORIENTED HARD CONTROL
@@ -362,6 +373,7 @@ namespace GeminiV26.EntryTypes
                     (eval.Direction == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5)
                     || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5)
                     || ctx.HasEarlyPullback_M5;
+                hasStructureForTiming = hasStructure;
 
                 if (!hasStructure)
                     setupScore -= 40;
@@ -370,6 +382,7 @@ namespace GeminiV26.EntryTypes
 
                 bool hasConfirmation =
                     (!noM1Trigger) || ctx.LastClosedBarInTrendDirection;
+                strongTriggerForTiming = hasConfirmation;
 
                 if (hasConfirmation)
                     setupScore += 20;
@@ -384,12 +397,14 @@ namespace GeminiV26.EntryTypes
 
                 bool hasStructure =
                     ctx.HasPullbackLong_M5 || ctx.HasPullbackShort_M5;
+                hasStructureForTiming = hasStructure;
 
                 if (hasStructure)
                     setupScore += 10;
 
                 bool continuationSignal = !noM1Trigger;
                 bool breakoutConfirmed = continuationSignal;
+                strongTriggerForTiming = continuationSignal || breakoutConfirmed;
 
                 if (continuationSignal || breakoutConfirmed)
                     setupScore += 20;
@@ -402,6 +417,7 @@ namespace GeminiV26.EntryTypes
                 bool hasStructure =
                     (eval.Direction == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5)
                     || (ctx.PullbackBars_M5 >= 2 && ctx.IsPullbackDecelerating_M5);
+                hasStructureForTiming = hasStructure;
 
                 if (!hasStructure)
                     setupScore -= 30;
@@ -409,6 +425,7 @@ namespace GeminiV26.EntryTypes
                     setupScore += 15;
 
                 bool continuationSignal = !noM1Trigger;
+                strongTriggerForTiming = continuationSignal;
 
                 if (continuationSignal)
                     setupScore += 20;
@@ -422,6 +439,7 @@ namespace GeminiV26.EntryTypes
 
                 bool hasStructure =
                     pullbackDepthR >= 0.15;
+                hasStructureForTiming = hasStructure;
 
                 if (!hasStructure)
                     setupScore -= 35;
@@ -429,6 +447,7 @@ namespace GeminiV26.EntryTypes
                     setupScore += 15;
 
                 bool continuationSignal = !noM1Trigger;
+                strongTriggerForTiming = continuationSignal;
 
                 if (continuationSignal)
                     setupScore += 20;
@@ -437,19 +456,33 @@ namespace GeminiV26.EntryTypes
             // =========================================================
             // FINAL RULES
             // =========================================================
+            if (timing.RequireStrongStructure && !hasStructureForTiming)
+            {
+                eval.Reason += "TIMING_LATE_NEEDS_STRONG_STRUCTURE;";
+                return FinalizeEval();
+            }
+
+            if (timing.RequireStrongTrigger && !strongTriggerForTiming)
+            {
+                eval.Reason += "TIMING_LATE_NEEDS_STRONG_TRIGGER;";
+                return FinalizeEval();
+            }
+
             bool breakoutDetected =
                 !noM1Trigger ||
                 (ctx.HasBreakout_M1 && ctx.BreakoutDirection == eval.Direction);
             bool strongCandle = ctx.LastClosedBarInTrendDirection;
             bool followThrough = breakoutDetected || ctx.HasReactionCandle_M5;
             score = TriggerScoreModel.Apply(ctx, $"TC_PULLBACK_{eval.Direction}", score, breakoutDetected, strongCandle, followThrough, "NO_PULLBACK_TRIGGER");
+            score += timing.ScoreAdjustment;
+            minScore += timing.MinScoreAdjustment;
             score += setupScore;
 
             if (setupScore <= 0)
-                score = Math.Min(score, MIN_SCORE - 10);
+                score = Math.Min(score, minScore - 10);
 
             eval.Score = score;
-            eval.IsValid = score >= MIN_SCORE;
+            eval.IsValid = score >= minScore;
 
             if (!eval.IsValid)
                 eval.Reason += $"ScoreBelowMin({score});";


### PR DESCRIPTION
### Motivation
- Introduce side-aware early vs late continuation decision logic so continuation setups are accepted earlier when appropriate and late continuations are rejected only when they represent a missed early opportunity, while overextended moves are always blocked.
- Ensure timing decisions never consume inactive-side values and provide clear decision telemetry for troubleshooting and tuning.

### Description
- Added a shared helper `Core/Entry/ContinuationTimingGate.cs` that classifies timing into Early, LateValid, LateReject, OverextendedReject, and SideInactiveReject and returns a decision payload including score/min-score adjustments and strictness flags.
- Integrated the gate into continuation-focused entry evaluators: `TC_FlagEntry`, `TC_PullbackEntry`, `BR_RangeBreakoutEntry`, `FX_MicroContinuationEntry`, and `FX_MicroStructureEntry`, applying early boosts, late penalties/requirements, and hard rejects per the new timing decision.
- Enforced side-validity before reading timing fields, clamped numeric timing inputs, and implemented the missed-early proxy using `ContinuationAttemptCount`, `BarsSinceImpulse`, and `ContinuationFreshness` thresholds.
- Added timing logs at decision points with tags `[ENTRY][TIMING][EARLY]`, `[ENTRY][TIMING][LATE_VALID]`, `[ENTRY][TIMING][LATE_REJECT]`, and `[ENTRY][TIMING][OVEREXTENDED]` that include symbol, direction, entry type, side-active state, early/late flags, attempts, bars-since-impulse, freshness, and the reason.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff issues and it reported no problems.
- Attempted to run `dotnet build` for a compile-time check but the environment lacks `dotnet`, so a full build/compile verification was not executed.
- Verified source modifications by integrating the gate into targeted evaluators and reviewing diffs to ensure only continuation-family logic was modified and changes are localized to entry-level decision paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6656727c08328875709f92a4546db)