### PR TITLE
Enforce asset-scoped HTF SSOT, add NOT_READY lifecycle and HTF source-trace consumption

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -3,6 +3,7 @@ using cAlgo.API.Internals;
 using Gemini.Memory;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Instruments.INDEX;
+using GeminiV26.Core;
 using GeminiV26.Core.Matrix;
 using GeminiV26.Core.Logging;
 using System;
@@ -374,6 +375,26 @@ namespace GeminiV26.Core.Entry
 
                 return maxConfidence;
             }
+        }
+
+        public TradeDirection ResolveAssetHtfAllowedDirection()
+        {
+            var instrumentClass = SymbolRouting.ResolveInstrumentClass(SymbolRouting.NormalizeSymbol(Symbol));
+            if (instrumentClass == InstrumentClass.FX) return FxHtfAllowedDirection;
+            if (instrumentClass == InstrumentClass.CRYPTO) return CryptoHtfAllowedDirection;
+            if (instrumentClass == InstrumentClass.METAL) return MetalHtfAllowedDirection;
+            if (instrumentClass == InstrumentClass.INDEX) return IndexHtfAllowedDirection;
+            return TradeDirection.None;
+        }
+
+        public double ResolveAssetHtfConfidence01()
+        {
+            var instrumentClass = SymbolRouting.ResolveInstrumentClass(SymbolRouting.NormalizeSymbol(Symbol));
+            if (instrumentClass == InstrumentClass.FX) return FxHtfConfidence01;
+            if (instrumentClass == InstrumentClass.CRYPTO) return CryptoHtfConfidence01;
+            if (instrumentClass == InstrumentClass.METAL) return MetalHtfConfidence01;
+            if (instrumentClass == InstrumentClass.INDEX) return IndexHtfConfidence01;
+            return 0.0;
         }
 
         public string SymbolName => Symbol;

--- a/Core/HtfBias/CryptoHtfBiasEngine.cs
+++ b/Core/HtfBias/CryptoHtfBiasEngine.cs
@@ -86,7 +86,7 @@ namespace GeminiV26.Core.HtfBias
             {
                 c = new CryptoBiasContext();
                 _ctx[symbolName] = c;
-                SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "CRYPTO_HTF INIT NEUTRAL", 0.0);
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "CRYPTO_HTF NOT_READY INIT", 0.20);
 
                 if (!_runtimeSymbols.TryGetBars(BiasTf, symbolName, out c.H4) ||
                     !_runtimeSymbols.TryGetBars(UpdateTf, symbolName, out c.H1))
@@ -109,11 +109,14 @@ namespace GeminiV26.Core.HtfBias
             }
 
             if (c.H4 == null || c.H1 == null || c.Ema21 == null || c.Ema50 == null || c.Ema200 == null || c.AtrH4 == null || c.Dms == null)
+            {
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "CRYPTO_HTF NOT_READY NULL_INDICATOR", 0.20);
                 return;
+            }
 
             if (c.H1.Count < 10 || c.H4.Count < EmaAnchor + 8)
             {
-                SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "CRYPTO_HTF NOT_READY", 0.0);
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "CRYPTO_HTF NOT_READY INSUFFICIENT_DATA", 0.20);
                 return;
             }
 
@@ -130,7 +133,7 @@ namespace GeminiV26.Core.HtfBias
             int i = c.H4.Count - 2;
             if (i < EmaAnchor + 4)
             {
-                SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "CRYPTO_HTF NOT_READY", 0.0);
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "CRYPTO_HTF NOT_READY WARMUP", 0.20);
                 return;
             }
 
@@ -431,9 +434,9 @@ namespace GeminiV26.Core.HtfBias
             _bot.Print($"[RESOLVER][HTF_FAIL] symbol={symbolName} reason=unresolved_runtime_symbol");
             return new HtfBiasSnapshot
             {
-                State = HtfBiasState.Neutral,
+                State = HtfBiasState.NotReady,
                 AllowedDirection = TradeDirection.None,
-                Confidence01 = 0.0,
+                Confidence01 = 0.20,
                 Reason = "HTF_UNAVAILABLE unresolved_runtime_symbol"
             };
         }

--- a/Core/HtfBias/FxHtfBiasEngine.cs
+++ b/Core/HtfBias/FxHtfBiasEngine.cs
@@ -82,7 +82,7 @@ namespace GeminiV26.Core.HtfBias
             {
                 c = new FxBiasContext();
                 _ctx[symbolName] = c;
-                SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "FX_HTF INIT NEUTRAL", 0.50);
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "FX_HTF NOT_READY INIT", 0.20);
 
                 if (!_runtimeSymbols.TryGetBars(BiasTf, symbolName, out c.H4) ||
                     !_runtimeSymbols.TryGetBars(UpdateTf, symbolName, out c.H1))
@@ -96,7 +96,10 @@ namespace GeminiV26.Core.HtfBias
                 }
 
                 if (c.H4.Count < EmaSlow + 8 || c.H1.Count < 10)
+                {
+                    SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "FX_HTF NOT_READY INSUFFICIENT_DATA", 0.20);
                     return;
+                }
 
                 c.Ema50 = _bot.Indicators.ExponentialMovingAverage(c.H4.ClosePrices, EmaFast);
                 c.Ema200 = _bot.Indicators.ExponentialMovingAverage(c.H4.ClosePrices, EmaSlow);
@@ -107,10 +110,16 @@ namespace GeminiV26.Core.HtfBias
             }
 
             if (c.H1 == null || c.H4 == null || c.Ema50 == null || c.Ema200 == null || c.AtrH4 == null || c.Dms == null)
+            {
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "FX_HTF NOT_READY NULL_INDICATOR", 0.20);
                 return;
+            }
 
             if (c.H1.Count < 10 || c.H4.Count < EmaSlow + 8)
+            {
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "FX_HTF NOT_READY INSUFFICIENT_DATA", 0.20);
                 return;
+            }
 
             int h1Closed = c.H1.Count - 2;
             if (h1Closed < 1)
@@ -367,9 +376,9 @@ namespace GeminiV26.Core.HtfBias
             _bot.Print($"[RESOLVER][HTF_FAIL] symbol={symbolName} reason=unresolved_runtime_symbol");
             return new HtfBiasSnapshot
             {
-                State = HtfBiasState.Neutral,
+                State = HtfBiasState.NotReady,
                 AllowedDirection = TradeDirection.None,
-                Confidence01 = 0.0,
+                Confidence01 = 0.20,
                 Reason = "HTF_UNAVAILABLE unresolved_runtime_symbol"
             };
         }

--- a/Core/HtfBias/HtfBiasModels.cs
+++ b/Core/HtfBias/HtfBiasModels.cs
@@ -5,7 +5,8 @@ namespace GeminiV26.Core.HtfBias
         Neutral = 0,
         Bull = 1,
         Bear = 2,
-        Transition = 3
+        Transition = 3,
+        NotReady = 4
     }
 
     public interface IHtfBiasProvider

--- a/Core/HtfBias/IndexHtfBiasEngine.cs
+++ b/Core/HtfBias/IndexHtfBiasEngine.cs
@@ -83,7 +83,7 @@ namespace GeminiV26.Core.HtfBias
                 return c;
 
             c = new IndexBiasContext();
-            SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "INDEX_HTF INIT NEUTRAL", 0.30);
+            SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "INDEX_HTF NOT_READY INIT", 0.20);
             _ctx[symbolName] = c;
 
             if (!_runtimeSymbols.TryGetBars(BiasTf, symbolName, out c.H1) ||
@@ -109,11 +109,14 @@ namespace GeminiV26.Core.HtfBias
         private void UpdateIfNeeded(string symbolName, IndexBiasContext c)
         {
             if (c.H1 == null || c.M15 == null || c.Ema21 == null || c.Ema50 == null || c.Ema200 == null || c.AtrH1 == null || c.Dms == null)
+            {
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "INDEX_HTF NOT_READY NULL_INDICATOR", 0.20);
                 return;
+            }
 
             if (c.M15.Count < 10 || c.H1.Count < EmaAnchor + 12)
             {
-                SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "INDEX_HTF NEUTRAL (insufficient data)", 0.25);
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "INDEX_HTF NOT_READY INSUFFICIENT_DATA", 0.20);
                 return;
             }
 
@@ -134,7 +137,7 @@ namespace GeminiV26.Core.HtfBias
             int i = c.H1.Count - 2;
             if (i < EmaAnchor + 8)
             {
-                SetState(c.Snapshot, HtfBiasState.Neutral, TradeDirection.None, "INDEX_HTF NEUTRAL (warmup)", 0.25);
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "INDEX_HTF NOT_READY WARMUP", 0.20);
                 return;
             }
 
@@ -410,9 +413,9 @@ namespace GeminiV26.Core.HtfBias
             _bot.Print($"[RESOLVER][HTF_FAIL] symbol={symbolName} reason=unresolved_runtime_symbol");
             return new HtfBiasSnapshot
             {
-                State = HtfBiasState.Neutral,
+                State = HtfBiasState.NotReady,
                 AllowedDirection = TradeDirection.None,
-                Confidence01 = 0.0,
+                Confidence01 = 0.20,
                 Reason = "HTF_UNAVAILABLE unresolved_runtime_symbol"
             };
         }

--- a/Core/HtfBias/MetalHtfBiasEngine.cs
+++ b/Core/HtfBias/MetalHtfBiasEngine.cs
@@ -123,10 +123,16 @@ namespace GeminiV26.Core.HtfBias
             }
 
             if (c.M15 == null || c.H1 == null || c.Ema21 == null || c.Ema55 == null || c.AtrH1 == null || c.Dms == null)
+            {
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "METAL_HTF NOT_READY NULL_INDICATOR", 0.20);
                 return;
+            }
 
             if (c.M15.Count < 10 || c.H1.Count < Math.Max(EmaSlow, 80))
+            {
+                SetState(c.Snapshot, HtfBiasState.NotReady, TradeDirection.None, "METAL_HTF NOT_READY INSUFFICIENT_DATA", 0.20);
                 return;
+            }
 
             int m15Closed = c.M15.Count - 2;
             if (m15Closed < 1) return;
@@ -256,9 +262,9 @@ namespace GeminiV26.Core.HtfBias
             _bot.Print($"[RESOLVER][HTF_FAIL] symbol={symbolName} reason=unresolved_runtime_symbol");
             return new HtfBiasSnapshot
             {
-                State = HtfBiasState.Neutral,
+                State = HtfBiasState.NotReady,
                 AllowedDirection = TradeDirection.None,
-                Confidence01 = 0.0,
+                Confidence01 = 0.20,
                 Reason = "HTF_UNAVAILABLE unresolved_runtime_symbol"
             };
         }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1167,6 +1167,7 @@ namespace GeminiV26.Core
 
             foreach (var e in symbolSignals)
             {
+                StampEntrySourceHtfTrace(_ctx, e);
                 _bot.Print(TradeLogIdentity.WithTempId($"[DIR][ROUTER_CAND] sym={_bot.SymbolName} type={e?.Type} valid={e?.IsValid} score={e?.Score} dir={e?.Direction} reason={e?.Reason}", _ctx));
                 LogHtfFlowStage(_ctx, e, "ENTRY_EVALUATION", "_entryRouter.Evaluate");
             }
@@ -2842,9 +2843,10 @@ namespace GeminiV26.Core
             string reason = $"{candidate.Reason} {candidate.RejectReason}";
             if (!string.IsNullOrWhiteSpace(reason) && reason.Contains("HTF_MISMATCH"))
             {
+                bool hasDirection = candidate.Direction != TradeDirection.None;
+                bool hasHtf = allowed != TradeDirection.None;
                 bool trueDirectionMismatch = IsTrueDirectionMismatch(candidate.Direction, allowed);
-                bool noDirectionCase = candidate.Direction == TradeDirection.None;
-                string htfClassification = ResolveHtfRejectClassification(align, trueDirectionMismatch, noDirectionCase);
+                string htfClassification = ResolveHtfRejectClassification(align, trueDirectionMismatch, !hasDirection || !hasHtf);
                 _bot.Print(
                     $"[AUDIT][HTF REJECT ANALYSIS] symbol={ctx.Symbol} asset={asset} entryType={candidate.Type} candidateDirection={candidate.Direction} " +
                     $"htfAllowedDirection={allowed} htfState={state} align={align} trueDirectionMismatch={(trueDirectionMismatch ? "YES" : "NO")} " +
@@ -2861,16 +2863,34 @@ namespace GeminiV26.Core
 
         private static string ResolveHtfRejectClassification(bool align, bool trueDirectionMismatch, bool noDirectionCase)
         {
+            if (!align)
+                return "HTF_NOT_ALIGNED";
+
             if (trueDirectionMismatch)
                 return "HTF_MISMATCH";
 
             if (noDirectionCase)
                 return "HTF_NO_DIRECTION";
 
-            if (!align)
-                return "HTF_NOT_ALIGNED";
+            return "HTF_OK";
+        }
 
-            return "HTF_NOT_ALIGNED";
+        private void StampEntrySourceHtfTrace(EntryContext ctx, EntryEvaluation eval)
+        {
+            if (ctx == null || eval == null)
+                return;
+
+            TradeDirection allowedDirection = ResolveHtfAllowedDirection(ctx);
+            TradeDirection candidateDirection = ctx.LogicBiasDirection;
+            bool align = allowedDirection == candidateDirection;
+
+            eval.HtfTraceSourceStage = "ENTRY_SOURCE";
+            eval.HtfTraceSourceModule = eval.Type.ToString();
+            eval.HtfTraceSourceState = ResolveHtfState(ctx);
+            eval.HtfTraceSourceAllowedDirection = allowedDirection;
+            eval.HtfTraceSourceAlign = align;
+            eval.HtfTraceSourceCandidateDirection = candidateDirection;
+            eval.HtfConfidence01 = ResolveHtfConfidence(ctx);
         }
 
         private static TradeDirection FromTradeType(TradeType tradeType)

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -121,40 +121,12 @@ namespace GeminiV26.Core
 
                 bool structureAligned = IsStructureAligned(entryContext, candidate.Direction);
                 bool hasImpulse = entryContext?.HasImpulse_M5 == true;
-                bool htfAligned = entryContext == null
-                    || entryContext.FxHtfAllowedDirection == TradeDirection.None
-                    || candidate.Direction == TradeDirection.None
-                    || candidate.Direction == entryContext.FxHtfAllowedDirection;
-                TradeDirection consumerAllowedDirection = entryContext?.FxHtfAllowedDirection ?? TradeDirection.None;
-                string consumerHtfState = entryContext?.FxHtfReason ?? "N/A";
-                TradeDirection routedHtfAllowedDirection = TradeDirection.None;
-                string routedHtfState = "N/A";
-                if (entryContext != null)
-                {
-                    var instrumentClass = SymbolRouting.ResolveInstrumentClass(candidate.Symbol ?? _bot.SymbolName);
-                    switch (instrumentClass)
-                    {
-                        case InstrumentClass.FX:
-                            routedHtfAllowedDirection = entryContext.FxHtfAllowedDirection;
-                            routedHtfState = entryContext.FxHtfReason ?? "N/A";
-                            break;
-                        case InstrumentClass.CRYPTO:
-                            routedHtfAllowedDirection = entryContext.CryptoHtfAllowedDirection;
-                            routedHtfState = entryContext.CryptoHtfReason ?? "N/A";
-                            break;
-                        case InstrumentClass.METAL:
-                            routedHtfAllowedDirection = entryContext.MetalHtfAllowedDirection;
-                            routedHtfState = entryContext.MetalHtfReason ?? "N/A";
-                            break;
-                        case InstrumentClass.INDEX:
-                            routedHtfAllowedDirection = entryContext.IndexHtfAllowedDirection;
-                            routedHtfState = entryContext.IndexHtfReason ?? "N/A";
-                            break;
-                    }
-                }
-                bool routedHtfAlign = candidate.Direction == TradeDirection.None
-                    ? false
-                    : routedHtfAllowedDirection == TradeDirection.None || candidate.Direction == routedHtfAllowedDirection;
+                TradeDirection routedHtfAllowedDirection = candidate.HtfTraceSourceAllowedDirection;
+                string routedHtfState = candidate.HtfTraceSourceState ?? "N/A";
+                bool routedHtfAlign = candidate.HtfTraceSourceAlign;
+                bool htfAligned = routedHtfAlign;
+                TradeDirection consumerAllowedDirection = routedHtfAllowedDirection;
+                string consumerHtfState = routedHtfState;
                 string assetClass = SymbolRouting.ResolveInstrumentClass(candidate.Symbol ?? _bot.SymbolName).ToString();
                 bool continuationValid = !IsContinuationSetup(candidate.Type)
                     || (entryContext?.MarketState?.IsTrend == true && candidate.Direction == entryContext.TrendDirection);
@@ -276,9 +248,10 @@ namespace GeminiV26.Core
                     && candidate.Reason != null
                     && candidate.Reason.Contains("HTF_MISMATCH"))
                 {
+                    bool hasDirection = candidate.Direction != TradeDirection.None;
+                    bool hasHtf = routedHtfAllowedDirection != TradeDirection.None;
                     bool trueDirectionMismatch = IsTrueDirectionMismatch(candidate.Direction, routedHtfAllowedDirection);
-                    bool noDirectionCase = candidate.Direction == TradeDirection.None;
-                    string htfClassification = ResolveHtfRejectClassification(routedHtfAlign, trueDirectionMismatch, noDirectionCase);
+                    string htfClassification = ResolveHtfRejectClassification(routedHtfAlign, trueDirectionMismatch, !hasDirection || !hasHtf);
 
                     _bot.Print(
                         $"[AUDIT][HTF TRACE][REJECT] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} " +
@@ -296,9 +269,10 @@ namespace GeminiV26.Core
                 string rejectText = $"{candidate.Reason} {candidate.RejectReason}";
                 if (!string.IsNullOrWhiteSpace(rejectText) && rejectText.Contains("HTF_MISMATCH"))
                 {
+                    bool hasDirection = candidate.Direction != TradeDirection.None;
+                    bool hasHtf = routedHtfAllowedDirection != TradeDirection.None;
                     bool trueDirectionMismatch = IsTrueDirectionMismatch(candidate.Direction, routedHtfAllowedDirection);
-                    bool noDirectionCase = candidate.Direction == TradeDirection.None;
-                    string htfClassification = ResolveHtfRejectClassification(routedHtfAlign, trueDirectionMismatch, noDirectionCase);
+                    string htfClassification = ResolveHtfRejectClassification(routedHtfAlign, trueDirectionMismatch, !hasDirection || !hasHtf);
                     _bot.Print(
                         $"[AUDIT][HTF REJECT ANALYSIS] symbol={candidate.Symbol ?? _bot.SymbolName} asset={assetClass} entryType={candidate.Type} " +
                         $"candidateDirection={candidate.Direction} htfAllowedDirection={routedHtfAllowedDirection} htfState={routedHtfState} " +
@@ -373,16 +347,16 @@ namespace GeminiV26.Core
 
         private static string ResolveHtfRejectClassification(bool align, bool trueDirectionMismatch, bool noDirectionCase)
         {
-            if (trueDirectionMismatch)
-                return "HTF_MISMATCH";
-
             if (noDirectionCase)
                 return "HTF_NO_DIRECTION";
+
+            if (trueDirectionMismatch)
+                return "HTF_MISMATCH";
 
             if (!align)
                 return "HTF_NOT_ALIGNED";
 
-            return "HTF_NOT_ALIGNED";
+            return "HTF_OK";
         }
 
         private static string ResolveRejectReason(EntryEvaluation candidate, int threshold)
@@ -447,11 +421,16 @@ namespace GeminiV26.Core
                 return true;
 
             eval.IgnoreHTFForDecision = false;
-            eval.HtfConfidence01 = entryContext?.FxHtfConfidence01 ?? 0.0;
-            eval.IsHTFMisaligned = entryContext != null
-                && entryContext.FxHtfAllowedDirection != TradeDirection.None
+            if (string.IsNullOrWhiteSpace(eval.HtfTraceSourceStage))
+            {
+                _bot.Print(
+                    $"[AUDIT][HTF CONFLICT][SKIPPED_NO_SOURCE] symbol={symbol} asset={assetClass} entryType={eval.Type} candidateDirection={eval.Direction}");
+            }
+
+            eval.HtfConfidence01 = Math.Max(0.0, Math.Min(1.0, eval.HtfConfidence01));
+            eval.IsHTFMisaligned = eval.HtfTraceSourceAllowedDirection != TradeDirection.None
                 && eval.Direction != TradeDirection.None
-                && eval.Direction != entryContext.FxHtfAllowedDirection;
+                && eval.Direction != eval.HtfTraceSourceAllowedDirection;
 
             int scoreBeforeTimingBias = eval.Score;
             int thresholdBias = 0;

--- a/EntryTypes/BR_RangeBreakoutEntry.cs
+++ b/EntryTypes/BR_RangeBreakoutEntry.cs
@@ -48,7 +48,7 @@ namespace GeminiV26.EntryTypes
                 return CreateInvalid(ctx, "NoRange;");
             }
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
             {
                 return CreateInvalid(ctx, "HTF_MISMATCH");
             }

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -105,7 +105,7 @@ namespace GeminiV26.EntryTypes.Crypto
 
             var profile = CryptoInstrumentMatrix.Get(ctx.Symbol);
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
                 return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -24,7 +24,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 if (ctx.LogicBias == TradeDirection.None)
                     return Block(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
 
-                if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+                if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
                     return Block(ctx, "HTF_MISMATCH", 0, TradeDirection.None);
 
                 if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -27,7 +27,7 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MIN_RANGE_BARS)
                 return Invalid(ctx, "NO_RANGE");
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
                 return Invalid(ctx, "HTF_MISMATCH", TradeDirection.None, 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -22,7 +22,7 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsVolatilityAcceptable_Crypto)
                 return Invalid(ctx, "CRYPTO_VOL_DISABLED");
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
                 return Invalid(ctx, "HTF_MISMATCH", TradeDirection.None, 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -68,27 +68,27 @@ namespace GeminiV26.EntryTypes.INDEX
             // HTF SOFT HANDLING
             // =============================
             bool htfStrongMismatch =
-                ctx.HtfConfidence >= 0.6 &&
-                ctx.HtfDirection != TradeDirection.None &&
-                ctx.HtfDirection != dir;
+                ctx.ResolveAssetHtfConfidence01() >= 0.6 &&
+                ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None &&
+                ctx.ResolveAssetHtfAllowedDirection() != dir;
 
             bool htfWeakMismatch =
-                ctx.HtfConfidence >= 0.35 &&
-                ctx.HtfConfidence < 0.6 &&
-                ctx.HtfDirection != TradeDirection.None &&
-                ctx.HtfDirection != dir;
+                ctx.ResolveAssetHtfConfidence01() >= 0.35 &&
+                ctx.ResolveAssetHtfConfidence01() < 0.6 &&
+                ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None &&
+                ctx.ResolveAssetHtfAllowedDirection() != dir;
 
             bool htfAligned =
-                ctx.HtfDirection == dir &&
-                ctx.HtfDirection != TradeDirection.None;
+                ctx.ResolveAssetHtfAllowedDirection() == dir &&
+                ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None;
 
             if (htfStrongMismatch)
                 score -= 18;
             else if (htfWeakMismatch)
                 score -= 8;
-            else if (htfAligned && ctx.HtfConfidence >= 0.6)
+            else if (htfAligned && ctx.ResolveAssetHtfConfidence01() >= 0.6)
                 score += 6;
-            else if (htfAligned && ctx.HtfConfidence >= 0.35)
+            else if (htfAligned && ctx.ResolveAssetHtfConfidence01() >= 0.35)
                 score += 3;
 
             // =============================

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -73,7 +73,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 $"minAdx={minAdxTrend:F1} chopAdx={chopAdxThreshold:F1} fatigueTh={fatigueThreshold} scoreMult={scoreMultiplier:F2}"
             );
 
-            bool hasHtfMismatch = ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias;
+            bool hasHtfMismatch = ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias;
 
             if (ctx.LogicBias == TradeDirection.Long)
             {

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -34,7 +34,7 @@ namespace GeminiV26.EntryTypes.INDEX
             if (p == null)
                 return Reject(ctx, TradeDirection.None, 0, "NO_INDEX_PROFILE");
 
-            bool hasHtfMismatch = ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias;
+            bool hasHtfMismatch = ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias;
 
             if (ctx.LogicBias == TradeDirection.Long)
             {

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -83,7 +83,7 @@ namespace GeminiV26.EntryTypes.METAL
                     return Invalid(ctx, "AMBIGUOUS_SPIKE");
             }
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
                 return InvalidDir(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -45,7 +45,7 @@ namespace GeminiV26.EntryTypes.METAL
                     Reason = "NO_LOGIC_BIAS"
                 };
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
                 return new EntryEvaluation
                 {
                     Symbol = ctx?.Symbol,

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -33,7 +33,7 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx.MarketState?.IsTrend != true)
                 return Reject(ctx, "NO_TREND_STATE");
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
                 return Reject(ctx, "HTF_MISMATCH");
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -25,7 +25,7 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx.LogicBias == TradeDirection.None)
                 return RejectDecision(ctx, TradeDirection.None, 0, "NO_LOGIC_BIAS", null);
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
                 return RejectDecision(ctx, TradeDirection.None, 0, "HTF_MISMATCH", null);
 
             if (ctx.LogicBias == TradeDirection.Long)

--- a/EntryTypes/TC_FlagEntry.cs
+++ b/EntryTypes/TC_FlagEntry.cs
@@ -58,7 +58,7 @@ namespace GeminiV26.EntryTypes
                 return CreateInvalid(ctx, "WeakImpulse;");
             }
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
             {
                 return CreateInvalid(ctx, "HTF_MISMATCH");
             }

--- a/EntryTypes/TC_PullbackEntry.cs
+++ b/EntryTypes/TC_PullbackEntry.cs
@@ -39,7 +39,7 @@ namespace GeminiV26.EntryTypes
                 return CreateInvalid(ctx, "NO_LOGIC_BIAS");
             }
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
             {
                 return CreateInvalid(ctx, "HTF_MISMATCH");
             }

--- a/EntryTypes/TR_ReversalEntry.cs
+++ b/EntryTypes/TR_ReversalEntry.cs
@@ -46,7 +46,7 @@ namespace GeminiV26.EntryTypes
                 return CreateInvalid(ctx, $"WeakEvidence({ctx.ReversalEvidenceScore});");
             }
 
-            if (ctx.HtfConfidence >= 0.6 && ctx.HtfDirection != ctx.LogicBias)
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
                 return CreateInvalid(ctx, "HTF_MISMATCH");
 
             if (ctx.LogicBias == TradeDirection.Long)


### PR DESCRIPTION
### Motivation
- Make HTF authority deterministic and asset-scoped (FX/INDEX/METAL/CRYPTO) and eliminate global/aggregate HTF contamination in decision paths. 
- Prevent stale HTF snapshots and unify lifecycle semantics so insufficient data / null indicators explicitly reset HTF to a `NOT_READY` state with low confidence. 
- Ensure router acts as a pure consumer of HTF trace produced by entry evaluation and add mandatory source tracing for auditability.

### Description
- Introduced `HtfBiasState.NotReady` and updated all HTF bias engines (`FxHtfBiasEngine`, `IndexHtfBiasEngine`, `MetalHtfBiasEngine`, `CryptoHtfBiasEngine`) to set `NotReady` + `AllowedDirection=None` + low `Confidence01` when bars/indicators are insufficient or null, and for unavailable snapshots. 
- Added asset-scoped accessor helpers on `EntryContext`: `ResolveAssetHtfAllowedDirection()` and `ResolveAssetHtfConfidence01()`, and replaced legacy `ctx.HtfDirection` / `ctx.HtfConfidence` checks in entry evaluators to use these asset-specific accessors. 
- Stamped an entry-source HTF trace for every `EntryEvaluation` in `TradeCore` (`HtfTraceSourceStage = "ENTRY_SOURCE"`, `HtfTraceSourceModule`, `HtfTraceSourceState`, `HtfTraceSourceAllowedDirection`, `HtfTraceSourceAlign`, `HtfTraceSourceCandidateDirection`, and `HtfConfidence01`) so the router always sees a source snapshot for audit/consumption. 
- Made `TradeRouter` a pure consumer of the HTF source trace: it no longer recomputes or reads cross-asset `ctx.HtfDirection`/`ctx.HtfConfidence`; router logic now uses candidate `HtfTraceSource*` values, logs `[AUDIT][HTF CONFLICT][SKIPPED_NO_SOURCE]` when trace is missing, and classification logic was standardized so `HTF_MISMATCH` is only for true direction conflicts while `HTF_NO_DIRECTION` covers missing/no-direction cases. 

### Testing
- Ran repository scans to validate replacements and trace stamping using ripgrep patterns (checks for removal/usage of `ctx.HtfDirection` / `ctx.HtfConfidence` in decision paths and presence of `ENTRY_SOURCE` stamping); these grep checks succeeded. 
- Verified presence of `HtfBiasState.NotReady` and its usage across HTF engines via targeted `rg` queries; these checks succeeded. 
- Attempted to run a full build with `dotnet build`, but the environment lacks the .NET SDK so the build failed with `/bin/bash: line 1: dotnet: command not found` (environment limitation, not code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c81e92824c83289742ab491400913c)