### PR TITLE
Unify HTF classification across ENTRY_TRACE stages

### DIFF
--- a/Core/Entry/EntryEvaluation.cs
+++ b/Core/Entry/EntryEvaluation.cs
@@ -36,6 +36,7 @@
         public string LastDirectionDropStage;
         public string LastDirectionDropModule;
         public string EntryTraceClassification;
+        public string HtfClassification;
 
         // Score tracing (observability only).
         public int PreQualityScore;

--- a/Core/Entry/EntryRouter.cs
+++ b/Core/Entry/EntryRouter.cs
@@ -38,8 +38,11 @@ namespace GeminiV26.Core.Entry
 
                 foreach (var entryType in _entryTypes)
                 {
+                    var startClassification = HtfClassificationModel.ComputeHtfClassification(
+                        TradeDirection.None,
+                        ctx?.ResolveAssetHtfAllowedDirection() ?? TradeDirection.None);
                     ctx?.Print(
-                        $"[ENTRY_TRACE][START] symbol={ctx?.Symbol} entryType={entryType?.GetType().Name} stage=START candidateDirection={TradeDirection.None} score=NA blockReason=NA");
+                        $"[ENTRY_TRACE][START] symbol={ctx?.Symbol} entryType={entryType?.GetType().Name} stage=START candidateDirection={TradeDirection.None} score=NA classification={startClassification}");
 
                     var eval = entryType.Evaluate(ctx);
 
@@ -58,9 +61,12 @@ namespace GeminiV26.Core.Entry
                         eval.DirectionAfterScore = eval.Direction;
                         eval.DirectionAfterGates = eval.Direction;
                         eval.EntryTraceClassification = "ENTRY_UNKNOWN";
+                        eval.HtfClassification = HtfClassificationModel.ComputeHtfClassification(
+                            eval.RawDirection,
+                            ctx?.ResolveAssetHtfAllowedDirection() ?? TradeDirection.None);
 
                         ctx?.Print(
-                            $"[ENTRY_TRACE][LOGIC] symbol={ctx?.Symbol} entryType={eval.Type} stage=LOGIC candidateDirection={eval.Direction} score={eval.Score} blockReason={eval.Reason ?? "NA"} " +
+                            $"[ENTRY_TRACE][LOGIC] symbol={ctx?.Symbol} entryType={eval.Type} stage=LOGIC candidateDirection={eval.Direction} score={eval.Score} classification={eval.HtfClassification} " +
                             $"rawDirection={eval.RawDirection} logicBiasDirection={eval.LogicBiasDirection} logicConfidence={eval.RawLogicConfidence} " +
                             $"patternDetected={eval.PatternDetected.ToString().ToLowerInvariant()} setupType={eval.SetupType}");
 
@@ -69,14 +75,14 @@ namespace GeminiV26.Core.Entry
                         eval.DirectionAfterScore = eval.Direction;
                         bool passedThreshold = eval.Score >= EntryDecisionPolicy.MinScoreThreshold;
                         ctx?.Print(
-                            $"[ENTRY_TRACE][SCORE] symbol={ctx?.Symbol} entryType={eval.Type} stage=SCORE candidateDirection={eval.Direction} score={eval.Score} blockReason={eval.Reason ?? "NA"} " +
+                            $"[ENTRY_TRACE][SCORE] symbol={ctx?.Symbol} entryType={eval.Type} stage=SCORE candidateDirection={eval.Direction} score={eval.Score} classification={eval.HtfClassification} " +
                             $"baseScore={eval.BaseScore} afterHtfScoreAdjustment={eval.AfterHtfScoreAdjustment} afterPenalty={eval.AfterPenaltyScore} finalScore={eval.FinalScoreSnapshot} " +
                             $"scoreThreshold={EntryDecisionPolicy.MinScoreThreshold} passedThreshold={passedThreshold.ToString().ToLowerInvariant()}");
 
                         eval.Reason = "[ROUTER] " + (eval.Reason ?? "");
                         ctx?.Print(
                             $"[ENTRY_TRACE][FINAL] symbol={ctx?.Symbol} entryType={eval.Type} stage=ENTRY_ROUTER candidateDirection={eval.Direction} score={eval.Score} " +
-                            $"blockReason={eval.Reason ?? "NA"} finalCandidateDirection={eval.Direction} finalScore={eval.Score} blocked={(!eval.IsValid).ToString().ToLowerInvariant()} finalReason={eval.Reason ?? "NA"}");
+                            $"classification={eval.HtfClassification} finalCandidateDirection={eval.Direction} finalScore={eval.Score} blocked={(!eval.IsValid).ToString().ToLowerInvariant()} finalReason={eval.Reason ?? "NA"}");
                     }
 
                     // DEBUG – marad

--- a/Core/Entry/HtfClassificationModel.cs
+++ b/Core/Entry/HtfClassificationModel.cs
@@ -1,0 +1,18 @@
+namespace GeminiV26.Core.Entry
+{
+    public static class HtfClassificationModel
+    {
+        public static string ComputeHtfClassification(
+            TradeDirection candidateDirection,
+            TradeDirection htfAllowedDirection)
+        {
+            if (candidateDirection == TradeDirection.None || htfAllowedDirection == TradeDirection.None)
+                return "HTF_NO_DIRECTION";
+
+            if (candidateDirection != htfAllowedDirection)
+                return "HTF_MISMATCH";
+
+            return "HTF_OK";
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1173,9 +1173,10 @@ namespace GeminiV26.Core
                 LogHtfFlowStage(_ctx, e, "ENTRY_EVALUATION", "_entryRouter.Evaluate");
                 if (e != null)
                 {
+                    EnsureHtfClassification(_ctx, e);
                     e.AfterHtfScoreAdjustment = e.Score;
                     _bot.Print(TradeLogIdentity.WithTempId(
-                        $"[ENTRY_TRACE][LOGIC] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=LOGIC candidateDirection={e.Direction} score={e.Score} blockReason={e.Reason ?? "NA"} " +
+                        $"[ENTRY_TRACE][LOGIC] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=LOGIC candidateDirection={e.Direction} score={e.Score} classification={e.HtfClassification} " +
                         $"rawDirection={e.RawDirection} logicBiasDirection={e.LogicBiasDirection} logicConfidence={e.RawLogicConfidence} patternDetected={e.PatternDetected.ToString().ToLowerInvariant()} setupType={e.SetupType ?? e.Type.ToString()}",
                         _ctx));
                 }
@@ -1242,7 +1243,7 @@ namespace GeminiV26.Core
                         e.DirectionAfterScore = e.Direction;
                         bool passedThreshold = e.Score >= EntryDecisionPolicy.MinScoreThreshold;
                         _bot.Print(TradeLogIdentity.WithTempId(
-                            $"[ENTRY_TRACE][SCORE] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=SCORE candidateDirection={e.Direction} score={e.Score} blockReason={e.Reason ?? "NA"} " +
+                            $"[ENTRY_TRACE][SCORE] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=SCORE candidateDirection={e.Direction} score={e.Score} classification={e.HtfClassification} " +
                             $"baseScore={e.BaseScore} afterHtfScoreAdjustment={e.AfterHtfScoreAdjustment} afterPenalty={e.AfterPenaltyScore} finalScore={e.FinalScoreSnapshot} " +
                             $"scoreThreshold={e.ScoreThresholdSnapshot} passedThreshold={passedThreshold.ToString().ToLowerInvariant()}",
                             _ctx));
@@ -1257,7 +1258,7 @@ namespace GeminiV26.Core
                 foreach (var e in symbolSignals.Where(x => x != null))
                 {
                     _bot.Print(TradeLogIdentity.WithTempId(
-                        $"[ENTRY_TRACE][GATES] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=GATES candidateDirection={e.DirectionAfterGates} score={e.Score} blockReason={e.Reason ?? "NA"}",
+                        $"[ENTRY_TRACE][GATES] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=GATES candidateDirection={e.DirectionAfterGates} score={e.Score} classification={e.HtfClassification}",
                         _ctx));
                     LogCriticalDirectionDrop(_ctx, e);
                 }
@@ -1276,7 +1277,7 @@ namespace GeminiV26.Core
                 if (selected == null)
                 {
                     _bot.Print(TradeLogIdentity.WithTempId(
-                        $"[ENTRY_TRACE][FINAL] symbol={_bot.SymbolName} entryType=None stage=FINAL candidateDirection={TradeDirection.None} score=NA blockReason=NO_SELECTED_ENTRY " +
+                        $"[ENTRY_TRACE][FINAL] symbol={_bot.SymbolName} entryType=None stage=FINAL candidateDirection={TradeDirection.None} score=NA classification=HTF_NO_DIRECTION " +
                         $"finalCandidateDirection={TradeDirection.None} finalScore=NA blocked=true finalReason=NO_SELECTED_ENTRY",
                         _ctx));
                     _bot.Print("BLOCK: entry gate");
@@ -1286,7 +1287,7 @@ namespace GeminiV26.Core
 
                 _bot.Print(TradeLogIdentity.WithTempId(
                     $"[ENTRY_TRACE][FINAL] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} stage=FINAL candidateDirection={selected.Direction} score={selected.Score} " +
-                    $"blockReason={selected.Reason ?? "NA"} finalCandidateDirection={selected.Direction} finalScore={selected.Score} blocked={(!selected.IsValid).ToString().ToLowerInvariant()} finalReason={selected.Reason ?? "NA"}",
+                    $"classification={selected.HtfClassification} finalCandidateDirection={selected.Direction} finalScore={selected.Score} blocked={(!selected.IsValid).ToString().ToLowerInvariant()} finalReason={selected.Reason ?? "NA"}",
                     _ctx));
 
 
@@ -1361,7 +1362,7 @@ namespace GeminiV26.Core
                     selected.DirectionAfterGates = TradeDirection.None;
                     LogCriticalDirectionDrop(_ctx, selected);
                     _bot.Print(TradeLogIdentity.WithTempId(
-                        $"[ENTRY_TRACE][FINAL] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} stage=FINAL candidateDirection={selected.Direction} score={selected.Score} blockReason={selected.Reason ?? "NA"} finalCandidateDirection={TradeDirection.None} finalScore={selected.Score} blocked=true finalReason=FINAL_DIRECTION_NONE",
+                        $"[ENTRY_TRACE][FINAL] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} stage=FINAL candidateDirection={selected.Direction} score={selected.Score} classification={selected.HtfClassification} finalCandidateDirection={TradeDirection.None} finalScore={selected.Score} blocked=true finalReason=FINAL_DIRECTION_NONE",
                         _ctx));
                     _bot.Print("BLOCK: direction/entry failed");
                     _bot.Print($"[TC] ENTRY DROPPED: Direction=None (type={selected.Type} score={selected.Score} reason={selected.Reason})");
@@ -1732,6 +1733,18 @@ namespace GeminiV26.Core
             return summary;
         }
 
+        private static void EnsureHtfClassification(EntryContext ctx, EntryEvaluation candidate)
+        {
+            if (candidate == null || !string.IsNullOrWhiteSpace(candidate.HtfClassification))
+                return;
+
+            TradeDirection htfAllowedDirection = ctx?.ResolveAssetHtfAllowedDirection() ?? TradeDirection.None;
+            TradeDirection candidateDirection = candidate.RawDirection != TradeDirection.None
+                ? candidate.RawDirection
+                : candidate.Direction;
+            candidate.HtfClassification = HtfClassificationModel.ComputeHtfClassification(candidateDirection, htfAllowedDirection);
+        }
+
         private void LogEntryTraceGate(
             EntryContext ctx,
             EntryEvaluation candidate,
@@ -1743,10 +1756,11 @@ namespace GeminiV26.Core
             if (candidate == null)
                 return;
 
+            EnsureHtfClassification(ctx, candidate);
             TradeDirection afterDirection = candidate.Direction;
             candidate.DirectionAfterGates = afterDirection;
             _bot.Print(TradeLogIdentity.WithTempId(
-                $"[ENTRY_TRACE][GATE] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} stage=GATE candidateDirection={afterDirection} score={candidate.Score} blockReason={reason ?? "NA"} " +
+                $"[ENTRY_TRACE][GATE] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} stage=GATE candidateDirection={afterDirection} score={candidate.Score} classification={candidate.HtfClassification ?? "HTF_NO_DIRECTION"} " +
                 $"gateName={gateName} beforeDirection={beforeDirection} afterDirection={afterDirection} blocked={blocked.ToString().ToLowerInvariant()} reason={reason ?? "NA"}",
                 ctx));
 
@@ -1821,7 +1835,7 @@ namespace GeminiV26.Core
 
             candidate.EntryTraceClassification = classification;
             _bot.Print(TradeLogIdentity.WithTempId(
-                $"[ENTRY_TRACE][CLASSIFICATION] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} stage=CLASSIFICATION candidateDirection={candidate.Direction} score={candidate.Score} blockReason={candidate.Reason ?? "NA"} classification={classification}",
+                $"[ENTRY_TRACE][CLASSIFICATION] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} stage=CLASSIFICATION candidateDirection={candidate.Direction} score={candidate.Score} classification={classification}",
                 ctx));
         }
 
@@ -3046,29 +3060,12 @@ namespace GeminiV26.Core
             string reason = $"{candidate.Reason} {candidate.RejectReason}";
             if (!string.IsNullOrWhiteSpace(reason) && reason.Contains("HTF_"))
             {
-                string htfClassification = ResolveHtfRejectClassification(candidate.Direction, allowed, align);
+                string htfClassification = HtfClassificationModel.ComputeHtfClassification(candidate.Direction, allowed);
                 _bot.Print(
                     $"[AUDIT][HTF REJECT ANALYSIS] symbol={ctx.Symbol} asset={asset} entryType={candidate.Type} candidateDirection={candidate.Direction} " +
                     $"htfAllowedDirection={allowed} htfState={state} align={align} trueDirectionMismatch={(candidate.Direction != TradeDirection.None && allowed != TradeDirection.None && candidate.Direction != allowed ? "YES" : "NO")} " +
                     $"classification={htfClassification} rejectModule={module}");
             }
-        }
-
-        private static string ResolveHtfRejectClassification(
-            TradeDirection candidateDirection,
-            TradeDirection htfAllowedDirection,
-            bool align)
-        {
-            if (candidateDirection == TradeDirection.None || htfAllowedDirection == TradeDirection.None)
-                return "HTF_NO_DIRECTION";
-
-            if (candidateDirection != htfAllowedDirection)
-                return "HTF_MISMATCH";
-
-            if (!align)
-                return "HTF_NOT_ALIGNED";
-
-            return "HTF_OK";
         }
 
         private void StampEntrySourceHtfTrace(EntryContext ctx, EntryEvaluation eval)

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -222,8 +222,8 @@ namespace GeminiV26.Core
 
                 string htfClassification = ResolveHtfRejectClassification(
                     candidate.Direction,
-                    routedHtfAllowedDirection,
-                    routedHtfAlign);
+                    routedHtfAllowedDirection);
+                candidate.HtfClassification = htfClassification;
 
                 if (!candidate.IsValid)
                 {
@@ -349,20 +349,8 @@ namespace GeminiV26.Core
 
         private static string ResolveHtfRejectClassification(
             TradeDirection candidateDirection,
-            TradeDirection htfAllowedDirection,
-            bool align)
-        {
-            if (candidateDirection == TradeDirection.None || htfAllowedDirection == TradeDirection.None)
-                return "HTF_NO_DIRECTION";
-
-            if (candidateDirection != htfAllowedDirection)
-                return "HTF_MISMATCH";
-
-            if (!align)
-                return "HTF_NOT_ALIGNED";
-
-            return "HTF_OK";
-        }
+            TradeDirection htfAllowedDirection)
+            => HtfClassificationModel.ComputeHtfClassification(candidateDirection, htfAllowedDirection);
 
         private static string ResolveRejectReason(EntryEvaluation candidate, int threshold)
         {


### PR DESCRIPTION
### Motivation
- Eliminate inconsistent HTF reason labeling in ENTRY_TRACE logs so a single HTF classification is used for each entry attempt. 
- Prevent legacy or intermediate reason strings (e.g. `HTF_MISMATCH` vs `HTF_NO_DIRECTION`) from polluting diagnostics and breaking audits. 
- Ensure the HTF outcome is computed once from a unified model and propagated through all entry stages (LOGIC, SCORE, GATES, FINAL).

### Description
- Added a unified classifier `HtfClassificationModel.ComputeHtfClassification(candidateDirection, htfAllowedDirection)` implementing the strict states `HTF_NO_DIRECTION`, `HTF_MISMATCH`, and `HTF_OK` (file `Core/Entry/HtfClassificationModel.cs`).
- Added `HtfClassification` to `EntryEvaluation` and compute/store the classification once per evaluation in `EntryRouter` and via `EnsureHtfClassification` in `TradeCore`, so the same value is reused across stages (files `Core/Entry/EntryEvaluation.cs`, `Core/Entry/EntryRouter.cs`, `Core/TradeCore.cs`).
- Replaced `blockReason=...` usage in ENTRY_TRACE logs with `classification=...` for START/LOGIC/SCORE/GATES/FINAL messages and ensured logs read the stored `HtfClassification` instead of recomputing or using legacy strings (files `Core/Entry/EntryRouter.cs`, `Core/TradeCore.cs`).
- Aligned `TradeRouter`/`TradeCore` reject analysis to the unified model by routing calls to the new classifier and removing the previous `HTF_NOT_ALIGNED` branching from the classification logic (`Core/TradeRouter.cs`, `Core/TradeCore.cs`).

### Testing
- Ran repository searches with `rg` to validate logging changes and found no occurrences of `blockReason=HTF_MISMATCH` (search returned zero matches). 
- Confirmed presence of normalized no-direction outputs with `rg "classification=HTF_NO_DIRECTION"` which matched the expected ENTRY_TRACE final no-selection path. 
- Verified that `ENTRY_TRACE` patterns containing `blockReason=` were removed or converted to `classification=` via targeted `rg` checks, and committed the change after validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c82d90e52883289b77c975ada011c4)