### PR TITLE
TASK-07.1: Finetune early-phase TVM thresholds

### DIFF
--- a/Core/TradeViabilityMonitor.cs
+++ b/Core/TradeViabilityMonitor.cs
@@ -198,7 +198,7 @@ namespace GeminiV26.Core
             }
 
             bool noFollowThrough =
-                barsSinceEntry >= 3 &&
+                barsSinceEntry >= 4 &&
                 ctx.MfeR < 0.15 &&
                 ctx.MaeR > 0.25;
 
@@ -212,7 +212,7 @@ namespace GeminiV26.Core
             bool noProgress = barsSinceEntry >= 3 && ctx.MfeR < 0.10;
             bool adverseExpansion = ctx.MaeR > 0.35;
             bool momentumWeak = ctx.Adx_M5 < 20.0 || atrShrinking;
-            bool fastAdverse = ctx.MaeR > 0.25 && barsSinceEntry <= 2;
+            bool fastAdverse = ctx.MaeR > 0.35 && barsSinceEntry <= 2;
 
             LogTvmOncePerBar(
                 ctx,


### PR DESCRIPTION
### Motivation
- Reduce false early exits after the existing EARLY_PROTECTION by slightly relaxing two thresholds in the early-phase decision path without changing logic, variables, structure, or persistence.

### Description
- In `Core/TradeViabilityMonitor.cs` inside `EvaluateEarlyPhase(...)` I adjusted two thresholds: `noFollowThrough` changed from `barsSinceEntry >= 3` to `barsSinceEntry >= 4`, and `fastAdverse` changed from `ctx.MaeR > 0.25` to `ctx.MaeR > 0.35`; no other lines, variables, control flow, `dangerCount` logic, persistence checks, or log strings were modified.

### Testing
- Performed repository checks (`git diff`, `git show`, `git status`) and confirmed a single file changed with exactly the two threshold edits and a commit was created, and attempted `dotnet build` which failed due to the runtime not being available in the environment (no unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69982bb90832893f3d56688efcdf3)