### PR TITLE
Reject early continuation entries with no pullback or trigger

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2187,6 +2187,19 @@ namespace GeminiV26.Core
                 candidate.HasStrongTrigger = trigger.TriggerConfirmed;
                 candidate.HasStrongStructure = HasStrongStructure(ctx, candidate.Direction);
 
+                if (ShouldRejectEarlyNoStructure(ctx, candidate, candidate.HasStrongTrigger))
+                {
+                    candidate.IsValid = false;
+                    candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
+                        ? "[EARLY_NO_STRUCTURE]"
+                        : $"{candidate.Reason} [EARLY_NO_STRUCTURE]";
+                    ClearArmedSetup(candidate);
+                    _bot.Print(TradeLogIdentity.WithTempId(
+                        $"[ENTRY][REJECT][EARLY_NO_STRUCTURE] {candidate.Symbol ?? _bot.SymbolName} {candidate.Type} {candidate.Direction} barsSinceBreak={barsSinceBreak} pullback={ctx.BarsSinceFirstPullback} score={candidate.Score}",
+                        ctx));
+                    continue;
+                }
+
                 if (!trigger.IsManaged)
                 {
                     candidate.TriggerConfirmed = true;
@@ -2297,6 +2310,36 @@ namespace GeminiV26.Core
                 default:
                     return false;
             }
+        }
+
+        private static bool ShouldRejectEarlyNoStructure(
+            EntryContext ctx,
+            EntryEvaluation candidate,
+            bool hasStrongTrigger)
+        {
+            if (ctx == null || candidate == null || candidate.Direction == TradeDirection.None)
+                return false;
+
+            if (!IsContinuationEarlyValidityType(candidate.Type))
+                return false;
+
+            bool isEarly =
+                (candidate.Direction == TradeDirection.Long && ctx.HasEarlyContinuationLong) ||
+                (candidate.Direction == TradeDirection.Short && ctx.HasEarlyContinuationShort);
+
+            bool hasPullback = ctx.BarsSinceFirstPullback >= 0;
+            bool hasMinimalStructure = hasPullback;
+
+            return isEarly &&
+                   !hasMinimalStructure &&
+                   !hasStrongTrigger;
+        }
+
+        private static bool IsContinuationEarlyValidityType(EntryType type)
+        {
+            string typeName = type.ToString();
+            return typeName.IndexOf("Continuation", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   typeName.IndexOf("MicroStructure", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private static int GetBarsSinceBreak(EntryContext ctx, TradeDirection direction)


### PR DESCRIPTION
### Motivation
- Prevent entries that occur at the top of an impulse with no pullback and no real trigger by introducing a minimal hard validity floor for early continuation candidates.
- Target continuation-type families (FX continuation and micro-structure cases) while preserving existing architecture, scoring, router, and final acceptance behavior.

### Description
- Added a hard rejection in `UpdateExecutionStateMachine` (`Core/TradeCore.cs`) that invalidates candidates when they are in an early continuation window (`ctx.HasEarlyContinuationLong/Short`), have no minimal pullback structure (`ctx.BarsSinceFirstPullback < 0`), and have no strong trigger (`candidate.HasStrongTrigger == false`).
- The guard applies to continuation/micro-structure families via `IsContinuationEarlyValidityType` which matches `*Continuation*` and `*MicroStructure*` entry type names so FX plus index/crypto equivalents are covered.
- The rejection is a hard validity filter (`candidate.IsValid = false`) and leaves scoring formulas, `TradeRouter`, and `PassFinalAcceptance` untouched.
- Emits the mandatory log line with required tag and fields: `[ENTRY][REJECT][EARLY_NO_STRUCTURE] {symbol} {entryType} {direction} barsSinceBreak={...} pullback={...} score={...}`.

### Testing
- Attempted automated build with `dotnet build -v minimal`, but the environment lacks the `dotnet` tool so the build could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68d6540c08328aab02d6f542ac3ec)