### PR TITLE
Add targeted Index_Flag HTF mismatch and early-break audit logging

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2136,6 +2136,14 @@ namespace GeminiV26.Core
 
             candidate.Score = Math.Max(0, candidate.Score - appliedPenalty);
             candidate.Reason = $"{candidate.Reason} [EARLY_BREAK_PENALTY]";
+            if (candidate.Type == EntryType.Index_Flag && candidate.TriggerConfirmed)
+            {
+                _bot.Print(
+                    $"[AUDIT][EARLY BREAK] type={candidate.Type} " +
+                    $"penalty={appliedPenalty} " +
+                    $"scoreBefore={originalScore} " +
+                    $"scoreAfter={candidate.Score}");
+            }
 
             _bot.Print(TradeLogIdentity.WithTempId(
                 $"[ENTRY][AUTH] source=EARLY_BREAK_PROTECT symbol={candidate.Symbol ?? _bot.SymbolName} " +

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -125,6 +125,31 @@ namespace GeminiV26.Core
                     || entryContext.FxHtfAllowedDirection == TradeDirection.None
                     || candidate.Direction == TradeDirection.None
                     || candidate.Direction == entryContext.FxHtfAllowedDirection;
+                TradeDirection routedHtfAllowedDirection = TradeDirection.None;
+                string routedHtfState = "N/A";
+                if (entryContext != null)
+                {
+                    var instrumentClass = SymbolRouting.ResolveInstrumentClass(candidate.Symbol ?? _bot.SymbolName);
+                    switch (instrumentClass)
+                    {
+                        case InstrumentClass.FX:
+                            routedHtfAllowedDirection = entryContext.FxHtfAllowedDirection;
+                            routedHtfState = entryContext.FxHtfReason ?? "N/A";
+                            break;
+                        case InstrumentClass.CRYPTO:
+                            routedHtfAllowedDirection = entryContext.CryptoHtfAllowedDirection;
+                            routedHtfState = entryContext.CryptoHtfReason ?? "N/A";
+                            break;
+                        case InstrumentClass.METAL:
+                            routedHtfAllowedDirection = entryContext.MetalHtfAllowedDirection;
+                            routedHtfState = entryContext.MetalHtfReason ?? "N/A";
+                            break;
+                        case InstrumentClass.INDEX:
+                            routedHtfAllowedDirection = entryContext.IndexHtfAllowedDirection;
+                            routedHtfState = entryContext.IndexHtfReason ?? "N/A";
+                            break;
+                    }
+                }
                 bool continuationValid = !IsContinuationSetup(candidate.Type)
                     || (entryContext?.MarketState?.IsTrend == true && candidate.Direction == entryContext.TrendDirection);
                 bool pullbackValid = candidate.Direction == TradeDirection.Long
@@ -142,6 +167,15 @@ namespace GeminiV26.Core
                     $"continuation={continuationValid} " +
                     $"pullback={pullbackValid} " +
                     $"breakout={breakoutValid}");
+                if (candidate.Type == EntryType.Index_Flag && candidate.TriggerConfirmed)
+                {
+                    _bot.Print(
+                        $"[AUDIT][HTF SOURCE] type={candidate.Type} " +
+                        $"htfAlign={htfAligned} " +
+                        $"biasState={routedHtfState} " +
+                        $"allowedDir={routedHtfAllowedDirection} " +
+                        $"candidateDir={candidate.Direction}");
+                }
 
                 if (!candidate.IsValid)
                 {
@@ -166,6 +200,18 @@ namespace GeminiV26.Core
                     entryContext));
 
                 candidate.RejectReason = ResolveRejectReason(candidate, EntryDecisionPolicy.MinScoreThreshold);
+                if (candidate.Type == EntryType.Index_Flag
+                    && candidate.TriggerConfirmed
+                    && candidate.Reason != null
+                    && candidate.Reason.Contains("HTF_MISMATCH"))
+                {
+                    _bot.Print(
+                        $"[AUDIT][HTF ROUTER] type={candidate.Type} " +
+                        $"reason=HTF_MISMATCH " +
+                        $"biasState={routedHtfState} " +
+                        $"allowedDir={routedHtfAllowedDirection} " +
+                        $"candidateDir={candidate.Direction}");
+                }
                 _bot.Print(TradeLogIdentity.WithTempId(
                     $"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} side={candidate.Direction} " +
                     $"rawValid={candidate.RawValid.ToString().ToLowerInvariant()} finalValid={candidate.FinalValid.ToString().ToLowerInvariant()} " +
@@ -178,6 +224,16 @@ namespace GeminiV26.Core
 
                 if (candidate.RejectReason != "ACCEPTED")
                 {
+                    if (candidate.Type == EntryType.Index_Flag
+                        && candidate.TriggerConfirmed
+                        && candidate.Reason != null
+                        && candidate.Reason.Contains("HTF_MISMATCH"))
+                    {
+                        _bot.Print(
+                            $"[AUDIT][HTF CONFLICT] type={candidate.Type} " +
+                            $"htfAlign={htfAligned} " +
+                            $"reason={candidate.Reason}");
+                    }
                     _bot.Print(TradeLogIdentity.WithTempId(
                         $"[ENTRY REJECT DETAIL] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} side={candidate.Direction} " +
                         $"reason={candidate.RejectReason} structureAligned={IsStructureAligned(entryContext, candidate.Direction).ToString().ToLowerInvariant()} " +


### PR DESCRIPTION
### Motivation
- Add targeted observability to trace why `HTF_MISMATCH` is triggered for `Index_Flag` when `htfAlign == true`. 
- Keep behavior, thresholds, and logic unchanged while minimizing noise by restricting tracing to the post-trigger `Index_Flag` path. 
- Provide visibility across the validity (htfAlign) calculation, router rejection decision, boolean-vs-reason conflicts, and early-break penalty interaction to identify root cause (source mismatch, stale direction, or penalty mislabeling).

### Description
- In `Core/TradeRouter.cs` capture a routed HTF snapshot by resolving `routedHtfAllowedDirection` and `routedHtfState` from `entryContext` based on the instrument class. 
- Emit an `[AUDIT][HTF SOURCE]` log immediately after `htfAlign` is computed for candidates where `candidate.Type == EntryType.Index_Flag && candidate.TriggerConfirmed`, including `htfAlign`, routed bias state, allowed direction, and `candidate.Direction`. 
- Emit an `[AUDIT][HTF ROUTER]` log when the candidate `Reason` contains `HTF_MISMATCH` for the same gated path, showing `reason=HTF_MISMATCH` plus routed bias state/allowed direction/candidate direction. 
- Emit an `[AUDIT][HTF CONFLICT]` log right before reject detail when a `TriggerConfirmed` `Index_Flag` still contains `HTF_MISMATCH` to detect boolean vs reason inconsistencies, and add an `[AUDIT][EARLY BREAK]` log in `Core/TradeCore.cs` inside `ApplyManagedEarlyBreakTriggers` that prints penalty and score delta for the same gated path. 
- No scoring, HTF decision logic, thresholds, or behavior were modified; all additions are logging only and gated to `Index_Flag && candidate.TriggerConfirmed` to limit noise.

### Testing
- Attempted to run `dotnet build -v minimal` to validate the change, but the build could not be executed in this environment because the .NET SDK is not installed (`/bin/bash: dotnet: command not found`). 
- No other automated test suite was executed in this environment due to missing runtime/tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6db9fc5808328897b78d85751f102)