### PR TITLE
Fix CRYPTO HTF source snapshot propagation in router audits

### DIFF
--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -156,10 +156,6 @@ namespace GeminiV26.Core
                     ? false
                     : routedHtfAllowedDirection == TradeDirection.None || candidate.Direction == routedHtfAllowedDirection;
                 string assetClass = SymbolRouting.ResolveInstrumentClass(candidate.Symbol ?? _bot.SymbolName).ToString();
-                bool legacyHtfAlign = entryContext == null
-                    ? false
-                    : candidate.Direction != TradeDirection.None
-                        && (entryContext.HtfDirection == TradeDirection.None || candidate.Direction == entryContext.HtfDirection);
                 bool continuationValid = !IsContinuationSetup(candidate.Type)
                     || (entryContext?.MarketState?.IsTrend == true && candidate.Direction == entryContext.TrendDirection);
                 bool pullbackValid = candidate.Direction == TradeDirection.Long
@@ -181,20 +177,46 @@ namespace GeminiV26.Core
                     $"[AUDIT][HTF FLOW][ROUTER_CONSUME] symbol={candidate.Symbol ?? _bot.SymbolName} asset={assetClass} entryType={candidate.Type} " +
                     $"stage={nameof(TradeRouter)} module={nameof(TradeRouter)} htfState={routedHtfState} allowedDirection={routedHtfAllowedDirection} " +
                     $"align={routedHtfAlign} candidateDirection={candidate.Direction}");
+                bool hasSourceSnapshot =
+                    !string.IsNullOrWhiteSpace(candidate.HtfTraceSourceStage)
+                    || !string.IsNullOrWhiteSpace(candidate.HtfTraceSourceModule)
+                    || !string.IsNullOrWhiteSpace(candidate.HtfTraceSourceState);
+                bool divergence = hasSourceSnapshot
+                    && (!string.Equals(candidate.HtfTraceSourceState, routedHtfState, StringComparison.Ordinal)
+                        || candidate.HtfTraceSourceAllowedDirection != routedHtfAllowedDirection
+                        || candidate.HtfTraceSourceAlign != routedHtfAlign);
                 _bot.Print(
                     $"[AUDIT][HTF ROUTER] asset={assetClass} symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} " +
                     $"routerHtfState={routedHtfState} routerAllowedDirection={routedHtfAllowedDirection} routerAlign={routedHtfAlign} " +
                     $"sourceHtfState={candidate.HtfTraceSourceState ?? "N/A"} sourceAllowedDirection={candidate.HtfTraceSourceAllowedDirection} " +
-                    $"sourceAlign={candidate.HtfTraceSourceAlign} divergence={(!string.Equals(candidate.HtfTraceSourceState ?? "N/A", routedHtfState ?? "N/A", StringComparison.Ordinal) || candidate.HtfTraceSourceAllowedDirection != routedHtfAllowedDirection || candidate.HtfTraceSourceAlign != routedHtfAlign)}");
-                if (entryContext != null &&
-                    (entryContext.HtfDirection != routedHtfAllowedDirection
-                     || Math.Abs(entryContext.HtfConfidence - ResolveAssetHtfConfidence(entryContext, assetClass)) > 0.0001))
+                    $"sourceAlign={candidate.HtfTraceSourceAlign} divergence={divergence}");
+                if (assetClass == nameof(InstrumentClass.CRYPTO))
+                {
+                    _bot.Print(
+                        $"[AUDIT][HTF ROUTER][CRYPTO] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} candidateDirection={candidate.Direction} " +
+                        $"sourceHtfState={candidate.HtfTraceSourceState ?? "N/A"} sourceAllowedDirection={candidate.HtfTraceSourceAllowedDirection} sourceAlign={candidate.HtfTraceSourceAlign} " +
+                        $"routedHtfState={routedHtfState} routedAllowedDirection={routedHtfAllowedDirection} routedAlign={routedHtfAlign} divergence={divergence}");
+                }
+                if (!hasSourceSnapshot)
+                {
+                    _bot.Print(
+                        $"[AUDIT][HTF CONFLICT][SKIPPED_NO_SOURCE] symbol={candidate.Symbol ?? _bot.SymbolName} asset={assetClass} entryType={candidate.Type} " +
+                        $"candidateDirection={candidate.Direction} routedState={routedHtfState} routedAllowedDirection={routedHtfAllowedDirection} routedAlign={routedHtfAlign}");
+                }
+                else if (divergence)
                 {
                     _bot.Print(
                         $"[AUDIT][HTF CONFLICT][GLOBAL] symbol={candidate.Symbol ?? _bot.SymbolName} asset={assetClass} entryType={candidate.Type} " +
-                        $"stageA=EntryContext.Legacy stageB=EntryContext.AssetSpecific stateA=LEGACY_AGG stateB={routedHtfState} " +
-                        $"allowedDirA={entryContext.HtfDirection} allowedDirB={routedHtfAllowedDirection} " +
-                        $"htfAlignA={legacyHtfAlign} htfAlignB={routedHtfAlign} interpretationMismatch=true");
+                        $"stageA={candidate.HtfTraceSourceStage ?? "SOURCE"} stageB={nameof(TradeRouter)} stateA={candidate.HtfTraceSourceState ?? "N/A"} stateB={routedHtfState} " +
+                        $"allowedDirA={candidate.HtfTraceSourceAllowedDirection} allowedDirB={routedHtfAllowedDirection} " +
+                        $"htfAlignA={candidate.HtfTraceSourceAlign} htfAlignB={routedHtfAlign}");
+                    if (assetClass == nameof(InstrumentClass.CRYPTO))
+                    {
+                        _bot.Print(
+                            $"[AUDIT][HTF CONFLICT][CRYPTO] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} candidateDirection={candidate.Direction} " +
+                            $"sourceHtfState={candidate.HtfTraceSourceState ?? "N/A"} sourceAllowedDirection={candidate.HtfTraceSourceAllowedDirection} sourceAlign={candidate.HtfTraceSourceAlign} " +
+                            $"routedHtfState={routedHtfState} routedAllowedDirection={routedHtfAllowedDirection} routedAlign={routedHtfAlign}");
+                    }
                 }
                 if (candidate.Type == EntryType.Index_Flag && candidate.TriggerConfirmed)
                 {
@@ -318,26 +340,6 @@ namespace GeminiV26.Core
             _bot.Print(TradeLogIdentity.WithTempId($"[ACCEPT] type={winner.Type} dir={winner.Direction} score={winner.Score} reason={winner.Reason}", entryContext));
             _bot.Print(TradeLogIdentity.WithTempId($"[TR] WINNER: {winner.Type} dir={winner.Direction} score={winner.Score} valid={winner.IsValid} reason={winner.Reason}", entryContext));
             return winner;
-        }
-
-        private static double ResolveAssetHtfConfidence(EntryContext ctx, string assetClass)
-        {
-            if (ctx == null)
-                return 0.0;
-
-            switch (assetClass)
-            {
-                case nameof(InstrumentClass.FX):
-                    return ctx.FxHtfConfidence01;
-                case nameof(InstrumentClass.CRYPTO):
-                    return ctx.CryptoHtfConfidence01;
-                case nameof(InstrumentClass.METAL):
-                    return ctx.MetalHtfConfidence01;
-                case nameof(InstrumentClass.INDEX):
-                    return ctx.IndexHtfConfidence01;
-                default:
-                    return 0.0;
-            }
         }
 
         private static bool IsExecutable(EntryEvaluation c)

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -326,7 +326,7 @@ namespace GeminiV26.EntryTypes.Crypto
             if (score < MinScore)
                 return Invalid(ctx, dir, $"LOW_SCORE({score})", score);
 
-            return new EntryEvaluation
+            var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = EntryType.Crypto_Flag,
@@ -335,20 +335,16 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = true,
                 Reason = $"CR_FLAG_V2 dir={dir} score={score} rangeATR={rangeAtr:F2} rangeState={(hasValidRange ? "OK" : "FLAG_RANGE_UNKNOWN")} flagState={flagState}"
             };
+            ApplyCryptoSourceTrace(ctx, eval, dir);
+            return eval;
         }
 
-        private static EntryEvaluation Invalid(EntryContext ctx, string reason) =>
-            new EntryEvaluation
-            {
-                Symbol = ctx?.Symbol,
-                Type = EntryType.Crypto_Flag,
-                Direction = TradeDirection.None,
-                IsValid = false,
-                Reason = reason
-            };
+        private static EntryEvaluation Invalid(EntryContext ctx, string reason)
+            => Invalid(ctx, TradeDirection.None, reason, 0);
 
-        private static EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason, int score) =>
-            new EntryEvaluation
+        private static EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason, int score)
+        {
+            var eval = new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = EntryType.Crypto_Flag,
@@ -357,6 +353,24 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = false,
                 Reason = reason
             };
+            ApplyCryptoSourceTrace(ctx, eval, dir);
+            return eval;
+        }
+
+        private static void ApplyCryptoSourceTrace(EntryContext ctx, EntryEvaluation evaluation, TradeDirection candidateDirection)
+        {
+            if (evaluation == null)
+                return;
+
+            var sourceAllowedDirection = ctx?.CryptoHtfAllowedDirection ?? TradeDirection.None;
+            evaluation.HtfTraceSourceStage = "SOURCE";
+            evaluation.HtfTraceSourceModule = "CRYPTO_ENTRY";
+            evaluation.HtfTraceSourceState = ctx?.CryptoHtfReason ?? "N/A";
+            evaluation.HtfTraceSourceAllowedDirection = sourceAllowedDirection;
+            evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
+            evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
+            evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
+        }
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -885,7 +885,7 @@ namespace GeminiV26.EntryTypes.Crypto
             if (score < dynamicMinScore)
                 return Block(ctx, $"SCORE_TOO_LOW_{score}_MIN_{dynamicMinScore}", score, dir);
 
-            return new EntryEvaluation
+            var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = EntryType.Crypto_Pullback,
@@ -894,13 +894,15 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = true,
                 Reason = $"BTC_PULLBACK_OK dir={dir} score={score}"
             };
+            ApplyCryptoSourceTrace(ctx, eval, dir);
+            return eval;
         }
 
         private EntryEvaluation Block(EntryContext ctx, string reason, int score, TradeDirection dir = TradeDirection.None)
         {
             Console.WriteLine($"[BTC_PULLBACK][BLOCK] {reason} | dir={dir} | score={score}");
 
-            return new EntryEvaluation
+            var eval = new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = EntryType.Crypto_Pullback,
@@ -909,6 +911,23 @@ namespace GeminiV26.EntryTypes.Crypto
                 Score = score,
                 Reason = reason
             };
+            ApplyCryptoSourceTrace(ctx, eval, dir);
+            return eval;
+        }
+
+        private static void ApplyCryptoSourceTrace(EntryContext ctx, EntryEvaluation evaluation, TradeDirection candidateDirection)
+        {
+            if (evaluation == null)
+                return;
+
+            var sourceAllowedDirection = ctx?.CryptoHtfAllowedDirection ?? TradeDirection.None;
+            evaluation.HtfTraceSourceStage = "SOURCE";
+            evaluation.HtfTraceSourceModule = "CRYPTO_ENTRY";
+            evaluation.HtfTraceSourceState = ctx?.CryptoHtfReason ?? "N/A";
+            evaluation.HtfTraceSourceAllowedDirection = sourceAllowedDirection;
+            evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
+            evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
+            evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
         }
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -91,7 +91,7 @@ namespace GeminiV26.EntryTypes.Crypto
             // BREAK STRENGTH
             // =========================
             if (ctx.RangeBreakAtrSize_M5 > 1.2)
-                return Invalid(ctx, "OVEREXTENDED_BREAK");
+                return Invalid(ctx, "OVEREXTENDED_BREAK", dir, 0);
 
             score += 10;
 
@@ -143,25 +143,23 @@ namespace GeminiV26.EntryTypes.Crypto
         }
 
         private static EntryEvaluation NewEval(EntryContext ctx, TradeDirection dir)
-            => new EntryEvaluation
+        {
+            var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = EntryType.Crypto_RangeBreakout,
                 Direction = dir
             };
+            ApplyCryptoSourceTrace(ctx, eval, dir);
+            return eval;
+        }
 
         private static EntryEvaluation Invalid(EntryContext ctx, string reason)
-            => new EntryEvaluation
-            {
-                Symbol = ctx?.Symbol,
-                Type = EntryType.Crypto_RangeBreakout,
-                Direction = TradeDirection.None,
-                IsValid = false,
-                Reason = reason + ";"
-            };
+            => Invalid(ctx, reason, TradeDirection.None, 0);
 
         private static EntryEvaluation Invalid(EntryContext ctx, string reason, TradeDirection dir, int score)
-            => new EntryEvaluation
+        {
+            var eval = new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = EntryType.Crypto_RangeBreakout,
@@ -170,6 +168,24 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = false,
                 Reason = reason + ";"
             };
+            ApplyCryptoSourceTrace(ctx, eval, dir);
+            return eval;
+        }
+
+        private static void ApplyCryptoSourceTrace(EntryContext ctx, EntryEvaluation evaluation, TradeDirection candidateDirection)
+        {
+            if (evaluation == null)
+                return;
+
+            var sourceAllowedDirection = ctx?.CryptoHtfAllowedDirection ?? TradeDirection.None;
+            evaluation.HtfTraceSourceStage = "SOURCE";
+            evaluation.HtfTraceSourceModule = "CRYPTO_ENTRY";
+            evaluation.HtfTraceSourceState = ctx?.CryptoHtfReason ?? "N/A";
+            evaluation.HtfTraceSourceAllowedDirection = sourceAllowedDirection;
+            evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
+            evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
+            evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
+        }
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -76,7 +76,7 @@ namespace GeminiV26.EntryTypes.Crypto
             if (score < MinScore)
                 return Invalid(ctx, $"LOW_SCORE_{dir}_{score}", dir, score);
 
-            return new EntryEvaluation
+            var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
@@ -85,13 +85,16 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = true,
                 Reason = $"CRYPTO_IMPULSE dir={dir} score={score}"
             };
+            ApplyCryptoSourceTrace(ctx, eval, dir);
+            return eval;
         }
 
         private EntryEvaluation Invalid(EntryContext ctx, string reason)
             => Invalid(ctx, reason, TradeDirection.None, 0);
 
         private EntryEvaluation Invalid(EntryContext ctx, string reason, TradeDirection dir, int score)
-            => new EntryEvaluation
+        {
+            var eval = new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
@@ -100,6 +103,24 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = false,
                 Reason = reason
             };
+            ApplyCryptoSourceTrace(ctx, eval, dir);
+            return eval;
+        }
+
+        private static void ApplyCryptoSourceTrace(EntryContext ctx, EntryEvaluation evaluation, TradeDirection candidateDirection)
+        {
+            if (evaluation == null)
+                return;
+
+            var sourceAllowedDirection = ctx?.CryptoHtfAllowedDirection ?? TradeDirection.None;
+            evaluation.HtfTraceSourceStage = "SOURCE";
+            evaluation.HtfTraceSourceModule = "CRYPTO_ENTRY";
+            evaluation.HtfTraceSourceState = ctx?.CryptoHtfReason ?? "N/A";
+            evaluation.HtfTraceSourceAllowedDirection = sourceAllowedDirection;
+            evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
+            evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
+            evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
+        }
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
         {


### PR DESCRIPTION
### Motivation
- Improve observability so CRYPTO HTF source snapshot from entry evaluators is visible end‑to‑end and router audit logs use the real source values instead of defaults.
- This change is audit/observability only and must not alter trading logic, thresholds, scoring, penalties or entry/exit behavior.

### Description
- Populate audit-only HTF trace fields on crypto entry evaluations using CRYPTO-specific context (`CryptoHtfReason`, `CryptoHtfAllowedDirection`, `CryptoHtfConfidence01`) for both valid and reject paths in `BTC_FlagEntry`, `BTC_PullbackEntry`, `BTC_RangeBreakoutEntry`, and `Crypto_ImpulseEntry` by adding `ApplyCryptoSourceTrace` helpers and calling them before returns.
- Ensure `BTC_RangeBreakoutEntry` invalid path preserves candidate direction for the `OVEREXTENDED_BREAK` rejection and stamps the source trace there as well.
- Update `Core/TradeRouter.cs` audit logging to read source snapshot directly from `candidate.HtfTraceSource*` fields (do not recompute), only evaluate divergence when a source snapshot is present, and add clearer logs: `[AUDIT][HTF CONFLICT][SKIPPED_NO_SOURCE]`, `[AUDIT][HTF ROUTER][CRYPTO]`, and `[AUDIT][HTF CONFLICT][CRYPTO]`.
- Confirmed `EntryEvaluation` already contains the HTF trace fields so no schema changes were required and the same `EntryEvaluation` instances travel through EntryRouter → TradeCore → TradeRouter unchanged.

### Testing
- Attempted to build with `dotnet build -v minimal` but the environment does not have the `dotnet` CLI installed, so the build could not be run (`/bin/bash: dotnet: command not found`).
- Static verification: repository changes committed and files updated (`BTC_FlagEntry`, `BTC_PullbackEntry`, `BTC_RangeBreakoutEntry`, `Crypto_ImpulseEntry`, `Core/TradeRouter.cs`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c705d773408328ade312bceec4ab51)