### PR TITLE
Fix trigger confirmation propagation to prevent false executable states

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2220,24 +2220,37 @@ namespace GeminiV26.Core
                     continue;
                 }
 
+                _bot.Print($"[TRIGGER] type={candidate.Type} confirmed={trigger.TriggerConfirmed}");
+                candidate.TriggerConfirmed = trigger.TriggerConfirmed;
+                _bot.Print($"[TRIGGER STATE] candidate={candidate.TriggerConfirmed}");
+
+                if (candidate.TriggerConfirmed != trigger.TriggerConfirmed)
+                {
+                    _bot.Print($"[INTEGRITY ERROR] Trigger mismatch | candidate={candidate.TriggerConfirmed} trigger={trigger.TriggerConfirmed} type={candidate.Type}");
+                }
+
                 if (!trigger.IsManaged)
                 {
-                    candidate.TriggerConfirmed = true;
                     candidate.State = EntryState.TRIGGERED;
                     continue;
                 }
 
-                candidate.TriggerConfirmed = true;
-                candidate.State = EntryState.TRIGGERED;
-
                 if (!trigger.TriggerConfirmed)
                 {
+                    candidate.TriggerConfirmed = false;
+                    _bot.Print($"[TRIGGER STATE] candidate={candidate.TriggerConfirmed}");
+                    if (candidate.TriggerConfirmed != trigger.TriggerConfirmed)
+                    {
+                        _bot.Print($"[INTEGRITY ERROR] Trigger mismatch | candidate={candidate.TriggerConfirmed} trigger={trigger.TriggerConfirmed} type={candidate.Type}");
+                    }
+                    candidate.State = EntryState.ARMED;
                     UpsertArmedSetup(candidate, barsSinceBreak);
                     _bot.Print($"[SETUP DETECTED] symbol={candidate.Symbol} score={candidate.Score} state=ARMED type={candidate.Type} dir={candidate.Direction}");
                     _bot.Print($"[TRIGGER WAIT] symbol={candidate.Symbol} reason={trigger.WaitReason} type={candidate.Type} dir={candidate.Direction} impact=score_only");
                 }
                 else
                 {
+                    candidate.State = EntryState.TRIGGERED;
                     UpsertArmedSetup(candidate, barsSinceBreak);
                     _bot.Print($"[TRIGGER CONFIRMED] symbol={candidate.Symbol} breakoutClose={trigger.BreakoutClose.ToString().ToLowerInvariant()} structureBreak={trigger.StructureBreak.ToString().ToLowerInvariant()} m1Break={trigger.M1Break.ToString().ToLowerInvariant()} type={candidate.Type} dir={candidate.Direction}");
                 }


### PR DESCRIPTION
### Motivation
- The state machine was overwriting evaluated trigger truth by unconditionally setting `candidate.TriggerConfirmed = true`, allowing non-triggered candidates to become executable. 
- The change aims to make `TriggerConfirmed` the single source of truth, propagating the trigger result downstream and preventing downstream force-true overrides. 

### Description
- Replaced unconditional downstream `candidate.TriggerConfirmed = true` assignments with `candidate.TriggerConfirmed = trigger.TriggerConfirmed` so candidate state mirrors the evaluated trigger. 
- Added debug logging around trigger evaluation and assignment using `_bot.Print` with `[TRIGGER]` and `[TRIGGER STATE]` entries. 
- Added an integrity guard log that emits `[INTEGRITY ERROR] Trigger mismatch | candidate=... trigger=...` when candidate and trigger values differ. 
- Ensured managed-but-unconfirmed triggers explicitly set `candidate.TriggerConfirmed = false` and `candidate.State = EntryState.ARMED`, while only confirmed (or unmanaged) paths set `EntryState.TRIGGERED`. 

### Testing
- Searched the repository for force-true patterns with `rg -n "TriggerConfirmed\s*=\s*true"` and confirmed no downstream unconditional `candidate.TriggerConfirmed = true` remains except the unmanaged-diagnostics default (`diagnostics.TriggerConfirmed = true`). (succeeded)
- Inspected the modified region with `nl -ba Core/TradeCore.cs | sed -n '2188,2275p'` to verify propagation, logging, and ARMED state assignment were applied as intended. (succeeded)
- Ran `dotnet build` in the environment and the command failed due to missing toolchain (`/bin/bash: dotnet: command not found`), so no binary build/test was executed. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b14be4688328bc44e5af81b0c9c5)