### PR TITLE
TASK-07: Hard early protection guard in TVM EvaluateEarlyPhase

### DIFF
--- a/Core/TradeViabilityMonitor.cs
+++ b/Core/TradeViabilityMonitor.cs
@@ -167,6 +167,29 @@ namespace GeminiV26.Core
                 $"[TVM PHASE] EARLY bars={barsSinceEntry} mfeR={ctx.MfeR:0.00} maeR={ctx.MaeR:0.00} " +
                 $"adx={ctx.Adx_M5:0.0} trend={marketTrend}");
 
+            // =====================================
+            // HARD EARLY PROTECTION (CRITICAL FIX)
+            // =====================================
+            if (barsSinceEntry <= 2)
+            {
+                // csak brutál fail esetén engedünk exitet
+                bool hardFail = ctx.MaeR > 0.60;
+
+                _bot.Print(TradeLogIdentity.WithPositionIds(
+                    $"[TVM][EARLY_PROTECT] bars={barsSinceEntry} maeR={ctx.MaeR:0.00} hardFail={hardFail}", ctx));
+
+                if (!hardFail)
+                {
+                    _bot.Print(TradeLogIdentity.WithPositionIds(
+                        "[TVM][HOLD][EARLY_PROTECTION_ACTIVE]", ctx));
+
+                    return false;
+                }
+
+                _bot.Print(TradeLogIdentity.WithPositionIds(
+                    "[TVM][ALLOW_EXIT][EARLY_HARD_FAIL]", ctx));
+            }
+
             if (!ctx.MarketTrend)
             {
                 ctx.IsDeadTrade = true;
@@ -186,7 +209,7 @@ namespace GeminiV26.Core
                 return true;
             }
 
-            bool noProgress = barsSinceEntry >= 2 && ctx.MfeR < 0.10;
+            bool noProgress = barsSinceEntry >= 3 && ctx.MfeR < 0.10;
             bool adverseExpansion = ctx.MaeR > 0.35;
             bool momentumWeak = ctx.Adx_M5 < 20.0 || atrShrinking;
             bool fastAdverse = ctx.MaeR > 0.25 && barsSinceEntry <= 2;


### PR DESCRIPTION
### Motivation
- Prevent premature early-phase exits that close trades within the first few bars on normal pullbacks or low initial progress by adding a minimal protection layer at the start of the early-phase evaluation.
- Preserve all existing danger/persistence/persistence and persistence-related logic while strictly limiting changes to an early protection gate and a single no-progress threshold tweak.

### Description
- Inserted a hard early-protection gate at the start of `EvaluateEarlyPhase(...)` that blocks any exit when `barsSinceEntry <= 2` unless `ctx.MaeR > 0.60` (treated as a `hardFail`).
- Added logging for the new flow using `_bot.Print(...)` with messages: `[TVM][EARLY_PROTECT]`, `[TVM][HOLD][EARLY_PROTECTION_ACTIVE]`, and `[TVM][ALLOW_EXIT][EARLY_HARD_FAIL]`.
- Adjusted the early `noProgress` condition from `barsSinceEntry >= 2` to `barsSinceEntry >= 3` to delay the no-progress trigger by one bar.
- No changes were made to danger counting, persistence logic, persistence checks, phase structure, or persistence/danger thresholds beyond the protection layer.

### Testing
- Attempted to run `dotnet build` in the environment, but the command failed with `dotnet: command not found`; no build or unit tests executed.
- Static inspection and local file update verified `Core/TradeViabilityMonitor.cs` was modified to include the protection gate and the `noProgress` threshold change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69833f33c8328a79c1f321c7bd9b3)