### PR TITLE
Add compatibility properties to EntryContext used by TradeCore

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -283,6 +283,8 @@ namespace GeminiV26.Core.Entry
         public SymbolMemoryState Memory { get; set; }
         public bool HasMemory => Memory != null;
         public SymbolMemoryState MemoryState { get; set; }
+        public MovePhase MovePhase => MemoryState?.MovePhase ?? MovePhase.Unknown;
+        public int BarsSinceFirstPullback => MemoryState?.BarsSinceFirstPullback ?? -1;
         public MemoryAssessment MemoryAssessment { get; set; }
         public ContinuationWindowState MemoryContinuationWindow { get; set; } = ContinuationWindowState.Unknown;
         public MoveExtensionState MemoryMoveExtension { get; set; } = MoveExtensionState.Unknown;


### PR DESCRIPTION
### Motivation
- Recent changes in `TradeCore` referenced `EntryContext` members that were removed, causing missing-member errors; this restores small compatibility passthroughs from the memory snapshot.

### Description
- Added two passthrough properties to `EntryContext`: `MovePhase` (returns `MemoryState.MovePhase` or `MovePhase.Unknown`) and `BarsSinceFirstPullback` (returns `MemoryState.BarsSinceFirstPullback` or `-1`).

### Testing
- No automated build or test run was executed because the repository has no `.sln`/`.csproj` to run `dotnet build`; changes were validated by inspecting updated files and committing the patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c692adff44832885cc19f91e12aab1)