### PR TITLE
Unify HTF reject classification across router and core logs

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2841,36 +2841,29 @@ namespace GeminiV26.Core
             }
 
             string reason = $"{candidate.Reason} {candidate.RejectReason}";
-            if (!string.IsNullOrWhiteSpace(reason) && reason.Contains("HTF_MISMATCH"))
+            if (!string.IsNullOrWhiteSpace(reason) && reason.Contains("HTF_"))
             {
-                bool hasDirection = candidate.Direction != TradeDirection.None;
-                bool hasHtf = allowed != TradeDirection.None;
-                bool trueDirectionMismatch = IsTrueDirectionMismatch(candidate.Direction, allowed);
-                string htfClassification = ResolveHtfRejectClassification(align, trueDirectionMismatch, !hasDirection || !hasHtf);
+                string htfClassification = ResolveHtfRejectClassification(candidate.Direction, allowed, align);
                 _bot.Print(
                     $"[AUDIT][HTF REJECT ANALYSIS] symbol={ctx.Symbol} asset={asset} entryType={candidate.Type} candidateDirection={candidate.Direction} " +
-                    $"htfAllowedDirection={allowed} htfState={state} align={align} trueDirectionMismatch={(trueDirectionMismatch ? "YES" : "NO")} " +
+                    $"htfAllowedDirection={allowed} htfState={state} align={align} trueDirectionMismatch={(candidate.Direction != TradeDirection.None && allowed != TradeDirection.None && candidate.Direction != allowed ? "YES" : "NO")} " +
                     $"classification={htfClassification} rejectModule={module}");
             }
         }
 
-        private static bool IsTrueDirectionMismatch(TradeDirection candidateDirection, TradeDirection allowedDirection)
+        private static string ResolveHtfRejectClassification(
+            TradeDirection candidateDirection,
+            TradeDirection htfAllowedDirection,
+            bool align)
         {
-            return candidateDirection != TradeDirection.None
-                && allowedDirection != TradeDirection.None
-                && candidateDirection != allowedDirection;
-        }
+            if (candidateDirection == TradeDirection.None || htfAllowedDirection == TradeDirection.None)
+                return "HTF_NO_DIRECTION";
 
-        private static string ResolveHtfRejectClassification(bool align, bool trueDirectionMismatch, bool noDirectionCase)
-        {
-            if (!align)
-                return "HTF_NOT_ALIGNED";
-
-            if (trueDirectionMismatch)
+            if (candidateDirection != htfAllowedDirection)
                 return "HTF_MISMATCH";
 
-            if (noDirectionCase)
-                return "HTF_NO_DIRECTION";
+            if (!align)
+                return "HTF_NOT_ALIGNED";
 
             return "HTF_OK";
         }

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -220,12 +220,30 @@ namespace GeminiV26.Core
                         $"candidateDir={candidate.Direction}");
                 }
 
+                string htfClassification = ResolveHtfRejectClassification(
+                    candidate.Direction,
+                    routedHtfAllowedDirection,
+                    routedHtfAlign);
+
                 if (!candidate.IsValid)
                 {
+                    string deathReason = candidate.Reason;
+                    if (!string.IsNullOrWhiteSpace(candidate.Reason) && candidate.Reason.Contains("HTF_"))
+                    {
+                        string originalReason = deathReason;
+                        deathReason = htfClassification;
+#if DEBUG
+                        if (!string.Equals(originalReason, htfClassification, StringComparison.Ordinal))
+                        {
+                            _bot.Print(
+                                $"[AUDIT][HTF][INCONSISTENT_REASON] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} reason={originalReason} classification={htfClassification}");
+                        }
+#endif
+                    }
                     _bot.Print(
                         $"[AUDIT][DEATH] type={candidate.Type} " +
                         $"score={candidate.Score} " +
-                        $"reason={candidate.Reason} " +
+                        $"reason={deathReason} " +
                         $"trigger={candidate.TriggerConfirmed} " +
                         $"state={candidate.State}");
 
@@ -246,13 +264,8 @@ namespace GeminiV26.Core
                 if (candidate.Type == EntryType.Index_Flag
                     && candidate.TriggerConfirmed
                     && candidate.Reason != null
-                    && candidate.Reason.Contains("HTF_MISMATCH"))
+                    && candidate.Reason.Contains("HTF_"))
                 {
-                    bool hasDirection = candidate.Direction != TradeDirection.None;
-                    bool hasHtf = routedHtfAllowedDirection != TradeDirection.None;
-                    bool trueDirectionMismatch = IsTrueDirectionMismatch(candidate.Direction, routedHtfAllowedDirection);
-                    string htfClassification = ResolveHtfRejectClassification(routedHtfAlign, trueDirectionMismatch, !hasDirection || !hasHtf);
-
                     _bot.Print(
                         $"[AUDIT][HTF TRACE][REJECT] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} " +
                         $"candidateDirection={candidate.Direction} rejectReason={candidate.Reason} " +
@@ -267,16 +280,12 @@ namespace GeminiV26.Core
                         $"candidateDir={candidate.Direction}");
                 }
                 string rejectText = $"{candidate.Reason} {candidate.RejectReason}";
-                if (!string.IsNullOrWhiteSpace(rejectText) && rejectText.Contains("HTF_MISMATCH"))
+                if (!string.IsNullOrWhiteSpace(rejectText) && rejectText.Contains("HTF_"))
                 {
-                    bool hasDirection = candidate.Direction != TradeDirection.None;
-                    bool hasHtf = routedHtfAllowedDirection != TradeDirection.None;
-                    bool trueDirectionMismatch = IsTrueDirectionMismatch(candidate.Direction, routedHtfAllowedDirection);
-                    string htfClassification = ResolveHtfRejectClassification(routedHtfAlign, trueDirectionMismatch, !hasDirection || !hasHtf);
                     _bot.Print(
                         $"[AUDIT][HTF REJECT ANALYSIS] symbol={candidate.Symbol ?? _bot.SymbolName} asset={assetClass} entryType={candidate.Type} " +
                         $"candidateDirection={candidate.Direction} htfAllowedDirection={routedHtfAllowedDirection} htfState={routedHtfState} " +
-                        $"align={routedHtfAlign} trueDirectionMismatch={(trueDirectionMismatch ? "YES" : "NO")} " +
+                        $"align={routedHtfAlign} trueDirectionMismatch={(candidate.Direction != TradeDirection.None && routedHtfAllowedDirection != TradeDirection.None && candidate.Direction != routedHtfAllowedDirection ? "YES" : "NO")} " +
                         $"classification={htfClassification} rejectModule={nameof(TradeRouter)}");
                 }
                 _bot.Print(TradeLogIdentity.WithTempId(
@@ -294,7 +303,7 @@ namespace GeminiV26.Core
                     if (candidate.Type == EntryType.Index_Flag
                         && candidate.TriggerConfirmed
                         && candidate.Reason != null
-                        && candidate.Reason.Contains("HTF_MISMATCH"))
+                        && candidate.Reason.Contains("HTF_"))
                     {
                         _bot.Print(
                             $"[AUDIT][HTF CONFLICT] type={candidate.Type} " +
@@ -338,19 +347,15 @@ namespace GeminiV26.Core
             return sourceBlocks == consumerBlocks;
         }
 
-        private static bool IsTrueDirectionMismatch(TradeDirection candidateDirection, TradeDirection allowedDirection)
+        private static string ResolveHtfRejectClassification(
+            TradeDirection candidateDirection,
+            TradeDirection htfAllowedDirection,
+            bool align)
         {
-            return candidateDirection != TradeDirection.None
-                && allowedDirection != TradeDirection.None
-                && candidateDirection != allowedDirection;
-        }
-
-        private static string ResolveHtfRejectClassification(bool align, bool trueDirectionMismatch, bool noDirectionCase)
-        {
-            if (noDirectionCase)
+            if (candidateDirection == TradeDirection.None || htfAllowedDirection == TradeDirection.None)
                 return "HTF_NO_DIRECTION";
 
-            if (trueDirectionMismatch)
+            if (candidateDirection != htfAllowedDirection)
                 return "HTF_MISMATCH";
 
             if (!align)


### PR DESCRIPTION
### Motivation
- Eliminate inconsistent HTF labeling where `reason=HTF_MISMATCH` could be emitted independently from the HTF reject classification, by making classification the single source of truth for all HTF-related logs and decision labels.
- Prevent misleading logs when `trueDirectionMismatch==NO` but the router still emitted `HTF_MISMATCH` as a reason.

### Description
- Compute HTF classification once per candidate in `Core/TradeRouter.cs` via `ResolveHtfRejectClassification(candidateDirection, htfAllowedDirection, align)` and reuse that value across HTF-related logs instead of emitting hardcoded `HTF_MISMATCH` reasons.
- Update `[AUDIT][DEATH]` to emit the computed classification as `reason` when the candidate already contains an `HTF_` reason family, preserving non-HTF reasons unchanged.
- Broaden HTF-triggered analysis/trace checks from matching `"HTF_MISMATCH"` to any `"HTF_"` family so classification-driven analysis is consistently applied in both `TradeRouter` and `TradeCore`.
- Unify and replace legacy helpers by changing `ResolveHtfRejectClassification` signatures in both `Core/TradeRouter.cs` and `Core/TradeCore.cs` to accept `(TradeDirection candidateDirection, TradeDirection htfAllowedDirection, bool align)` and enforce the specified rule order: `HTF_NO_DIRECTION` → `HTF_MISMATCH` → `HTF_NOT_ALIGNED` → `HTF_OK`.
- Add a DEBUG-only assertion log `"[AUDIT][HTF][INCONSISTENT_REASON]"` when an original HTF reason differs from the computed classification to help detect drift during development.

### Testing
- Ran repository searches with `rg` to find and validate updated call sites and that `ResolveHtfRejectClassification(` uses the new signature across `Core/TradeRouter.cs` and `Core/TradeCore.cs`, which succeeded.
- Searched for remaining occurrences of `HTF_MISMATCH` and `trueDirectionMismatch` to confirm logic paths were broadened to `HTF_` and classification usage was centralized, which succeeded.
- Attempted `dotnet build` but it failed in this environment because `dotnet` is not installed, so a full compile/test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8254165b08328a9757fdd6a3a2aad)