### PR TITLE
Harden trigger/state integrity synchronization in UpdateExecutionStateMachine

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2227,11 +2227,28 @@ namespace GeminiV26.Core
                 if (candidate.TriggerConfirmed != trigger.TriggerConfirmed)
                 {
                     _bot.Print($"[INTEGRITY ERROR] Trigger mismatch | candidate={candidate.TriggerConfirmed} trigger={trigger.TriggerConfirmed} type={candidate.Type}");
+
+                    // HARD FIX – enforce trigger truth
+                    candidate.TriggerConfirmed = trigger.TriggerConfirmed;
+
+                    _bot.Print($"[TRIGGER STATE FIX] candidate trigger restored to {candidate.TriggerConfirmed} | type={candidate.Type}");
                 }
 
                 if (!trigger.IsManaged)
                 {
-                    candidate.State = EntryState.TRIGGERED;
+                    if (candidate.TriggerConfirmed)
+                    {
+                        candidate.State = EntryState.TRIGGERED;
+                    }
+                    else
+                    {
+                        candidate.State = EntryState.ARMED;
+                    }
+
+                    if (!candidate.TriggerConfirmed && candidate.State == EntryState.TRIGGERED)
+                    {
+                        _bot.Print($"[INTEGRITY ERROR] Illegal state: TRIGGERED without trigger | type={candidate.Type}");
+                    }
                     continue;
                 }
 
@@ -2242,17 +2259,34 @@ namespace GeminiV26.Core
                     if (candidate.TriggerConfirmed != trigger.TriggerConfirmed)
                     {
                         _bot.Print($"[INTEGRITY ERROR] Trigger mismatch | candidate={candidate.TriggerConfirmed} trigger={trigger.TriggerConfirmed} type={candidate.Type}");
+
+                        // HARD FIX – enforce trigger truth
+                        candidate.TriggerConfirmed = trigger.TriggerConfirmed;
+
+                        _bot.Print($"[TRIGGER STATE FIX] candidate trigger restored to {candidate.TriggerConfirmed} | type={candidate.Type}");
                     }
-                    candidate.State = EntryState.ARMED;
                     UpsertArmedSetup(candidate, barsSinceBreak);
                     _bot.Print($"[SETUP DETECTED] symbol={candidate.Symbol} score={candidate.Score} state=ARMED type={candidate.Type} dir={candidate.Direction}");
                     _bot.Print($"[TRIGGER WAIT] symbol={candidate.Symbol} reason={trigger.WaitReason} type={candidate.Type} dir={candidate.Direction} impact=score_only");
                 }
                 else
                 {
-                    candidate.State = EntryState.TRIGGERED;
                     UpsertArmedSetup(candidate, barsSinceBreak);
                     _bot.Print($"[TRIGGER CONFIRMED] symbol={candidate.Symbol} breakoutClose={trigger.BreakoutClose.ToString().ToLowerInvariant()} structureBreak={trigger.StructureBreak.ToString().ToLowerInvariant()} m1Break={trigger.M1Break.ToString().ToLowerInvariant()} type={candidate.Type} dir={candidate.Direction}");
+                }
+
+                if (candidate.TriggerConfirmed)
+                {
+                    candidate.State = EntryState.TRIGGERED;
+                }
+                else
+                {
+                    candidate.State = EntryState.ARMED;
+                }
+
+                if (!candidate.TriggerConfirmed && candidate.State == EntryState.TRIGGERED)
+                {
+                    _bot.Print($"[INTEGRITY ERROR] Illegal state: TRIGGERED without trigger | type={candidate.Type}");
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Ensure trigger mismatches are not only logged but actively corrected so candidate truth cannot drift from resolved trigger diagnostics.
- Force candidate state to always reflect trigger truth to prevent illegal `TRIGGERED without trigger` combinations and keep WAIT paths non-executable.
- Add defensive logging to surface integrity violations and state fixes for easier troubleshooting.

### Description
- In `Core/TradeCore.cs` (method `UpdateExecutionStateMachine`) detect trigger mismatches and immediately restore `candidate.TriggerConfirmed = trigger.TriggerConfirmed`, and emit `[TRIGGER STATE FIX]` debug logs.
- Derive `candidate.State` from `candidate.TriggerConfirmed` in both unmanaged and managed trigger flows so `true -> TRIGGERED` and `false -> ARMED` are enforced at final sync points.
- Add defensive integrity logs for the illegal case `!candidate.TriggerConfirmed && candidate.State == EntryState.TRIGGERED` to detect unexpected flows.
- Preserve existing WAIT semantics by leaving unconfirmed triggers in the ARMED path and retaining existing `[TRIGGER WAIT]` / setup logging and `UpsertArmedSetup` calls.

### Testing
- Ran source inspection and context checks using `nl -ba Core/TradeCore.cs | sed -n '2208,2308p'` to confirm code placement and succeeded.
- Verified new log tokens and state assignments with `rg -n "TRIGGER STATE FIX|Illegal state: TRIGGERED without trigger|candidate.State = EntryState.TRIGGERED|candidate.State = EntryState.ARMED" Core/TradeCore.cs` and the search passed.
- Performed repository status and commit via `git status --short` and `git add Core/TradeCore.cs && git commit -m "Harden trigger/state integrity synchronization"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b2ecc92c8328a3c644b691a0a663)