### PR TITLE
Fix crypto entry direction fallback and add direction-source tracing

### DIFF
--- a/Core/Entry/CryptoDirectionFallback.cs
+++ b/Core/Entry/CryptoDirectionFallback.cs
@@ -1,0 +1,89 @@
+using System;
+using GeminiV26.Core;
+
+namespace GeminiV26.Core.Entry
+{
+    internal static class CryptoDirectionFallback
+    {
+        public static bool ApplyIfEligible(EntryContext ctx, EntryEvaluation eval, string reason)
+        {
+            if (ctx == null || eval == null)
+                return false;
+
+            TradeDirection biasDirection = ctx.LogicBiasDirection;
+            if (eval.Direction != TradeDirection.None || biasDirection == TradeDirection.None)
+                return false;
+
+            if (IsHardNoDirectionReason(reason))
+                return false;
+
+            bool patternDetected = DetectPattern(ctx, biasDirection);
+            bool structurePresent = patternDetected || HasContinuationStructure(ctx, biasDirection);
+            if (!structurePresent)
+                return false;
+
+            eval.Direction = biasDirection;
+            eval.RawDirection = biasDirection;
+            eval.FallbackDirectionUsed = true;
+            eval.PatternDetected = patternDetected;
+            eval.RawLogicConfidence = Math.Max(15, Math.Min(35, ctx.LogicBiasConfidence > 0 ? ctx.LogicBiasConfidence : 20));
+            eval.LogicConfidence = eval.RawLogicConfidence;
+
+            if (eval.Score <= 0)
+                eval.Score = 40;
+
+            eval.Reason = string.IsNullOrWhiteSpace(eval.Reason)
+                ? "FALLBACK_DIRECTION_FROM_LOGIC_BIAS"
+                : $"{eval.Reason}|FALLBACK_DIRECTION_FROM_LOGIC_BIAS";
+
+            return true;
+        }
+
+        public static bool DetectPattern(EntryContext ctx, TradeDirection direction)
+        {
+            if (ctx == null || direction == TradeDirection.None)
+                return false;
+
+            bool impulseDetected =
+                (ctx.HasImpulse_M1 && (ctx.ImpulseDirection == TradeDirection.None || ctx.ImpulseDirection == direction)) ||
+                (ctx.HasImpulse_M5 && (ctx.ImpulseDirection == TradeDirection.None || ctx.ImpulseDirection == direction));
+
+            bool breakoutDetected =
+                (ctx.HasBreakout_M1 && (ctx.BreakoutDirection == TradeDirection.None || ctx.BreakoutDirection == direction)) ||
+                ctx.RangeBreakDirection == direction ||
+                (direction == TradeDirection.Long
+                    ? (ctx.FlagBreakoutUp || ctx.FlagBreakoutUpConfirmed)
+                    : (ctx.FlagBreakoutDown || ctx.FlagBreakoutDownConfirmed));
+
+            bool pullbackValid =
+                ctx.PullbackBars_M5 >= 2 &&
+                (ctx.IsPullbackDecelerating_M5 || ctx.HasReactionCandle_M5 || ctx.LastClosedBarInTrendDirection);
+
+            return impulseDetected || breakoutDetected || pullbackValid;
+        }
+
+        private static bool HasContinuationStructure(EntryContext ctx, TradeDirection direction)
+        {
+            bool hasFlag = direction == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5;
+            bool hasRange = ctx.IsRange_M5 && ctx.RangeBarCount_M5 >= 10;
+            return hasFlag || hasRange;
+        }
+
+        private static bool IsHardNoDirectionReason(string reason)
+        {
+            if (string.IsNullOrWhiteSpace(reason))
+                return false;
+
+            string normalized = reason.ToUpperInvariant();
+            return normalized.Contains("CTX_NOT_READY")
+                || normalized.Contains("NO_LOGIC_BIAS")
+                || normalized.Contains("HTF_MISMATCH")
+                || normalized.Contains("DISABLED")
+                || normalized.Contains("NO_RANGE")
+                || normalized.Contains("NO_FLAG_WINDOW")
+                || normalized.Contains("LATE_FLAG")
+                || normalized.Contains("ATR_ZERO")
+                || normalized.Contains("NO_RECENT_IMPULSE");
+        }
+    }
+}

--- a/Core/Entry/EntryEvaluation.cs
+++ b/Core/Entry/EntryEvaluation.cs
@@ -25,6 +25,7 @@
         public TradeDirection LogicBiasDirection;
         public int RawLogicConfidence;
         public bool PatternDetected;
+        public bool FallbackDirectionUsed;
         public string SetupType;
         public int BaseScore;
         public int AfterHtfScoreAdjustment;

--- a/Core/Entry/EntryRouter.cs
+++ b/Core/Entry/EntryRouter.cs
@@ -50,8 +50,18 @@ namespace GeminiV26.Core.Entry
                     {
                         eval.RawDirection = eval.Direction;
                         eval.LogicBiasDirection = ctx?.LogicBiasDirection ?? TradeDirection.None;
-                        eval.RawLogicConfidence = ctx?.LogicBiasConfidence ?? 0;
-                        eval.PatternDetected = eval.Direction != TradeDirection.None;
+                        if (eval.RawLogicConfidence <= 0)
+                            eval.RawLogicConfidence = ctx?.LogicBiasConfidence ?? 0;
+
+                        if (!eval.PatternDetected)
+                            eval.PatternDetected = CryptoDirectionFallback.DetectPattern(ctx, eval.RawDirection != TradeDirection.None ? eval.RawDirection : eval.LogicBiasDirection);
+
+                        if (eval.RawDirection == TradeDirection.None && eval.LogicBiasDirection != TradeDirection.None)
+                        {
+                            CryptoDirectionFallback.ApplyIfEligible(ctx, eval, eval.Reason);
+                            eval.RawDirection = eval.Direction;
+                        }
+
                         eval.SetupType = eval.Type.ToString();
                         eval.BaseScore = eval.Score;
                         eval.AfterHtfScoreAdjustment = eval.Score;
@@ -69,6 +79,10 @@ namespace GeminiV26.Core.Entry
                             $"[ENTRY_TRACE][LOGIC] symbol={ctx?.Symbol} entryType={eval.Type} stage=LOGIC candidateDirection={eval.Direction} score={eval.Score} classification={eval.HtfClassification} " +
                             $"rawDirection={eval.RawDirection} logicBiasDirection={eval.LogicBiasDirection} logicConfidence={eval.RawLogicConfidence} " +
                             $"patternDetected={eval.PatternDetected.ToString().ToLowerInvariant()} setupType={eval.SetupType}");
+
+                        ctx?.Print(
+                            $"[ENTRY_TRACE][DIRECTION_SOURCE] symbol={ctx?.Symbol} entryType={eval.Type} biasDirection={eval.LogicBiasDirection} rawDirection={eval.RawDirection} " +
+                            $"fallbackUsed={eval.FallbackDirectionUsed.ToString().ToLowerInvariant()} patternDetected={eval.PatternDetected.ToString().ToLowerInvariant()}");
 
                         eval = EntryDecisionPolicy.Normalize(eval);
                         eval.FinalScoreSnapshot = eval.Score;

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -353,7 +353,8 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = false,
                 Reason = reason
             };
-            ApplyCryptoSourceTrace(ctx, eval, dir);
+            CryptoDirectionFallback.ApplyIfEligible(ctx, eval, reason);
+            ApplyCryptoSourceTrace(ctx, eval, eval.Direction);
             return eval;
         }
 

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -911,7 +911,8 @@ namespace GeminiV26.EntryTypes.Crypto
                 Score = score,
                 Reason = reason
             };
-            ApplyCryptoSourceTrace(ctx, eval, dir);
+            CryptoDirectionFallback.ApplyIfEligible(ctx, eval, reason);
+            ApplyCryptoSourceTrace(ctx, eval, eval.Direction);
             return eval;
         }
 

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -168,7 +168,8 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = false,
                 Reason = reason + ";"
             };
-            ApplyCryptoSourceTrace(ctx, eval, dir);
+            CryptoDirectionFallback.ApplyIfEligible(ctx, eval, reason);
+            ApplyCryptoSourceTrace(ctx, eval, eval.Direction);
             return eval;
         }
 

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -85,7 +85,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = true,
                 Reason = $"CRYPTO_IMPULSE dir={dir} score={score}"
             };
-            ApplyCryptoSourceTrace(ctx, eval, dir);
+            ApplyCryptoSourceTrace(ctx, eval, eval.Direction);
             return eval;
         }
 
@@ -103,7 +103,8 @@ namespace GeminiV26.EntryTypes.Crypto
                 IsValid = false,
                 Reason = reason
             };
-            ApplyCryptoSourceTrace(ctx, eval, dir);
+            CryptoDirectionFallback.ApplyIfEligible(ctx, eval, reason);
+            ApplyCryptoSourceTrace(ctx, eval, eval.Direction);
             return eval;
         }
 


### PR DESCRIPTION
### Motivation

- Entry logic was failing to produce `rawDirection` when `LogicBiasDirection` existed because direction generation was gated too strictly by `patternDetected`, causing many `ENTRY_NO_SIGNAL` cases and high `neverHadDirectionCount`.
- The change introduces an early fallback so that a candidate direction (Long/Short) is produced when bias + structure exists, while preserving hard invalidation rules and safety.

### Description

- Add a new helper `CryptoDirectionFallback` (`Core/Entry/CryptoDirectionFallback.cs`) that detects early signals (impulse, breakout, pullback, flag/range) and, when eligible, assigns a low-confidence fallback `rawDirection` from `LogicBiasDirection` and marks `FallbackDirectionUsed`.
- Wire the fallback into crypto entry modules by invoking `CryptoDirectionFallback.ApplyIfEligible(...)` on invalid/block returns in `BTC_PullbackEntry`, `BTC_FlagEntry`, `BTC_RangeBreakoutEntry`, and `Crypto_ImpulseEntry` so direction can reach the SCORE stage when appropriate.
- Extend `EntryEvaluation` with a `FallbackDirectionUsed` diagnostic flag to show when a fallback was applied (`Core/Entry/EntryEvaluation.cs`).
- Update `EntryRouter` to compute `PatternDetected` independently via `CryptoDirectionFallback.DetectPattern(...)`, attempt fallback when `LogicBiasDirection != None` but `rawDirection == None`, and emit a new `[ENTRY_TRACE][DIRECTION_SOURCE]` log showing `biasDirection`, `rawDirection`, `fallbackUsed`, and `patternDetected` for better diagnostics (`Core/Entry/EntryRouter.cs`).
- Minor adjustments to source-trace calls so the `HtfTraceSourceCandidateDirection` uses the final `eval.Direction` after fallback application.

### Testing

- Ran `git diff --check` to validate no whitespace/conflict artifacts; this passed.
- Attempted to run a full build with `dotnet build`, but the environment is missing the `.NET` SDK and the command failed (`/bin/bash: line 1: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c82f5719a08328a296f7d8441aee89)