### PR TITLE
Enforce global execution integrity gates

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1748,6 +1748,14 @@ namespace GeminiV26.Core
                 if (!TryGetRestartDecayState(ctx, candidate, out string restartReason))
                     continue;
 
+                if (!candidate.IsValid)
+                {
+                    _bot.Print(TradeLogIdentity.WithTempId(
+                        $"[INTEGRITY] SKIP restart protect on invalid candidate: {candidate.Type}",
+                        ctx));
+                    continue;
+                }
+
                 if (BotRestartState.IsHardProtectionPhase)
                 {
                     bool isCryptoCandidate = IsCryptoCandidate(candidate.Type);
@@ -1775,7 +1783,6 @@ namespace GeminiV26.Core
                             candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
                                 ? "[RESTART_PROTECT_SUPPRESSED_CONTINUATION_AUTH]"
                                 : $"{candidate.Reason} [RESTART_PROTECT_SUPPRESSED_CONTINUATION_AUTH]";
-                            candidate.IsValid = true;
                             EntryDecisionPolicy.Normalize(candidate);
 
                             _bot.Print(TradeLogIdentity.WithTempId(
@@ -1793,7 +1800,6 @@ namespace GeminiV26.Core
                             candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
                                 ? $"[RESTART_MID_TREND_SOFT_{restartReason}]"
                                 : $"{candidate.Reason} [RESTART_MID_TREND_SOFT_{restartReason}]";
-                            candidate.IsValid = true;
                             EntryDecisionPolicy.Normalize(candidate);
 
                             _bot.Print(TradeLogIdentity.WithTempId(
@@ -2401,6 +2407,23 @@ namespace GeminiV26.Core
         {
             if (ctx == null || eval == null)
                 return false;
+
+            int recommendedTimingPenalty = ctx.MemoryAssessment?.RecommendedTimingPenalty ?? ctx.MemoryTimingPenalty;
+            if (recommendedTimingPenalty <= -10)
+            {
+                _bot.Print(TradeLogIdentity.WithTempId(
+                    $"[TIMING BLOCK] penalty={recommendedTimingPenalty}",
+                    ctx));
+                return false;
+            }
+
+            if (BotRestartState.IsHardProtectionPhase && eval.Score < 60)
+            {
+                _bot.Print(TradeLogIdentity.WithTempId(
+                    "[RESTART BLOCK] HARD phase requires higher confidence",
+                    ctx));
+                return false;
+            }
 
             string symbol = ctx.Symbol ?? _bot.SymbolName;
             bool isLong = eval.Direction == TradeDirection.Long;

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -78,6 +78,28 @@ namespace GeminiV26.Core
                 {
                     decision = candidate.TriggerConfirmed ? "ACCEPT" : "ACCEPT_SCORE_MODEL";
 
+                    if (!candidate.TriggerConfirmed)
+                    {
+                        _bot.Print(TradeLogIdentity.WithTempId(
+                            $"[EXEC BLOCK] NOT TRIGGERED → BLOCK execution | {candidate.Type} score={candidate.Score}",
+                            entryContext));
+                    }
+
+                    if (decision == "ACCEPT_SCORE_MODEL")
+                    {
+                        _bot.Print(TradeLogIdentity.WithTempId(
+                            "[EXEC BLOCK] SCORE_MODEL cannot execute (no trigger)",
+                            entryContext));
+                    }
+
+                    if (!IsExecutable(candidate))
+                    {
+                        _bot.Print(TradeLogIdentity.WithTempId(
+                            $"[EXEC FILTER] candidate not executable | trigger={candidate.TriggerConfirmed.ToString().ToLowerInvariant()} valid={candidate.IsValid.ToString().ToLowerInvariant()}",
+                            entryContext));
+                        continue;
+                    }
+
                     if (winner == null
                         || candidate.Score > winner.Score
                         || (candidate.Score == winner.Score
@@ -122,6 +144,13 @@ namespace GeminiV26.Core
             _bot.Print(TradeLogIdentity.WithTempId($"[ACCEPT] type={winner.Type} dir={winner.Direction} score={winner.Score} reason={winner.Reason}", entryContext));
             _bot.Print(TradeLogIdentity.WithTempId($"[TR] WINNER: {winner.Type} dir={winner.Direction} score={winner.Score} valid={winner.IsValid} reason={winner.Reason}", entryContext));
             return winner;
+        }
+
+        private static bool IsExecutable(EntryEvaluation c)
+        {
+            return c != null
+                && c.IsValid
+                && c.TriggerConfirmed;
         }
 
         private static string ResolveRejectReason(EntryEvaluation candidate, int threshold)
@@ -247,8 +276,15 @@ namespace GeminiV26.Core
                 if (eval.State == EntryState.SETUP_DETECTED)
                     return RejectFxCandidate(eval, decisionScore, "FX_EARLY_BLOCK", entryContext);
 
-                if (!continuationAuthority)
-                    return RejectFxCandidate(eval, decisionScore, "FX_TRIGGER_REQUIRED", entryContext);
+                if (continuationAuthority)
+                {
+                    _bot.Print(TradeLogIdentity.WithTempId(
+                        "[AUTH BLOCK] continuation authority cannot bypass trigger",
+                        entryContext));
+                    return RejectFxCandidate(eval, decisionScore, "AUTH_TRIGGER_BYPASS_BLOCK", entryContext);
+                }
+
+                return RejectFxCandidate(eval, decisionScore, "FX_TRIGGER_REQUIRED", entryContext);
             }
 
             if (decisionScore < 45)


### PR DESCRIPTION
### Motivation
- Enforce global trade integrity so invalid setups can never be resurrected, untriggered setups never execute, and continuation authority cannot bypass trigger checks across all instruments.
- Make restart/timing rules hard gates at final acceptance to eliminate late/weak entries while preserving high-quality setups.

### Description
- `Core/TradeCore.cs`: `ApplyRestartProtection` now skips processing for `candidate.IsValid == false` (logs `[INTEGRITY]`) and removed restart paths that set `candidate.IsValid = true`, preserving immutability of validity; `PassFinalAcceptance` now blocks when `RecommendedTimingPenalty <= -10` (`[TIMING BLOCK]`) and during hard restart phase when `eval.Score < 60` (`[RESTART BLOCK]`).
- `Core/TradeRouter.cs`: `SelectEntry` logs and blocks non-triggered candidates (`[EXEC BLOCK]`) and explicitly blocks `ACCEPT_SCORE_MODEL` from execution, introduces `IsExecutable` helper that enforces `IsValid && TriggerConfirmed` before winner selection (logs `[EXEC FILTER]`).
- `Core/TradeRouter.cs`: FX acceptance logic now prevents continuation-authority from bypassing trigger requirements (logs `[AUTH BLOCK]` and rejects such candidates via `RejectFxCandidate`).
- Added structured debug logging tags for observability: `[INTEGRITY]`, `[EXEC BLOCK]`, `[EXEC FILTER]`, `[TIMING BLOCK]`, `[RESTART BLOCK]`, and `[AUTH BLOCK]`.

### Testing
- Ran repository text searches for relevant symbols and evidence of changes using `rg` (lookups for `ApplyRestartProtection`, `IsValid = true`, `ACCEPT_SCORE_MODEL`, `TriggerConfirmed`, `HasContinuationAuthority`, `RecommendedTimingPenalty`, logging tags), and all expected patterns were found; searches succeeded.
- Inspected diffs with `git diff` and repository status with `git status` to confirm modifications are limited to `Core/TradeCore.cs` and `Core/TradeRouter.cs`, and the changes were committed; these checks succeeded.
- Verified presence of new log lines and removed `candidate.IsValid = true` occurrences via `rg` which reported the expected insertions/removals; this verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6acaf49b4832899d03ce89139948e)