### PR TITLE
Use ctx.MovePhase first with Memory fallback and add source debug for EARLY_NO_STRUCTURE

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2189,14 +2189,27 @@ namespace GeminiV26.Core
 
                 if (ShouldRejectEarlyNoStructure(ctx, candidate, candidate.HasStrongTrigger))
                 {
-                    MovePhase movePhase = ctx.MemoryState?.MovePhase ?? MovePhase.Unknown;
+                    MovePhase movePhase;
+                    bool phaseFromCtx = ctx.MovePhase != MovePhase.Unknown;
+                    if (phaseFromCtx)
+                    {
+                        movePhase = ctx.MovePhase;
+                    }
+                    else if (ctx.MemoryState != null)
+                    {
+                        movePhase = ctx.MemoryState.MovePhase;
+                    }
+                    else
+                    {
+                        movePhase = MovePhase.Unknown;
+                    }
                     candidate.IsValid = false;
                     candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
                         ? "[EARLY_NO_STRUCTURE]"
                         : $"{candidate.Reason} [EARLY_NO_STRUCTURE]";
                     ClearArmedSetup(candidate);
                     _bot.Print(TradeLogIdentity.WithTempId(
-                        $"[ENTRY][REJECT][EARLY_NO_STRUCTURE] {candidate.Symbol ?? _bot.SymbolName} {candidate.Type} {candidate.Direction} phase={movePhase} barsSinceBreak={barsSinceBreak} pullback={ctx.BarsSinceFirstPullback} score={candidate.Score}",
+                        $"[ENTRY][REJECT][EARLY_NO_STRUCTURE] {candidate.Symbol ?? _bot.SymbolName} {candidate.Type} {candidate.Direction} phase={movePhase} source={(phaseFromCtx ? "CTX" : "MEM")} barsSinceBreak={barsSinceBreak} pullback={ctx.BarsSinceFirstPullback} score={candidate.Score}",
                         ctx));
                     continue;
                 }
@@ -2327,7 +2340,20 @@ namespace GeminiV26.Core
             bool isEarly =
                 (candidate.Direction == TradeDirection.Long && ctx.HasEarlyContinuationLong) ||
                 (candidate.Direction == TradeDirection.Short && ctx.HasEarlyContinuationShort);
-            bool isImpulsePhase = (ctx.MemoryState?.MovePhase ?? MovePhase.Unknown) == MovePhase.Impulse;
+            MovePhase movePhase;
+            if (ctx.MovePhase != MovePhase.Unknown)
+            {
+                movePhase = ctx.MovePhase;
+            }
+            else if (ctx.MemoryState != null)
+            {
+                movePhase = ctx.MemoryState.MovePhase;
+            }
+            else
+            {
+                movePhase = MovePhase.Unknown;
+            }
+            bool isImpulsePhase = movePhase == MovePhase.Impulse;
 
             bool hasPullback = ctx.BarsSinceFirstPullback >= 0;
             bool hasMinimalStructure = hasPullback;


### PR DESCRIPTION
### Motivation
- The existing guard relied directly on `ctx.MemoryState.MovePhase`, which can be stale; the change uses the realtime `ctx.MovePhase` as primary source with a safe fallback to memory.
- Keep guard semantics unchanged while improving correctness to avoid false "impulse" detections and make debugging source selection visible.
- The codebase uses `MovePhase.Unknown` as the sentinel (there is no `MovePhase.None`), so the patch uses `Unknown` consistently.

### Description
- Resolve `movePhase` using `ctx.MovePhase` first, then `ctx.MemoryState.MovePhase` if present, else `MovePhase.Unknown` in `ShouldRejectEarlyNoStructure`.
- Apply the same ctx-first fallback when logging the `EARLY_NO_STRUCTURE` rejection inside `UpdateExecutionStateMachine` and add `source=CTX|MEM` to the log for diagnostics.
- Preserve existing guard logic that checks `movePhase == MovePhase.Impulse` and avoid other refactors or guard changes.
- Changes are limited to `Core/TradeCore.cs` only.

### Testing
- Ran repository searches (`rg`) to verify occurrences of `MovePhase` and the updated log token; the updated lines were found in `Core/TradeCore.cs` as expected.
- Committed the change successfully with `git commit` (no compilation/build step executed in this environment).
- No solution/project files were discovered in the repo root patterns, so no automated build or unit test run was performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c691c6370c8328afb9aba16f5285ce)