### PR TITLE
Tighten EARLY_NO_STRUCTURE guard to require MovePhase.Impulse

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2189,13 +2189,14 @@ namespace GeminiV26.Core
 
                 if (ShouldRejectEarlyNoStructure(ctx, candidate, candidate.HasStrongTrigger))
                 {
+                    MovePhase movePhase = ctx.MemoryState?.MovePhase ?? MovePhase.Unknown;
                     candidate.IsValid = false;
                     candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
                         ? "[EARLY_NO_STRUCTURE]"
                         : $"{candidate.Reason} [EARLY_NO_STRUCTURE]";
                     ClearArmedSetup(candidate);
                     _bot.Print(TradeLogIdentity.WithTempId(
-                        $"[ENTRY][REJECT][EARLY_NO_STRUCTURE] {candidate.Symbol ?? _bot.SymbolName} {candidate.Type} {candidate.Direction} barsSinceBreak={barsSinceBreak} pullback={ctx.BarsSinceFirstPullback} score={candidate.Score}",
+                        $"[ENTRY][REJECT][EARLY_NO_STRUCTURE] {candidate.Symbol ?? _bot.SymbolName} {candidate.Type} {candidate.Direction} phase={movePhase} barsSinceBreak={barsSinceBreak} pullback={ctx.BarsSinceFirstPullback} score={candidate.Score}",
                         ctx));
                     continue;
                 }
@@ -2326,11 +2327,13 @@ namespace GeminiV26.Core
             bool isEarly =
                 (candidate.Direction == TradeDirection.Long && ctx.HasEarlyContinuationLong) ||
                 (candidate.Direction == TradeDirection.Short && ctx.HasEarlyContinuationShort);
+            bool isImpulsePhase = (ctx.MemoryState?.MovePhase ?? MovePhase.Unknown) == MovePhase.Impulse;
 
             bool hasPullback = ctx.BarsSinceFirstPullback >= 0;
             bool hasMinimalStructure = hasPullback;
 
             return isEarly &&
+                   isImpulsePhase &&
                    !hasMinimalStructure &&
                    !hasStrongTrigger;
         }


### PR DESCRIPTION
### Motivation
- Prevent early continuation rejects from blocking valid post-pullback continuations by ensuring the existing `EARLY_NO_STRUCTURE` guard only rejects during the `Impulse` phase (`MovePhase.Impulse`).

### Description
- Added a single extra condition to `ShouldRejectEarlyNoStructure` so it returns true only when `(ctx.MemoryState?.MovePhase ?? MovePhase.Unknown) == MovePhase.Impulse`, and included `phase={movePhase}` in the existing reject log in `Core/TradeCore.cs`, without changing any other logic or refactoring.

### Testing
- Ran repository searches and validations (`rg`/`sed`) to confirm `MovePhase` exists, `ctx.MemoryState.MovePhase` is accessible, and the guard call site and ordering are unchanged, all succeeded.
- Inspected the diff for `Core/TradeCore.cs` and committed the change, and the commit operation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6906d7f548328873c5cb34312c8a8)