### PR TITLE
Add final veto-only acceptance gate in TradeCore

### DIFF
--- a/Core/Entry/EntryEvaluation.cs
+++ b/Core/Entry/EntryEvaluation.cs
@@ -42,6 +42,10 @@
             set => TriggerConfirmed = value;
         }
 
+        // Diagnostic-only final acceptance flags (no score impact).
+        public bool HasStrongTrigger { get; set; }
+        public bool HasStrongStructure { get; set; }
+
         public bool IsHTFMisaligned;
         public bool IgnoreHTFForDecision;
         public double HtfConfidence01;

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1284,6 +1284,12 @@ namespace GeminiV26.Core
                 _bot.Print($"[POS ?] [ENTRY] symbol={selected.Symbol ?? _bot.SymbolName} score={selected.Score} direction={selected.Direction}");
                 _bot.Print(TradeLogIdentity.WithTempId($"[DIR][ROUTED] sym={_bot.SymbolName} type={selected.Type} routedDir={selected.Direction} score={selected.Score}", _ctx));
 
+                if (!PassFinalAcceptance(_ctx, selected))
+                {
+                    _bot.Print("BLOCK: final acceptance gate");
+                    return;
+                }
+
                 _ctx.RoutedDirection = selected.Direction;
                 _ctx.FinalDirection = selected.Direction;
                 _bot.Print(TradeLogIdentity.WithTempId($"[DIR][SET] sym={_ctx.Symbol} finalDir={_ctx.FinalDirection}", _ctx));
@@ -2178,6 +2184,8 @@ namespace GeminiV26.Core
                 }
 
                 var trigger = ResolveTriggerDiagnostics(ctx, candidate);
+                candidate.HasStrongTrigger = trigger.TriggerConfirmed;
+                candidate.HasStrongStructure = HasStrongStructure(ctx, candidate.Direction);
 
                 if (!trigger.IsManaged)
                 {
@@ -2312,6 +2320,86 @@ namespace GeminiV26.Core
                 case EntryType.Crypto_RangeBreakout:
                 case EntryType.Crypto_Impulse:
                     return true;
+                default:
+                    return false;
+            }
+        }
+
+        private bool PassFinalAcceptance(EntryContext ctx, EntryEvaluation eval)
+        {
+            if (ctx == null || eval == null)
+                return false;
+
+            bool isLong = eval.Direction == TradeDirection.Long;
+            bool isShort = eval.Direction == TradeDirection.Short;
+            bool isOverextended =
+                (isLong && ctx.IsOverextendedLong) ||
+                (isShort && ctx.IsOverextendedShort);
+
+            if (isOverextended)
+            {
+                _bot.Print(TradeLogIdentity.WithTempId(
+                    $"[FINAL][REJECT][OVEREXT] symbol={ctx.Symbol ?? _bot.SymbolName} type={eval.Type} direction={eval.Direction} score={eval.Score}",
+                    ctx));
+                return false;
+            }
+
+            bool weakSetup = !eval.HasStrongTrigger && !eval.HasStrongStructure;
+            bool isLateContinuation =
+                (isLong && ctx.HasLateContinuationLong) ||
+                (isShort && ctx.HasLateContinuationShort);
+            if (isLateContinuation && weakSetup)
+            {
+                _bot.Print(TradeLogIdentity.WithTempId(
+                    $"[FINAL][REJECT][LATE] symbol={ctx.Symbol ?? _bot.SymbolName} type={eval.Type} direction={eval.Direction} score={eval.Score}",
+                    ctx));
+                return false;
+            }
+
+            bool isTrend = ctx.MarketState?.IsTrend == true;
+            if (isTrend &&
+                ctx.LogicBiasConfidence >= 60 &&
+                ctx.TrendDirection != TradeDirection.None &&
+                eval.Direction != ctx.TrendDirection)
+            {
+                _bot.Print(TradeLogIdentity.WithTempId(
+                    $"[FINAL][REJECT][TREND] symbol={ctx.Symbol ?? _bot.SymbolName} type={eval.Type} direction={eval.Direction} score={eval.Score} trendDirection={ctx.TrendDirection} logicBiasConfidence={ctx.LogicBiasConfidence}",
+                    ctx));
+                return false;
+            }
+
+            int weakBorderlineCutoff = EntryDecisionPolicy.MinScoreThreshold + 1;
+            if (weakSetup && eval.Score <= weakBorderlineCutoff)
+            {
+                _bot.Print(TradeLogIdentity.WithTempId(
+                    $"[FINAL][REJECT][WEAK] symbol={ctx.Symbol ?? _bot.SymbolName} type={eval.Type} direction={eval.Direction} score={eval.Score}",
+                    ctx));
+                return false;
+            }
+
+            _bot.Print(TradeLogIdentity.WithTempId(
+                $"[FINAL][PASS] symbol={ctx.Symbol ?? _bot.SymbolName} type={eval.Type} direction={eval.Direction} score={eval.Score}",
+                ctx));
+            return true;
+        }
+
+        private static bool HasStrongStructure(EntryContext ctx, TradeDirection direction)
+        {
+            if (ctx == null)
+                return false;
+
+            switch (direction)
+            {
+                case TradeDirection.Long:
+                    return ctx.BrokeLastSwingHigh_M5 ||
+                           ctx.FlagBreakoutUpConfirmed ||
+                           (ctx.HasBreakout_M1 && ctx.BreakoutDirection == TradeDirection.Long);
+
+                case TradeDirection.Short:
+                    return ctx.BrokeLastSwingLow_M5 ||
+                           ctx.FlagBreakoutDownConfirmed ||
+                           (ctx.HasBreakout_M1 && ctx.BreakoutDirection == TradeDirection.Short);
+
                 default:
                     return false;
             }


### PR DESCRIPTION
### Motivation
- Introduce a single deterministic final acceptance gate in `TradeCore` to block clearly bad trades that slip past fragmented upstream validation without refactoring existing architecture. 
- Provide a last-resort, veto-only layer (no rescoring/reranking) that reduces late continuation, overextended, trend-mismatch, and borderline weak setups while keeping TradeCore orchestration-focused. 

### Description
- Added `bool PassFinalAcceptance(EntryContext ctx, EntryEvaluation eval)` to `Core/TradeCore.cs` and called it immediately after router selection and before setting `RoutedDirection`/`FinalDirection` or executing the entry. 
- Implemented deterministic veto rules: hard reject if side-aware overextended (`ctx.IsOverextendedLong/Short`), reject late continuation when both `!eval.HasStrongTrigger && !eval.HasStrongStructure` and corresponding `ctx.HasLateContinuationLong/Short` is true, reject trend mismatch only when `ctx.MarketState?.IsTrend == true && ctx.LogicBiasConfidence >= 60 && ctx.TrendDirection != TradeDirection.None && eval.Direction != ctx.TrendDirection`, and a small borderline weak setup reject using `EntryDecisionPolicy.MinScoreThreshold + 1` as a conservative buffer. 
- Added concise mandatory logs for every decision using tokens `[FINAL][REJECT][OVEREXT]`, `[FINAL][REJECT][LATE]`, `[FINAL][REJECT][TREND]`, `[FINAL][REJECT][WEAK]`, and `[FINAL][PASS]` including `symbol`, `type`, `direction`, and `score`. 
- Added diagnostic-only booleans to `EntryEvaluation`: `HasStrongTrigger` and `HasStrongStructure`, and populated them in `UpdateExecutionStateMachine` (no score or routing impact); included a small helper `HasStrongStructure(ctx, direction)` that consumes existing context flags only. 
- Files changed: `Core/TradeCore.cs` and `Core/Entry/EntryEvaluation.cs` with a minimal, local patch (one function + one call + two diagnostic fields). 

### Testing
- Ran repository checks and commit workflow: `git diff --check` passed and the change was committed successfully. 
- Verified via repository search and inspection that the gate is placed after router selection and before execution and that `HasStrongTrigger`/`HasStrongStructure` are set from existing trigger diagnostics. 
- Build/compile was not executed in this environment because no solution/project files (`*.sln`/`*.csproj`) were available, so full compilation tests could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6862ffec48328af666ccb282accd1)