### PR TITLE
Add stale-trigger age check to UpdateExecutionStateMachine

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2236,6 +2236,16 @@ namespace GeminiV26.Core
                 }
                 _bot.Print($"[TRIGGER STATE] candidate={candidate.TriggerConfirmed}");
 
+                int currentBarIndex = ctx.M5?.Count - 1 ?? -1;
+                int triggerBarIndex = barsSinceBreak >= 0 ? currentBarIndex - barsSinceBreak : currentBarIndex;
+                int triggerAgeBars = currentBarIndex - triggerBarIndex;
+
+                if (candidate.TriggerConfirmed && triggerAgeBars > 3)
+                {
+                    _bot.Print("[TRIGGER BLOCK] Stale trigger");
+                    candidate.TriggerConfirmed = false;
+                }
+
                 if (!trigger.IsManaged)
                 {
                     if (candidate.TriggerConfirmed)


### PR DESCRIPTION
### Motivation
- Prevent executions based on triggers that are too old by invalidating confirmed triggers older than a small bar threshold. 
- Apply the staleness check immediately after trigger evaluation so downstream state and routing use the corrected trigger flag. 

### Description
- Added computation of `currentBarIndex`, `triggerBarIndex` (using `barsSinceBreak`) and `triggerAgeBars` inside `UpdateExecutionStateMachine` in `Core/TradeCore.cs`. 
- If `candidate.TriggerConfirmed` is true and `triggerAgeBars > 3` the code now logs `[TRIGGER BLOCK] Stale trigger` and sets `candidate.TriggerConfirmed = false`. 
- The new logic is placed after the trigger state logging (`[TRIGGER STATE]`) and before the existing managed/unmanaged trigger handling. 

### Testing
- No automated test suite was available in this repository snapshot, so no build or unit tests were executed. 
- Validation was performed via automated repository search and diff inspection to confirm the patch was applied and the change appears in `Core/TradeCore.cs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b53681bc8328afeb57ad18718bb1)