### PR TITLE
Add global HTF authority audit observability logs

### DIFF
--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -844,6 +844,7 @@ namespace GeminiV26.Core.Entry
                 ctx.CryptoHtfAllowedDirection = htf.AllowedDirection;
                 ctx.CryptoHtfConfidence01 = htf.Confidence01;
                 ctx.CryptoHtfReason = htf.Reason;
+                LogHtfAuditFlow(ctx, symbol, InstrumentClass.CRYPTO, htf.State.ToString(), htf.AllowedDirection, htf.Confidence01, htf.Reason);
             }
             else if (isFx)
             {
@@ -851,6 +852,7 @@ namespace GeminiV26.Core.Entry
                 ctx.FxHtfAllowedDirection = htf.AllowedDirection;
                 ctx.FxHtfConfidence01 = htf.Confidence01;
                 ctx.FxHtfReason = htf.Reason;
+                LogHtfAuditFlow(ctx, symbol, InstrumentClass.FX, htf.State.ToString(), htf.AllowedDirection, htf.Confidence01, htf.Reason);
             }
             else if (isIndex)
             {
@@ -858,6 +860,7 @@ namespace GeminiV26.Core.Entry
                 ctx.IndexHtfAllowedDirection = htf.AllowedDirection;
                 ctx.IndexHtfConfidence01 = htf.Confidence01;
                 ctx.IndexHtfReason = htf.Reason;
+                LogHtfAuditFlow(ctx, symbol, InstrumentClass.INDEX, htf.State.ToString(), htf.AllowedDirection, htf.Confidence01, htf.Reason);
             }
             else if (isMetal)
             {
@@ -865,12 +868,33 @@ namespace GeminiV26.Core.Entry
                 ctx.MetalHtfAllowedDirection = htf.AllowedDirection;
                 ctx.MetalHtfConfidence01 = htf.Confidence01;
                 ctx.MetalHtfReason = htf.Reason;
+                LogHtfAuditFlow(ctx, symbol, InstrumentClass.METAL, htf.State.ToString(), htf.AllowedDirection, htf.Confidence01, htf.Reason);
             }
 
             ctx.IsReady = true;
             _bot.Print($"[CTX][MEMORY_READY] symbol={symbol} hasMemory={ctx.HasMemory}");
             LogEntryMemorySnapshot(ctx, symbol);
             return ctx;
+        }
+
+        private void LogHtfAuditFlow(
+            EntryContext ctx,
+            string symbol,
+            InstrumentClass assetClass,
+            string htfState,
+            TradeDirection allowedDirection,
+            double confidence01,
+            string reason)
+        {
+            _bot.Print(
+                $"[AUDIT][HTF FLOW][SOURCE] symbol={symbol} asset={assetClass} entryType=N/A stage=SOURCE module={assetClass}HtfBiasEngine " +
+                $"htfState={htfState} allowedDirection={allowedDirection} align=false candidateDirection=None");
+            _bot.Print(
+                $"[AUDIT][HTF FLOW][CONTEXT_BUILD] symbol={symbol} asset={assetClass} entryType=N/A stage={nameof(EntryContextBuilder)} module={nameof(EntryContextBuilder)} " +
+                $"htfState={htfState} allowedDirection={allowedDirection} align=false candidateDirection=None htfConfidence={confidence01:0.00}");
+            _bot.Print(
+                $"[AUDIT][HTF CONTEXT] symbol={symbol} asset={assetClass} allowedDirection={allowedDirection} confidence={confidence01:0.00} reason={reason ?? "N/A"} " +
+                $"legacyDirection={ctx.HtfDirection} legacyConfidence={ctx.HtfConfidence:0.00}");
         }
 
         private void AttachMemorySnapshot(EntryContext ctx, string canonicalSymbol)

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1168,6 +1168,7 @@ namespace GeminiV26.Core
             foreach (var e in symbolSignals)
             {
                 _bot.Print(TradeLogIdentity.WithTempId($"[DIR][ROUTER_CAND] sym={_bot.SymbolName} type={e?.Type} valid={e?.IsValid} score={e?.Score} dir={e?.Direction} reason={e?.Reason}", _ctx));
+                LogHtfFlowStage(_ctx, e, "ENTRY_EVALUATION", "_entryRouter.Evaluate");
             }
 
         // =====================================================
@@ -1216,9 +1217,13 @@ namespace GeminiV26.Core
             _bot.Print(TradeLogIdentity.WithTempId($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}", _ctx));
             ApplyHtfBiasScoreOnly(symbolSignals, bias, "INDEX");
         }
+                foreach (var e in symbolSignals)
+                    LogHtfFlowStage(_ctx, e, "ENTRY_FILTER", nameof(ApplyHtfBiasScoreOnly));
 
                 UpdateExecutionStateMachine(_ctx, symbolSignals);
                 ApplyRestartProtection(_ctx, symbolSignals);
+                foreach (var e in symbolSignals)
+                    LogHtfFlowStage(_ctx, e, "ENTRY_FILTER", nameof(ApplyRestartProtection));
 
                 // =====================================================
                 // ROUTER
@@ -1226,6 +1231,8 @@ namespace GeminiV26.Core
                 var selected = _router.SelectEntry(symbolSignals, _ctx);
 
                 _bot.Print($"[TRACE] selected is null = {selected == null}");
+                if (selected != null)
+                    LogHtfFlowStage(_ctx, selected, "ROUTER_CONSUME", nameof(TradeRouter.SelectEntry));
 
                 if (selected == null)
                 {
@@ -1286,12 +1293,14 @@ namespace GeminiV26.Core
 
                 if (!PassFinalAcceptance(_ctx, selected))
                 {
+                    LogHtfFlowStage(_ctx, selected, "FINAL_DECISION", nameof(PassFinalAcceptance));
                     _bot.Print("BLOCK: final acceptance gate");
                     return;
                 }
 
                 _ctx.RoutedDirection = selected.Direction;
                 _ctx.FinalDirection = selected.Direction;
+                LogHtfFlowStage(_ctx, selected, "FINAL_DECISION", "DirectionSet");
                 _bot.Print(TradeLogIdentity.WithTempId($"[DIR][SET] sym={_ctx.Symbol} finalDir={_ctx.FinalDirection}", _ctx));
 
                 if (_ctx.FinalDirection == TradeDirection.None)
@@ -2780,6 +2789,66 @@ namespace GeminiV26.Core
             if (instrumentClass == InstrumentClass.METAL) return ctx.MetalHtfAllowedDirection;
             if (instrumentClass == InstrumentClass.INDEX) return ctx.IndexHtfAllowedDirection;
             return TradeDirection.None;
+        }
+
+        private double ResolveHtfConfidence(EntryContext ctx)
+        {
+            if (ctx == null)
+                return 0.0;
+
+            var instrumentClass = SymbolRouting.ResolveInstrumentClass(SymbolRouting.NormalizeSymbol(ctx.Symbol));
+            if (instrumentClass == InstrumentClass.FX) return ctx.FxHtfConfidence01;
+            if (instrumentClass == InstrumentClass.CRYPTO) return ctx.CryptoHtfConfidence01;
+            if (instrumentClass == InstrumentClass.METAL) return ctx.MetalHtfConfidence01;
+            if (instrumentClass == InstrumentClass.INDEX) return ctx.IndexHtfConfidence01;
+            return 0.0;
+        }
+
+        private string ResolveHtfState(EntryContext ctx)
+        {
+            if (ctx == null)
+                return "N/A";
+
+            var instrumentClass = SymbolRouting.ResolveInstrumentClass(SymbolRouting.NormalizeSymbol(ctx.Symbol));
+            if (instrumentClass == InstrumentClass.FX) return ctx.FxHtfReason ?? "N/A";
+            if (instrumentClass == InstrumentClass.CRYPTO) return ctx.CryptoHtfReason ?? "N/A";
+            if (instrumentClass == InstrumentClass.METAL) return ctx.MetalHtfReason ?? "N/A";
+            if (instrumentClass == InstrumentClass.INDEX) return ctx.IndexHtfReason ?? "N/A";
+            return "N/A";
+        }
+
+        private void LogHtfFlowStage(EntryContext ctx, EntryEvaluation candidate, string stageName, string module)
+        {
+            if (ctx == null || candidate == null)
+                return;
+
+            var allowed = ResolveHtfAllowedDirection(ctx);
+            string state = ResolveHtfState(ctx);
+            string asset = SymbolRouting.ResolveInstrumentClass(SymbolRouting.NormalizeSymbol(ctx.Symbol)).ToString();
+            bool align = candidate.Direction != TradeDirection.None && (allowed == TradeDirection.None || allowed == candidate.Direction);
+
+            _bot.Print(
+                $"[AUDIT][HTF FLOW][{stageName}] symbol={ctx.Symbol} asset={asset} entryType={candidate.Type} stage={stageName} module={module} " +
+                $"htfState={state} allowedDirection={allowed} align={align} candidateDirection={candidate.Direction}");
+
+            if (ctx.HtfDirection != allowed || Math.Abs(ctx.HtfConfidence - ResolveHtfConfidence(ctx)) > 0.0001)
+            {
+                bool legacyAlign = candidate.Direction != TradeDirection.None && (ctx.HtfDirection == TradeDirection.None || ctx.HtfDirection == candidate.Direction);
+                _bot.Print(
+                    $"[AUDIT][HTF CONFLICT][GLOBAL] symbol={ctx.Symbol} asset={asset} entryType={candidate.Type} stageA={stageName}_ASSET stageB={stageName}_LEGACY " +
+                    $"stateA={state} stateB=LEGACY_AGG allowedDirA={allowed} allowedDirB={ctx.HtfDirection} htfAlignA={align} htfAlignB={legacyAlign} interpretationMismatch=true");
+            }
+
+            string reason = $"{candidate.Reason} {candidate.RejectReason}";
+            if (!string.IsNullOrWhiteSpace(reason) && reason.Contains("HTF_MISMATCH"))
+            {
+                bool trueDirectionMismatch = allowed != TradeDirection.None
+                    && candidate.Direction != TradeDirection.None
+                    && candidate.Direction != allowed;
+                _bot.Print(
+                    $"[AUDIT][HTF REJECT ANALYSIS] symbol={ctx.Symbol} asset={asset} entryType={candidate.Type} candidateDirection={candidate.Direction} " +
+                    $"htfAllowedDirection={allowed} htfState={state} align={align} rejectModule={module} trueDirectionMismatch={(trueDirectionMismatch ? "YES" : "NO")}");
+            }
         }
 
         private static TradeDirection FromTradeType(TradeType tradeType)

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -155,6 +155,11 @@ namespace GeminiV26.Core
                 bool routedHtfAlign = candidate.Direction == TradeDirection.None
                     ? false
                     : routedHtfAllowedDirection == TradeDirection.None || candidate.Direction == routedHtfAllowedDirection;
+                string assetClass = SymbolRouting.ResolveInstrumentClass(candidate.Symbol ?? _bot.SymbolName).ToString();
+                bool legacyHtfAlign = entryContext == null
+                    ? false
+                    : candidate.Direction != TradeDirection.None
+                        && (entryContext.HtfDirection == TradeDirection.None || candidate.Direction == entryContext.HtfDirection);
                 bool continuationValid = !IsContinuationSetup(candidate.Type)
                     || (entryContext?.MarketState?.IsTrend == true && candidate.Direction == entryContext.TrendDirection);
                 bool pullbackValid = candidate.Direction == TradeDirection.Long
@@ -172,6 +177,25 @@ namespace GeminiV26.Core
                     $"continuation={continuationValid} " +
                     $"pullback={pullbackValid} " +
                     $"breakout={breakoutValid}");
+                _bot.Print(
+                    $"[AUDIT][HTF FLOW][ROUTER_CONSUME] symbol={candidate.Symbol ?? _bot.SymbolName} asset={assetClass} entryType={candidate.Type} " +
+                    $"stage={nameof(TradeRouter)} module={nameof(TradeRouter)} htfState={routedHtfState} allowedDirection={routedHtfAllowedDirection} " +
+                    $"align={routedHtfAlign} candidateDirection={candidate.Direction}");
+                _bot.Print(
+                    $"[AUDIT][HTF ROUTER] asset={assetClass} symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} " +
+                    $"routerHtfState={routedHtfState} routerAllowedDirection={routedHtfAllowedDirection} routerAlign={routedHtfAlign} " +
+                    $"sourceHtfState={candidate.HtfTraceSourceState ?? "N/A"} sourceAllowedDirection={candidate.HtfTraceSourceAllowedDirection} " +
+                    $"sourceAlign={candidate.HtfTraceSourceAlign} divergence={(!string.Equals(candidate.HtfTraceSourceState ?? "N/A", routedHtfState ?? "N/A", StringComparison.Ordinal) || candidate.HtfTraceSourceAllowedDirection != routedHtfAllowedDirection || candidate.HtfTraceSourceAlign != routedHtfAlign)}");
+                if (entryContext != null &&
+                    (entryContext.HtfDirection != routedHtfAllowedDirection
+                     || Math.Abs(entryContext.HtfConfidence - ResolveAssetHtfConfidence(entryContext, assetClass)) > 0.0001))
+                {
+                    _bot.Print(
+                        $"[AUDIT][HTF CONFLICT][GLOBAL] symbol={candidate.Symbol ?? _bot.SymbolName} asset={assetClass} entryType={candidate.Type} " +
+                        $"stageA=EntryContext.Legacy stageB=EntryContext.AssetSpecific stateA=LEGACY_AGG stateB={routedHtfState} " +
+                        $"allowedDirA={entryContext.HtfDirection} allowedDirB={routedHtfAllowedDirection} " +
+                        $"htfAlignA={legacyHtfAlign} htfAlignB={routedHtfAlign} interpretationMismatch=true");
+                }
                 if (candidate.Type == EntryType.Index_Flag && candidate.TriggerConfirmed)
                 {
                     _bot.Print(
@@ -243,6 +267,17 @@ namespace GeminiV26.Core
                         $"allowedDir={routedHtfAllowedDirection} " +
                         $"candidateDir={candidate.Direction}");
                 }
+                string rejectText = $"{candidate.Reason} {candidate.RejectReason}";
+                if (!string.IsNullOrWhiteSpace(rejectText) && rejectText.Contains("HTF_MISMATCH"))
+                {
+                    bool trueDirectionMismatch = routedHtfAllowedDirection != TradeDirection.None
+                        && candidate.Direction != TradeDirection.None
+                        && candidate.Direction != routedHtfAllowedDirection;
+                    _bot.Print(
+                        $"[AUDIT][HTF REJECT ANALYSIS] symbol={candidate.Symbol ?? _bot.SymbolName} asset={assetClass} entryType={candidate.Type} " +
+                        $"candidateDirection={candidate.Direction} htfAllowedDirection={routedHtfAllowedDirection} htfState={routedHtfState} " +
+                        $"align={routedHtfAlign} rejectModule={nameof(TradeRouter)} trueDirectionMismatch={(trueDirectionMismatch ? "YES" : "NO")}");
+                }
                 _bot.Print(TradeLogIdentity.WithTempId(
                     $"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} side={candidate.Direction} " +
                     $"rawValid={candidate.RawValid.ToString().ToLowerInvariant()} finalValid={candidate.FinalValid.ToString().ToLowerInvariant()} " +
@@ -283,6 +318,26 @@ namespace GeminiV26.Core
             _bot.Print(TradeLogIdentity.WithTempId($"[ACCEPT] type={winner.Type} dir={winner.Direction} score={winner.Score} reason={winner.Reason}", entryContext));
             _bot.Print(TradeLogIdentity.WithTempId($"[TR] WINNER: {winner.Type} dir={winner.Direction} score={winner.Score} valid={winner.IsValid} reason={winner.Reason}", entryContext));
             return winner;
+        }
+
+        private static double ResolveAssetHtfConfidence(EntryContext ctx, string assetClass)
+        {
+            if (ctx == null)
+                return 0.0;
+
+            switch (assetClass)
+            {
+                case nameof(InstrumentClass.FX):
+                    return ctx.FxHtfConfidence01;
+                case nameof(InstrumentClass.CRYPTO):
+                    return ctx.CryptoHtfConfidence01;
+                case nameof(InstrumentClass.METAL):
+                    return ctx.MetalHtfConfidence01;
+                case nameof(InstrumentClass.INDEX):
+                    return ctx.IndexHtfConfidence01;
+                default:
+                    return 0.0;
+            }
         }
 
         private static bool IsExecutable(EntryEvaluation c)


### PR DESCRIPTION
### Motivation
- Provide targeted, non-invasive observability to prove whether a single HTF authority exists and where HTF divergence occurs across FX / INDEX / METAL / CRYPTO. 
- Do full-system HTF authority auditing without changing trading logic, thresholds, penalties or architecture. 
- Emit structured audit traces per pipeline stage to classify `HTF_MISMATCH` rejections and detect legacy vs asset-specific interpretation drift.

### Description
- Added source & context audit prints in `EntryContextBuilder` to log `[AUDIT][HTF FLOW][SOURCE]`, `[AUDIT][HTF FLOW][CONTEXT_BUILD]` and a summary `[AUDIT][HTF CONTEXT]` when each asset-specific HTF snapshot is injected (FX/INDEX/METAL/CRYPTO), implemented in `Core/Entry/EntryContextBuilder.cs` via `LogHtfAuditFlow` and calls at dispatch. 
- Added pipeline-stage HTF flow logging and conflict analysis helpers in `TradeCore` (`LogHtfFlowStage`, `ResolveHtfState`, `ResolveHtfConfidence`) and placed calls at `ENTRY_EVALUATION`, `ENTRY_FILTER`, `ROUTER_CONSUME` and `FINAL_DECISION` to capture asset-specific allowed direction, align flags, and legacy-aggregate differences. 
- Extended `TradeRouter` to emit `[AUDIT][HTF FLOW][ROUTER_CONSUME]`, `[AUDIT][HTF ROUTER]`, global conflict detection (`[AUDIT][HTF CONFLICT][GLOBAL]`) and per-reject `HTF_MISMATCH` analysis (`[AUDIT][HTF REJECT ANALYSIS]`) for all candidate types and assets; also added `ResolveAssetHtfConfidence` helper to compare asset vs legacy confidence. 
- All changes are strictly additive logging/diagnostics; no entry decision logic, scoring, thresholds, penalties or behavior were modified. 

### Testing
- Ran repository searches to validate instrumentation locations with `rg` for the new audit tokens and helpers and confirmed matches (searches for `LogHtfFlowStage`, `LogHtfAuditFlow`, `[AUDIT][HTF FLOW]`, `[AUDIT][HTF CONFLICT][GLOBAL]`, `[AUDIT][HTF REJECT ANALYSIS]`, `[AUDIT][HTF ROUTER]`).
- Performed `git diff --check` to ensure no whitespace/format errors and verified working tree was clean after changes. 
- No runtime unit tests were modified or executed; changes are logging-only and observed via static checks above which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6e96a19108328a9f55222fa66c0e4)