### PR TITLE
Refine HTF reject classification for no-direction candidates

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2842,13 +2842,35 @@ namespace GeminiV26.Core
             string reason = $"{candidate.Reason} {candidate.RejectReason}";
             if (!string.IsNullOrWhiteSpace(reason) && reason.Contains("HTF_MISMATCH"))
             {
-                bool trueDirectionMismatch = allowed != TradeDirection.None
-                    && candidate.Direction != TradeDirection.None
-                    && candidate.Direction != allowed;
+                bool trueDirectionMismatch = IsTrueDirectionMismatch(candidate.Direction, allowed);
+                bool noDirectionCase = candidate.Direction == TradeDirection.None;
+                string htfClassification = ResolveHtfRejectClassification(align, trueDirectionMismatch, noDirectionCase);
                 _bot.Print(
                     $"[AUDIT][HTF REJECT ANALYSIS] symbol={ctx.Symbol} asset={asset} entryType={candidate.Type} candidateDirection={candidate.Direction} " +
-                    $"htfAllowedDirection={allowed} htfState={state} align={align} rejectModule={module} trueDirectionMismatch={(trueDirectionMismatch ? "YES" : "NO")}");
+                    $"htfAllowedDirection={allowed} htfState={state} align={align} trueDirectionMismatch={(trueDirectionMismatch ? "YES" : "NO")} " +
+                    $"classification={htfClassification} rejectModule={module}");
             }
+        }
+
+        private static bool IsTrueDirectionMismatch(TradeDirection candidateDirection, TradeDirection allowedDirection)
+        {
+            return candidateDirection != TradeDirection.None
+                && allowedDirection != TradeDirection.None
+                && candidateDirection != allowedDirection;
+        }
+
+        private static string ResolveHtfRejectClassification(bool align, bool trueDirectionMismatch, bool noDirectionCase)
+        {
+            if (trueDirectionMismatch)
+                return "HTF_MISMATCH";
+
+            if (noDirectionCase)
+                return "HTF_NO_DIRECTION";
+
+            if (!align)
+                return "HTF_NOT_ALIGNED";
+
+            return "HTF_NOT_ALIGNED";
         }
 
         private static TradeDirection FromTradeType(TradeType tradeType)

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -276,6 +276,10 @@ namespace GeminiV26.Core
                     && candidate.Reason != null
                     && candidate.Reason.Contains("HTF_MISMATCH"))
                 {
+                    bool trueDirectionMismatch = IsTrueDirectionMismatch(candidate.Direction, routedHtfAllowedDirection);
+                    bool noDirectionCase = candidate.Direction == TradeDirection.None;
+                    string htfClassification = ResolveHtfRejectClassification(routedHtfAlign, trueDirectionMismatch, noDirectionCase);
+
                     _bot.Print(
                         $"[AUDIT][HTF TRACE][REJECT] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} " +
                         $"candidateDirection={candidate.Direction} rejectReason={candidate.Reason} " +
@@ -284,7 +288,7 @@ namespace GeminiV26.Core
 
                     _bot.Print(
                         $"[AUDIT][HTF ROUTER] type={candidate.Type} " +
-                        $"reason=HTF_MISMATCH " +
+                        $"reason={htfClassification} " +
                         $"biasState={routedHtfState} " +
                         $"allowedDir={routedHtfAllowedDirection} " +
                         $"candidateDir={candidate.Direction}");
@@ -292,13 +296,14 @@ namespace GeminiV26.Core
                 string rejectText = $"{candidate.Reason} {candidate.RejectReason}";
                 if (!string.IsNullOrWhiteSpace(rejectText) && rejectText.Contains("HTF_MISMATCH"))
                 {
-                    bool trueDirectionMismatch = routedHtfAllowedDirection != TradeDirection.None
-                        && candidate.Direction != TradeDirection.None
-                        && candidate.Direction != routedHtfAllowedDirection;
+                    bool trueDirectionMismatch = IsTrueDirectionMismatch(candidate.Direction, routedHtfAllowedDirection);
+                    bool noDirectionCase = candidate.Direction == TradeDirection.None;
+                    string htfClassification = ResolveHtfRejectClassification(routedHtfAlign, trueDirectionMismatch, noDirectionCase);
                     _bot.Print(
                         $"[AUDIT][HTF REJECT ANALYSIS] symbol={candidate.Symbol ?? _bot.SymbolName} asset={assetClass} entryType={candidate.Type} " +
                         $"candidateDirection={candidate.Direction} htfAllowedDirection={routedHtfAllowedDirection} htfState={routedHtfState} " +
-                        $"align={routedHtfAlign} rejectModule={nameof(TradeRouter)} trueDirectionMismatch={(trueDirectionMismatch ? "YES" : "NO")}");
+                        $"align={routedHtfAlign} trueDirectionMismatch={(trueDirectionMismatch ? "YES" : "NO")} " +
+                        $"classification={htfClassification} rejectModule={nameof(TradeRouter)}");
                 }
                 _bot.Print(TradeLogIdentity.WithTempId(
                     $"[ENTRY DECISION] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} side={candidate.Direction} " +
@@ -357,6 +362,27 @@ namespace GeminiV26.Core
             bool sourceBlocks = sourceAllowedDirection != TradeDirection.None && sourceAllowedDirection != candidateDirection;
             bool consumerBlocks = consumerAllowedDirection != TradeDirection.None && consumerAllowedDirection != candidateDirection;
             return sourceBlocks == consumerBlocks;
+        }
+
+        private static bool IsTrueDirectionMismatch(TradeDirection candidateDirection, TradeDirection allowedDirection)
+        {
+            return candidateDirection != TradeDirection.None
+                && allowedDirection != TradeDirection.None
+                && candidateDirection != allowedDirection;
+        }
+
+        private static string ResolveHtfRejectClassification(bool align, bool trueDirectionMismatch, bool noDirectionCase)
+        {
+            if (trueDirectionMismatch)
+                return "HTF_MISMATCH";
+
+            if (noDirectionCase)
+                return "HTF_NO_DIRECTION";
+
+            if (!align)
+                return "HTF_NOT_ALIGNED";
+
+            return "HTF_NOT_ALIGNED";
         }
 
         private static string ResolveRejectReason(EntryEvaluation candidate, int threshold)


### PR DESCRIPTION
### Motivation
- Prevent false `HTF_MISMATCH` audit labels when `candidateDirection` is `None` and ensure `HTF_MISMATCH` denotes a true opposite-direction conflict only.
- Keep all trading decisions, thresholds and rejection behavior unchanged while improving HTF classification and audit clarity.
- Provide clearer audit output to distinguish real directional conflict, no-direction cases, and generic alignment issues.

### Description
- Added `IsTrueDirectionMismatch` and `ResolveHtfRejectClassification` helpers and wired them into `Core/TradeRouter.cs` to compute a classification (`HTF_MISMATCH`, `HTF_NO_DIRECTION`, `HTF_NOT_ALIGNED`) instead of always using `HTF_MISMATCH` in router audit messages.
- Applied the same classification logic and improved `[AUDIT][HTF REJECT ANALYSIS]` logs in `Core/TradeCore.cs` to include `candidateDirection`, `htfAllowedDirection`, `align`, `trueDirectionMismatch` and `classification` fields.
- Left all CRYPTO entry-side HTF guards and reject behavior intact (no changes to `EntryTypes/CRYPTO/*` decision logic), so runtime trading behavior is unchanged.
- Only labels/audit strings and additional derived fields were changed; no thresholds, filters or entry/exit logic were modified.

### Testing
- Ran pattern searches with `rg` to find HTF-related checks and verify affected files, which returned the expected locations (success).
- Inspected diffs (`git diff`) and file snippets to confirm new helper functions and updated log lines were inserted in `Core/TradeRouter.cs` and `Core/TradeCore.cs` (success).
- Attempted a build with `dotnet build` in the environment, but the build could not run because `dotnet` is not installed in this container (failure due to environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c79e35ef348328a2af78e0e4788fa5)