### PR TITLE
Add HTF trace audit instrumentation for Index_Flag source/consumer mismatch analysis

### DIFF
--- a/Core/Entry/EntryEvaluation.cs
+++ b/Core/Entry/EntryEvaluation.cs
@@ -49,5 +49,13 @@
         public bool IsHTFMisaligned;
         public bool IgnoreHTFForDecision;
         public double HtfConfidence01;
+
+        // AUDIT ONLY: HTF trace snapshot captured at source stage.
+        public string HtfTraceSourceStage;
+        public string HtfTraceSourceModule;
+        public string HtfTraceSourceState;
+        public TradeDirection HtfTraceSourceAllowedDirection;
+        public bool HtfTraceSourceAlign;
+        public TradeDirection HtfTraceSourceCandidateDirection;
     }
 }

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -125,6 +125,8 @@ namespace GeminiV26.Core
                     || entryContext.FxHtfAllowedDirection == TradeDirection.None
                     || candidate.Direction == TradeDirection.None
                     || candidate.Direction == entryContext.FxHtfAllowedDirection;
+                TradeDirection consumerAllowedDirection = entryContext?.FxHtfAllowedDirection ?? TradeDirection.None;
+                string consumerHtfState = entryContext?.FxHtfReason ?? "N/A";
                 TradeDirection routedHtfAllowedDirection = TradeDirection.None;
                 string routedHtfState = "N/A";
                 if (entryContext != null)
@@ -150,6 +152,9 @@ namespace GeminiV26.Core
                             break;
                     }
                 }
+                bool routedHtfAlign = candidate.Direction == TradeDirection.None
+                    ? false
+                    : routedHtfAllowedDirection == TradeDirection.None || candidate.Direction == routedHtfAllowedDirection;
                 bool continuationValid = !IsContinuationSetup(candidate.Type)
                     || (entryContext?.MarketState?.IsTrend == true && candidate.Direction == entryContext.TrendDirection);
                 bool pullbackValid = candidate.Direction == TradeDirection.Long
@@ -167,6 +172,26 @@ namespace GeminiV26.Core
                     $"continuation={continuationValid} " +
                     $"pullback={pullbackValid} " +
                     $"breakout={breakoutValid}");
+                if (candidate.Type == EntryType.Index_Flag && candidate.TriggerConfirmed)
+                {
+                    _bot.Print(
+                        $"[AUDIT][HTF TRACE][CONSUMER] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} " +
+                        $"candidateDirection={candidate.Direction} consumedHtfState={consumerHtfState} " +
+                        $"consumedAllowedDirection={consumerAllowedDirection} consumedHtfAlign={htfAligned} module={nameof(TradeRouter)}");
+
+                    if (!string.Equals(candidate.HtfTraceSourceState ?? "N/A", consumerHtfState ?? "N/A", StringComparison.Ordinal)
+                        || candidate.HtfTraceSourceAllowedDirection != consumerAllowedDirection
+                        || candidate.HtfTraceSourceAlign != htfAligned
+                        || !IsDirectionInterpretationMatch(candidate.Direction, candidate.HtfTraceSourceAllowedDirection, consumerAllowedDirection))
+                    {
+                        _bot.Print(
+                            $"[AUDIT][HTF CONFLICT] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} " +
+                            $"stageA={candidate.HtfTraceSourceStage ?? "UnknownSource"} stageB={nameof(TradeRouter)} " +
+                            $"stateA={candidate.HtfTraceSourceState ?? "N/A"} stateB={consumerHtfState} " +
+                            $"allowedDirA={candidate.HtfTraceSourceAllowedDirection} allowedDirB={consumerAllowedDirection} " +
+                            $"htfAlignA={candidate.HtfTraceSourceAlign} htfAlignB={htfAligned}");
+                    }
+                }
                 if (candidate.Type == EntryType.Index_Flag && candidate.TriggerConfirmed)
                 {
                     _bot.Print(
@@ -205,6 +230,12 @@ namespace GeminiV26.Core
                     && candidate.Reason != null
                     && candidate.Reason.Contains("HTF_MISMATCH"))
                 {
+                    _bot.Print(
+                        $"[AUDIT][HTF TRACE][REJECT] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} " +
+                        $"candidateDirection={candidate.Direction} rejectReason={candidate.Reason} " +
+                        $"currentHtfState={routedHtfState} currentAllowedDirection={routedHtfAllowedDirection} " +
+                        $"currentHtfAlign={routedHtfAlign} module={nameof(TradeRouter)}");
+
                     _bot.Print(
                         $"[AUDIT][HTF ROUTER] type={candidate.Type} " +
                         $"reason=HTF_MISMATCH " +
@@ -259,6 +290,16 @@ namespace GeminiV26.Core
             return c != null
                 && c.IsValid
                 && c.TriggerConfirmed;
+        }
+
+        private static bool IsDirectionInterpretationMatch(
+            TradeDirection candidateDirection,
+            TradeDirection sourceAllowedDirection,
+            TradeDirection consumerAllowedDirection)
+        {
+            bool sourceBlocks = sourceAllowedDirection != TradeDirection.None && sourceAllowedDirection != candidateDirection;
+            bool consumerBlocks = consumerAllowedDirection != TradeDirection.None && consumerAllowedDirection != candidateDirection;
+            return sourceBlocks == consumerBlocks;
         }
 
         private static string ResolveRejectReason(EntryEvaluation candidate, int threshold)

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -145,6 +145,13 @@ namespace GeminiV26.EntryTypes.INDEX
             double triggerScore = 0;
             const int maxPenalty = 22;
             bool continuationAuthority = HasContinuationAuthority(ctx, dir);
+            bool sourceHtfAlign = IsAlignedWithAllowedDirection(ctx?.IndexHtfAllowedDirection ?? TradeDirection.None, dir);
+            string sourceHtfState = ctx?.IndexHtfReason ?? "N/A";
+
+            ctx.Log?.Invoke(
+                $"[AUDIT][HTF TRACE][SOURCE] symbol={ctx?.Symbol} entryType={Type} candidateDirection={dir} " +
+                $"rawHtfState={sourceHtfState} allowedDirection={ctx?.IndexHtfAllowedDirection ?? TradeDirection.None} " +
+                $"htfAlign={sourceHtfAlign} sourceModule=IndexHtfBiasEngine");
 
             if (hasHtfMismatch)
             {
@@ -607,7 +614,13 @@ namespace GeminiV26.EntryTypes.INDEX
                 Reason =
                     $"IDX_FLAG_PRO dir={dir} score={score} mult={scoreMultiplier:F2} " +
                     $"fatigue={fatigueCount}/{fatigueThreshold} flagATR={flagAtr:F2} slopeATR={flagSlopeAtr:F2} " +
-                    $"emaATR={distFromEmaAtr:F2} rangeState={(hasValidRange ? "OK" : "FLAG_RANGE_UNKNOWN")}"
+                    $"emaATR={distFromEmaAtr:F2} rangeState={(hasValidRange ? "OK" : "FLAG_RANGE_UNKNOWN")}",
+                HtfTraceSourceStage = "Index_FlagEntry.EvaluateDir",
+                HtfTraceSourceModule = "IndexHtfBiasEngine",
+                HtfTraceSourceState = sourceHtfState,
+                HtfTraceSourceAllowedDirection = ctx?.IndexHtfAllowedDirection ?? TradeDirection.None,
+                HtfTraceSourceAlign = sourceHtfAlign,
+                HtfTraceSourceCandidateDirection = dir
             };
         }
 
@@ -674,6 +687,18 @@ namespace GeminiV26.EntryTypes.INDEX
                 $"ADX={ctx?.Adx_M5:F1} Impulse={hasImpulse} ATR={ctx?.AtrM5:F1}"
             );
 
+            bool sourceHtfAlign = IsAlignedWithAllowedDirection(ctx?.IndexHtfAllowedDirection ?? TradeDirection.None, dir);
+            string sourceHtfState = ctx?.IndexHtfReason ?? "N/A";
+
+            if (!string.IsNullOrWhiteSpace(reason) && reason.Contains("HTF_MISMATCH"))
+            {
+                ctx?.Log?.Invoke(
+                    $"[AUDIT][HTF TRACE][REJECT] symbol={ctx?.Symbol} entryType={EntryType.Index_Flag} candidateDirection={dir} " +
+                    $"rejectReason={reason} currentHtfState={sourceHtfState} " +
+                    $"currentAllowedDirection={ctx?.IndexHtfAllowedDirection ?? TradeDirection.None} " +
+                    $"currentHtfAlign={sourceHtfAlign} module=Index_FlagEntry");
+            }
+
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
@@ -681,8 +706,22 @@ namespace GeminiV26.EntryTypes.INDEX
                 Direction = dir,
                 IsValid = false,
                 Score = Math.Max(0, score),
-                Reason = reason
+                Reason = reason,
+                HtfTraceSourceStage = "Index_FlagEntry.EvaluateDir",
+                HtfTraceSourceModule = "IndexHtfBiasEngine",
+                HtfTraceSourceState = sourceHtfState,
+                HtfTraceSourceAllowedDirection = ctx?.IndexHtfAllowedDirection ?? TradeDirection.None,
+                HtfTraceSourceAlign = sourceHtfAlign,
+                HtfTraceSourceCandidateDirection = dir
             };
+        }
+
+        private static bool IsAlignedWithAllowedDirection(TradeDirection allowedDirection, TradeDirection candidateDirection)
+        {
+            if (candidateDirection == TradeDirection.None)
+                return false;
+
+            return allowedDirection == TradeDirection.None || allowedDirection == candidateDirection;
         }
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)


### PR DESCRIPTION
### Motivation
- Provide minimal, targeted observability to audit HTF truth propagation for Index_Flag candidates without changing trading logic, thresholds, scoring, or architecture. 
- Capture a source-stage HTF snapshot and compare it at router/consumer stages to detect where HTF interpretations diverge and to prove whether multiple HTF truth sources exist.

### Description
- Added audit-only HTF trace fields to `EntryEvaluation` to carry a source-stage snapshot: `HtfTraceSourceStage`, `HtfTraceSourceModule`, `HtfTraceSourceState`, `HtfTraceSourceAllowedDirection`, `HtfTraceSourceAlign`, and `HtfTraceSourceCandidateDirection` (file: `Core/Entry/EntryEvaluation.cs`).
- Instrumented Index source stage (`EntryTypes/INDEX/Index_FlagEntry.cs`) to emit `[AUDIT][HTF TRACE][SOURCE]` logs with runtime Index HTF values and to persist the source snapshot onto every returned `EntryEvaluation` (both valid and reject paths); added `[AUDIT][HTF TRACE][REJECT]` for `HTF_MISMATCH` rejects.
- Instrumented the router consumer (`Core/TradeRouter.cs`) to emit `[AUDIT][HTF TRACE][CONSUMER]` for triggered `Index_Flag` candidates, `[AUDIT][HTF TRACE][REJECT]` when reject reason contains `HTF_MISMATCH`, and `[AUDIT][HTF CONFLICT]` when source vs consumer HTF state/allowed direction/alignment differ; added a small audit-only helper `IsDirectionInterpretationMatch` to detect interpretation mismatches.
- Changes are strictly observability-only: no algorithmic change to scoring, gating, thresholds, or decision flow was made and no architectural refactor applied; all logs use runtime values and explicit module/stage names.

### Testing
- Verified inserted audit log occurrences with repository search (`rg`) to confirm the new `[AUDIT][HTF TRACE]` and `[AUDIT][HTF CONFLICT]` statements are present in `EntryTypes/INDEX/Index_FlagEntry.cs` and `Core/TradeRouter.cs`, and confirmed that `EntryEvaluation` contains the new trace fields.
- Inspected diffs to confirm only instrumentation and diagnostic fields were added and that no trading logic, thresholds, or scoring logic were modified.
- Attempted to run a build/test step but no solution or project files (`*.sln` / `*.csproj`) were present in the repository root in this environment, so an automated build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6e5e9002883289dc1ab507444b77c)