### PR TITLE
Add diagnostic audit trace for post-trigger candidate rejection path

### DIFF
--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -64,6 +64,10 @@ namespace GeminiV26.Core
                 string decision;
                 candidate.FinalValid = candidate.IsValid;
                 _bot.Print($"[BASELINE CHECK] type={candidate.Type} score={candidate.Score} valid={candidate.FinalValid.ToString().ToLowerInvariant()} source=ENTRY_ONLY");
+                if (candidate.TriggerConfirmed)
+                {
+                    _bot.Print($"[AUDIT][TRIGGERED] type={candidate.Type} score={candidate.Score} dir={candidate.Direction}");
+                }
 
                 if (!candidate.FinalValid)
                 {
@@ -92,6 +96,12 @@ namespace GeminiV26.Core
                             entryContext));
                     }
 
+                    _bot.Print(
+                        $"[AUDIT][EXEC CHECK] type={candidate.Type} " +
+                        $"trigger={candidate.TriggerConfirmed} " +
+                        $"valid={candidate.IsValid} " +
+                        $"state={candidate.State}");
+
                     if (!IsExecutable(candidate))
                     {
                         _bot.Print(TradeLogIdentity.WithTempId(
@@ -106,6 +116,48 @@ namespace GeminiV26.Core
                             && GetTypePriority(_bot.SymbolName, candidate.Type) < GetTypePriority(_bot.SymbolName, winner.Type)))
                     {
                         winner = candidate;
+                    }
+                }
+
+                bool structureAligned = IsStructureAligned(entryContext, candidate.Direction);
+                bool hasImpulse = entryContext?.HasImpulse_M5 == true;
+                bool htfAligned = entryContext == null
+                    || entryContext.FxHtfAllowedDirection == TradeDirection.None
+                    || candidate.Direction == TradeDirection.None
+                    || candidate.Direction == entryContext.FxHtfAllowedDirection;
+                bool continuationValid = !IsContinuationSetup(candidate.Type)
+                    || (entryContext?.MarketState?.IsTrend == true && candidate.Direction == entryContext.TrendDirection);
+                bool pullbackValid = candidate.Direction == TradeDirection.Long
+                    ? entryContext?.HasPullbackLong_M5 == true
+                    : candidate.Direction == TradeDirection.Short && entryContext?.HasPullbackShort_M5 == true;
+                bool breakoutValid =
+                    entryContext?.BreakoutDirection == candidate.Direction ||
+                    entryContext?.RangeBreakDirection == candidate.Direction;
+
+                _bot.Print(
+                    $"[AUDIT][VALIDITY] type={candidate.Type} " +
+                    $"structure={structureAligned} " +
+                    $"impulse={hasImpulse} " +
+                    $"htfAlign={htfAligned} " +
+                    $"continuation={continuationValid} " +
+                    $"pullback={pullbackValid} " +
+                    $"breakout={breakoutValid}");
+
+                if (!candidate.IsValid)
+                {
+                    _bot.Print(
+                        $"[AUDIT][DEATH] type={candidate.Type} " +
+                        $"score={candidate.Score} " +
+                        $"reason={candidate.Reason} " +
+                        $"trigger={candidate.TriggerConfirmed} " +
+                        $"state={candidate.State}");
+
+                    int nearMissThreshold = Math.Max(60, EntryDecisionPolicy.MinScoreThreshold - 5);
+                    if (candidate.TriggerConfirmed && candidate.Score >= nearMissThreshold)
+                    {
+                        _bot.Print(
+                            $"[AUDIT][NEAR MISS] type={candidate.Type} " +
+                            $"score={candidate.Score} reason={candidate.Reason}");
                     }
                 }
 


### PR DESCRIPTION
### Motivation
- Investigate why candidates with `TriggerConfirmed == true` are still not executing by adding targeted diagnostics in the post-trigger → final rejection path.
- Produce a structured, per-candidate trace of all contributing validity checks (structure, impulse, HTF alignment, continuation, pullback, breakout) without changing any thresholds, scoring, trigger, or entry logic.

### Description
- Added a `"[AUDIT][TRIGGERED]"` log when `candidate.TriggerConfirmed` is true to surface only post-trigger candidates (`Core/TradeRouter.cs`).
- Added `"[AUDIT][EXEC CHECK]"` immediately before the execution gate to capture `trigger`, `IsValid`, and `state` used by `IsExecutable`.
- Introduced a structured `"[AUDIT][VALIDITY]"` stack that computes and logs booleans (`structureAligned`, `hasImpulse`, `htfAligned`, `continuationValid`, `pullbackValid`, `breakoutValid`) derived from existing context checks.
- Added `"[AUDIT][DEATH]"` to log expanded rejection details (`score`, `reason`, `trigger`, `state`) and `"[AUDIT][NEAR MISS]"` for triggered invalid candidates scoring `>= max(60, MinScoreThreshold - 5)`; all changes use `_bot.Print` only and do not alter behavioral code paths.

### Testing
- No automated tests were added or run; the change is diagnostic-only logging (`_bot.Print`) and has been committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c7c456b083289593ce5ef6a458dc)