### PR TITLE
Integrate continuation timing gate, fix freshness handling, and make structure checks direction-aware

### DIFF
--- a/Core/Entry/ContinuationTimingGate.cs
+++ b/Core/Entry/ContinuationTimingGate.cs
@@ -60,6 +60,9 @@ namespace GeminiV26.Core.Entry
             int barsSinceImpulse = isLong ? ctx.BarsSinceImpulseLong : ctx.BarsSinceImpulseShort;
             double freshness = isLong ? ctx.ContinuationFreshnessLong : ctx.ContinuationFreshnessShort;
 
+            if (double.IsNaN(freshness) || double.IsInfinity(freshness))
+                freshness = 0.0;
+
             if (!isSideActive)
             {
                 Log(ctx, "LATE_REJECT", direction, entryType, isSideActive, hasFreshPullback, hasEarlyContinuation, hasLateContinuation, continuationAttempts, barsSinceImpulse, freshness, "TIMING_SIDE_INACTIVE");
@@ -84,9 +87,8 @@ namespace GeminiV26.Core.Entry
             if (hasLateContinuation)
             {
                 bool likelyMissed =
-                    continuationAttempts > 1 ||
-                    barsSinceImpulse > MissedLateBarsThreshold ||
-                    freshness < MissedLateFreshnessThreshold;
+                    (continuationAttempts > 1 && freshness < MissedLateFreshnessThreshold) ||
+                    (barsSinceImpulse > MissedLateBarsThreshold && freshness < 0.40);
 
                 if (likelyMissed)
                 {

--- a/EntryTypes/BR_RangeBreakoutEntry.cs
+++ b/EntryTypes/BR_RangeBreakoutEntry.cs
@@ -155,8 +155,9 @@ namespace GeminiV26.EntryTypes
                     setupScore += 15;
 
                 bool hasStructure =
-                    ctx.HasPullbackLong_M5 || ctx.HasPullbackShort_M5;
+                    dir == TradeDirection.Long ? ctx.HasPullbackLong_M5 : ctx.HasPullbackShort_M5;
                 hasStructureForTiming = hasStructure;
+                ctx.Log?.Invoke("[ENTRY][DIR_FIX] using direction-pure structure selection");
 
                 if (hasStructure)
                     setupScore += 10;

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -44,6 +44,11 @@ namespace GeminiV26.EntryTypes.FX
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)
         {
             int setupScore = 0;
+            int minScore = MinScore;
+
+            var timing = ContinuationTimingGate.Evaluate(ctx, dir, Type.ToString());
+            if (!timing.IsAllowed)
+                return Invalid(ctx, dir, timing.Reason, 0);
 
             bool hasImpulse =
                 dir == TradeDirection.Long ? ctx.HasImpulseLong_M5 : ctx.HasImpulseShort_M5;
@@ -107,6 +112,12 @@ namespace GeminiV26.EntryTypes.FX
             if (hasContinuation)
                 setupScore += 20;
 
+            if (timing.RequireStrongStructure && !hasStructure)
+                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_STRUCTURE", 0);
+
+            if (timing.RequireStrongTrigger && !m1Confirm)
+                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_TRIGGER", 0);
+
             // ✅ FIX: side-aware score boost
             if (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir)
                 score += 10;
@@ -126,12 +137,14 @@ namespace GeminiV26.EntryTypes.FX
 
 
             score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
+            score += timing.ScoreAdjustment;
+            minScore += timing.MinScoreAdjustment;
             score += setupScore;
 
             if (setupScore <= 0)
-                score = System.Math.Min(score, MinScore - 10);
+                score = System.Math.Min(score, minScore - 10);
 
-            if (score < MinScore)
+            if (score < minScore)
                 return Invalid(ctx, dir, "LOW_SCORE", score);
 
             return new EntryEvaluation

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -51,6 +51,11 @@ namespace GeminiV26.EntryTypes.FX
         private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)
         {
             int setupScore = 0;
+            int minScore = MinScore;
+
+            var timing = ContinuationTimingGate.Evaluate(ctx, dir, Type.ToString());
+            if (!timing.IsAllowed)
+                return Invalid(ctx, dir, timing.Reason, 0);
 
             bool hasImpulse =
                 dir == TradeDirection.Long ? ctx.HasImpulseLong_M5 : ctx.HasImpulseShort_M5;
@@ -124,6 +129,12 @@ namespace GeminiV26.EntryTypes.FX
             if (hasContinuation)
                 setupScore += 20;
 
+            if (timing.RequireStrongStructure && !hasStructure)
+                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_STRUCTURE", 0);
+
+            if (timing.RequireStrongTrigger && !continuationSignal)
+                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_TRIGGER", 0);
+
             int score = 30;
 
             if (continuationSignal)
@@ -144,10 +155,12 @@ namespace GeminiV26.EntryTypes.FX
 
 
             score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
+            score += timing.ScoreAdjustment;
+            minScore += timing.MinScoreAdjustment;
             score += setupScore;
 
             if (setupScore <= 0)
-                score = System.Math.Min(score, MinScore - 10);
+                score = System.Math.Min(score, minScore - 10);
 
             // =====================================================
             // SCORE → DIRECTION

--- a/EntryTypes/TC_FlagEntry.cs
+++ b/EntryTypes/TC_FlagEntry.cs
@@ -182,8 +182,9 @@ namespace GeminiV26.EntryTypes
                     setupScore += 15;
 
                 bool hasStructure =
-                    ctx.HasPullbackLong_M5 || ctx.HasPullbackShort_M5 || ctx.IsValidFlagStructure_M5;
+                    (dir == TradeDirection.Long ? ctx.HasPullbackLong_M5 : ctx.HasPullbackShort_M5) || ctx.IsValidFlagStructure_M5;
                 hasStructureForTiming = hasStructure;
+                ctx.Log?.Invoke("[ENTRY][DIR_FIX] using direction-pure structure selection");
 
                 if (hasStructure)
                     setupScore += 10;

--- a/EntryTypes/TC_PullbackEntry.cs
+++ b/EntryTypes/TC_PullbackEntry.cs
@@ -396,8 +396,9 @@ namespace GeminiV26.EntryTypes
                     setupScore += 15;
 
                 bool hasStructure =
-                    ctx.HasPullbackLong_M5 || ctx.HasPullbackShort_M5;
+                    eval.Direction == TradeDirection.Long ? ctx.HasPullbackLong_M5 : ctx.HasPullbackShort_M5;
                 hasStructureForTiming = hasStructure;
+                ctx.Log?.Invoke("[ENTRY][DIR_FIX] using direction-pure structure selection");
 
                 if (hasStructure)
                     setupScore += 10;


### PR DESCRIPTION
### Motivation
- Prevent invalid numeric values from breaking timing logic by sanitizing `freshness` and make missed-late detection less aggressive with refined thresholds. 
- Enforce timing-based constraints (allow/reject, score adjustments, and minimum score adjustments) in continuation entries so late/early timing windows influence entry decisions. 
- Fix direction-agnostic structure selection for index instrument class so structure checks are evaluated per trade direction.

### Description
- Add NaN/Infinity protection for `freshness` in `ContinuationTimingGate.Evaluate` and adjust the `likelyMissed` predicate to combine `continuationAttempts`, `barsSinceImpulse`, and `freshness` with more granular thresholds. 
- Introduce use of `ContinuationTimingGate.Evaluate(ctx, dir, Type.ToString())` in FX continuation entries and apply its outputs: reject when `IsAllowed` is false, apply `ScoreAdjustment` and `MinScoreAdjustment`, and enforce `RequireStrongStructure` and `RequireStrongTrigger` constraints. 
- Change index instrument-class structure checks to be direction-aware in `BR_RangeBreakoutEntry`, `TC_FlagEntry`, and `TC_PullbackEntry` by selecting pullback/flag properties based on `dir` (and `eval.Direction` where appropriate) and add a log marker `"[ENTRY][DIR_FIX] using direction-pure structure selection"`. 
- Ensure minimum score logic uses the adjusted `minScore` variable where timing modifies the baseline minimum.

### Testing
- Built the solution with `dotnet build` and ran the unit test suite with `dotnet test`; the build and tests completed successfully. 
- Ran static checks/linting and addressed issues; no regressions detected in the automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c667823874832881d1990b1765b580)