### PR TITLE
Unify HTF classification across entry trace pipeline

### DIFF
--- a/Core/Entry/EntryEvaluation.cs
+++ b/Core/Entry/EntryEvaluation.cs
@@ -38,6 +38,8 @@
         public string LastDirectionDropModule;
         public string EntryTraceClassification;
         public string HtfClassification;
+        public TradeDirection HtfClassificationCandidateDirection;
+        public TradeDirection HtfClassificationAllowedDirection;
 
         // Score tracing (observability only).
         public int PreQualityScore;

--- a/Core/Entry/EntryRouter.cs
+++ b/Core/Entry/EntryRouter.cs
@@ -38,9 +38,10 @@ namespace GeminiV26.Core.Entry
 
                 foreach (var entryType in _entryTypes)
                 {
+                    TradeDirection htfAllowedDirection = ctx?.ResolveAssetHtfAllowedDirection() ?? TradeDirection.None;
                     var startClassification = HtfClassificationModel.ComputeHtfClassification(
                         TradeDirection.None,
-                        ctx?.ResolveAssetHtfAllowedDirection() ?? TradeDirection.None);
+                        htfAllowedDirection);
                     ctx?.Print(
                         $"[ENTRY_TRACE][START] symbol={ctx?.Symbol} entryType={entryType?.GetType().Name} stage=START candidateDirection={TradeDirection.None} score=NA classification={startClassification}");
 
@@ -71,9 +72,10 @@ namespace GeminiV26.Core.Entry
                         eval.DirectionAfterScore = eval.Direction;
                         eval.DirectionAfterGates = eval.Direction;
                         eval.EntryTraceClassification = "ENTRY_UNKNOWN";
-                        eval.HtfClassification = HtfClassificationModel.ComputeHtfClassification(
-                            eval.RawDirection,
-                            ctx?.ResolveAssetHtfAllowedDirection() ?? TradeDirection.None);
+                        HtfClassificationModel.InitializeEntryHtfClassification(
+                            eval,
+                            eval.Direction,
+                            htfAllowedDirection);
 
                         ctx?.Print(
                             $"[ENTRY_TRACE][LOGIC] symbol={ctx?.Symbol} entryType={eval.Type} stage=LOGIC candidateDirection={eval.Direction} score={eval.Score} classification={eval.HtfClassification} " +

--- a/Core/Entry/HtfClassificationModel.cs
+++ b/Core/Entry/HtfClassificationModel.cs
@@ -14,5 +14,18 @@ namespace GeminiV26.Core.Entry
 
             return "HTF_OK";
         }
+
+        public static void InitializeEntryHtfClassification(
+            EntryEvaluation eval,
+            TradeDirection candidateDirection,
+            TradeDirection htfAllowedDirection)
+        {
+            if (eval == null || !string.IsNullOrWhiteSpace(eval.HtfClassification))
+                return;
+
+            eval.HtfClassificationCandidateDirection = candidateDirection;
+            eval.HtfClassificationAllowedDirection = htfAllowedDirection;
+            eval.HtfClassification = ComputeHtfClassification(candidateDirection, htfAllowedDirection);
+        }
     }
 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1176,7 +1176,7 @@ namespace GeminiV26.Core
                     EnsureHtfClassification(_ctx, e);
                     e.AfterHtfScoreAdjustment = e.Score;
                     _bot.Print(TradeLogIdentity.WithTempId(
-                        $"[ENTRY_TRACE][LOGIC] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=LOGIC candidateDirection={e.Direction} score={e.Score} classification={e.HtfClassification} " +
+                        $"[ENTRY_TRACE][LOGIC] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=LOGIC candidateDirection={GetEntryTraceCandidateDirection(e)} score={e.Score} classification={e.HtfClassification} " +
                         $"rawDirection={e.RawDirection} logicBiasDirection={e.LogicBiasDirection} logicConfidence={e.RawLogicConfidence} patternDetected={e.PatternDetected.ToString().ToLowerInvariant()} setupType={e.SetupType ?? e.Type.ToString()}",
                         _ctx));
                 }
@@ -1243,7 +1243,7 @@ namespace GeminiV26.Core
                         e.DirectionAfterScore = e.Direction;
                         bool passedThreshold = e.Score >= EntryDecisionPolicy.MinScoreThreshold;
                         _bot.Print(TradeLogIdentity.WithTempId(
-                            $"[ENTRY_TRACE][SCORE] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=SCORE candidateDirection={e.Direction} score={e.Score} classification={e.HtfClassification} " +
+                            $"[ENTRY_TRACE][SCORE] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=SCORE candidateDirection={GetEntryTraceCandidateDirection(e)} score={e.Score} classification={e.HtfClassification} " +
                             $"baseScore={e.BaseScore} afterHtfScoreAdjustment={e.AfterHtfScoreAdjustment} afterPenalty={e.AfterPenaltyScore} finalScore={e.FinalScoreSnapshot} " +
                             $"scoreThreshold={e.ScoreThresholdSnapshot} passedThreshold={passedThreshold.ToString().ToLowerInvariant()}",
                             _ctx));
@@ -1258,7 +1258,7 @@ namespace GeminiV26.Core
                 foreach (var e in symbolSignals.Where(x => x != null))
                 {
                     _bot.Print(TradeLogIdentity.WithTempId(
-                        $"[ENTRY_TRACE][GATES] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=GATES candidateDirection={e.DirectionAfterGates} score={e.Score} classification={e.HtfClassification}",
+                        $"[ENTRY_TRACE][GATES] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} stage=GATES candidateDirection={GetEntryTraceCandidateDirection(e)} score={e.Score} classification={e.HtfClassification}",
                         _ctx));
                     LogCriticalDirectionDrop(_ctx, e);
                 }
@@ -1286,7 +1286,7 @@ namespace GeminiV26.Core
                 }
 
                 _bot.Print(TradeLogIdentity.WithTempId(
-                    $"[ENTRY_TRACE][FINAL] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} stage=FINAL candidateDirection={selected.Direction} score={selected.Score} " +
+                    $"[ENTRY_TRACE][FINAL] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} stage=FINAL candidateDirection={GetEntryTraceCandidateDirection(selected)} score={selected.Score} " +
                     $"classification={selected.HtfClassification} finalCandidateDirection={selected.Direction} finalScore={selected.Score} blocked={(!selected.IsValid).ToString().ToLowerInvariant()} finalReason={selected.Reason ?? "NA"}",
                     _ctx));
 
@@ -1362,7 +1362,7 @@ namespace GeminiV26.Core
                     selected.DirectionAfterGates = TradeDirection.None;
                     LogCriticalDirectionDrop(_ctx, selected);
                     _bot.Print(TradeLogIdentity.WithTempId(
-                        $"[ENTRY_TRACE][FINAL] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} stage=FINAL candidateDirection={selected.Direction} score={selected.Score} classification={selected.HtfClassification} finalCandidateDirection={TradeDirection.None} finalScore={selected.Score} blocked=true finalReason=FINAL_DIRECTION_NONE",
+                        $"[ENTRY_TRACE][FINAL] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} stage=FINAL candidateDirection={GetEntryTraceCandidateDirection(selected)} score={selected.Score} classification={selected.HtfClassification} finalCandidateDirection={TradeDirection.None} finalScore={selected.Score} blocked=true finalReason=FINAL_DIRECTION_NONE",
                         _ctx));
                     _bot.Print("BLOCK: direction/entry failed");
                     _bot.Print($"[TC] ENTRY DROPPED: Direction=None (type={selected.Type} score={selected.Score} reason={selected.Reason})");
@@ -1739,10 +1739,20 @@ namespace GeminiV26.Core
                 return;
 
             TradeDirection htfAllowedDirection = ctx?.ResolveAssetHtfAllowedDirection() ?? TradeDirection.None;
-            TradeDirection candidateDirection = candidate.RawDirection != TradeDirection.None
-                ? candidate.RawDirection
+            HtfClassificationModel.InitializeEntryHtfClassification(
+                candidate,
+                candidate.Direction,
+                htfAllowedDirection);
+        }
+
+        private static TradeDirection GetEntryTraceCandidateDirection(EntryEvaluation candidate)
+        {
+            if (candidate == null)
+                return TradeDirection.None;
+
+            return candidate.HtfClassificationCandidateDirection != TradeDirection.None
+                ? candidate.HtfClassificationCandidateDirection
                 : candidate.Direction;
-            candidate.HtfClassification = HtfClassificationModel.ComputeHtfClassification(candidateDirection, htfAllowedDirection);
         }
 
         private void LogEntryTraceGate(
@@ -1758,9 +1768,10 @@ namespace GeminiV26.Core
 
             EnsureHtfClassification(ctx, candidate);
             TradeDirection afterDirection = candidate.Direction;
+            TradeDirection traceCandidateDirection = GetEntryTraceCandidateDirection(candidate);
             candidate.DirectionAfterGates = afterDirection;
             _bot.Print(TradeLogIdentity.WithTempId(
-                $"[ENTRY_TRACE][GATE] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} stage=GATE candidateDirection={afterDirection} score={candidate.Score} classification={candidate.HtfClassification ?? "HTF_NO_DIRECTION"} " +
+                $"[ENTRY_TRACE][GATE] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} stage=GATE candidateDirection={traceCandidateDirection} score={candidate.Score} classification={candidate.HtfClassification ?? "HTF_NO_DIRECTION"} " +
                 $"gateName={gateName} beforeDirection={beforeDirection} afterDirection={afterDirection} blocked={blocked.ToString().ToLowerInvariant()} reason={reason ?? "NA"}",
                 ctx));
 
@@ -3060,7 +3071,8 @@ namespace GeminiV26.Core
             string reason = $"{candidate.Reason} {candidate.RejectReason}";
             if (!string.IsNullOrWhiteSpace(reason) && reason.Contains("HTF_"))
             {
-                string htfClassification = HtfClassificationModel.ComputeHtfClassification(candidate.Direction, allowed);
+                EnsureHtfClassification(ctx, candidate);
+                string htfClassification = candidate.HtfClassification ?? "HTF_NO_DIRECTION";
                 _bot.Print(
                     $"[AUDIT][HTF REJECT ANALYSIS] symbol={ctx.Symbol} asset={asset} entryType={candidate.Type} candidateDirection={candidate.Direction} " +
                     $"htfAllowedDirection={allowed} htfState={state} align={align} trueDirectionMismatch={(candidate.Direction != TradeDirection.None && allowed != TradeDirection.None && candidate.Direction != allowed ? "YES" : "NO")} " +
@@ -3074,8 +3086,9 @@ namespace GeminiV26.Core
                 return;
 
             TradeDirection allowedDirection = ResolveHtfAllowedDirection(ctx);
-            TradeDirection candidateDirection = ctx.LogicBiasDirection;
-            bool align = allowedDirection == candidateDirection;
+            TradeDirection candidateDirection = eval.Direction;
+            bool align = candidateDirection != TradeDirection.None
+                && (allowedDirection == TradeDirection.None || allowedDirection == candidateDirection);
 
             eval.HtfTraceSourceStage = "ENTRY_SOURCE";
             eval.HtfTraceSourceModule = eval.Type.ToString();
@@ -3084,6 +3097,7 @@ namespace GeminiV26.Core
             eval.HtfTraceSourceAlign = align;
             eval.HtfTraceSourceCandidateDirection = candidateDirection;
             eval.HtfConfidence01 = ResolveHtfConfidence(ctx);
+            HtfClassificationModel.InitializeEntryHtfClassification(eval, candidateDirection, allowedDirection);
         }
 
         private static TradeDirection FromTradeType(TradeType tradeType)

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -220,10 +220,14 @@ namespace GeminiV26.Core
                         $"candidateDir={candidate.Direction}");
                 }
 
-                string htfClassification = ResolveHtfRejectClassification(
-                    candidate.Direction,
-                    routedHtfAllowedDirection);
-                candidate.HtfClassification = htfClassification;
+                string htfClassification = candidate.HtfClassification;
+                if (string.IsNullOrWhiteSpace(htfClassification))
+                {
+                    _bot.Print(
+                        $"[AUDIT][HTF CONFLICT][SKIPPED_NO_SOURCE] symbol={candidate.Symbol ?? _bot.SymbolName} asset={assetClass} entryType={candidate.Type} " +
+                        $"candidateDirection={candidate.Direction} routedState={routedHtfState} routedAllowedDirection={routedHtfAllowedDirection} routedAlign={routedHtfAlign}");
+                    htfClassification = "HTF_NO_DIRECTION";
+                }
 
                 if (!candidate.IsValid)
                 {
@@ -346,11 +350,6 @@ namespace GeminiV26.Core
             bool consumerBlocks = consumerAllowedDirection != TradeDirection.None && consumerAllowedDirection != candidateDirection;
             return sourceBlocks == consumerBlocks;
         }
-
-        private static string ResolveHtfRejectClassification(
-            TradeDirection candidateDirection,
-            TradeDirection htfAllowedDirection)
-            => HtfClassificationModel.ComputeHtfClassification(candidateDirection, htfAllowedDirection);
 
         private static string ResolveRejectReason(EntryEvaluation candidate, int threshold)
         {


### PR DESCRIPTION
### Motivation
- Existing entry attempt logs could show conflicting HTF labels across stages because classification was recomputed or derived from multiple places, producing false HTF conflict signals.
- The goal is a strict single-source HTF classification per entry attempt: compute once (after candidate direction and allowed HTF are known), persist it on the evaluation, and reuse it unchanged across all ENTRY_TRACE stages and the router.

### Description
- Added a single initialization API `HtfClassificationModel.InitializeEntryHtfClassification(...)` that computes and stores the classification and its input snapshot on `EntryEvaluation` via `HtfClassification`, `HtfClassificationCandidateDirection`, and `HtfClassificationAllowedDirection` (file `Core/Entry/HtfClassificationModel.cs`).
- Persisted HTF classification inputs on `EntryEvaluation` by adding `HtfClassificationCandidateDirection` and `HtfClassificationAllowedDirection` fields so the classification is immutable per attempt (file `Core/Entry/EntryEvaluation.cs`).
- Initialize the immutable classification at source (router/evaluate and `StampEntrySourceHtfTrace`) using the finalized entry direction and resolved asset HTF, and ensure downstream stages call `EnsureHtfClassification(...)` to consume the stored value rather than recomputing (files `Core/Entry/EntryRouter.cs`, `Core/TradeCore.cs`).
- Updated ENTRY_TRACE logging in `LOGIC`, `SCORE`, `GATES`, `FINAL`, and gate traces to print a stable per-attempt candidate direction snapshot (`GetEntryTraceCandidateDirection(...)`) tied to the stored classification so the same value is used end-to-end (file `Core/TradeCore.cs`).
- Removed router-side reclassification: `TradeRouter` now consumes `candidate.HtfClassification` only and, if missing, emits an explicit `[AUDIT][HTF CONFLICT][SKIPPED_NO_SOURCE]` instead of reinterpreting/overriding the source classification (file `Core/TradeRouter.cs`).
- Files changed: `Core/Entry/HtfClassificationModel.cs`, `Core/Entry/EntryEvaluation.cs`, `Core/Entry/EntryRouter.cs`, `Core/TradeCore.cs`, `Core/TradeRouter.cs`.

### Testing
- Executed repository searches with `rg` to validate removal of legacy inline labels and reclassification points, including `rg -n "blockReason=HTF_MISMATCH"` and `rg -n "HTF_NOT_ALIGNED|ResolveHtfRejectClassification" Core`, and confirmed no matches for the legacy patterns.
- Verified `ComputeHtfClassification(` usage is limited to the core model and initial START trace seed via `rg -n "ComputeHtfClassification\(" Core` which returned only the expected model/start locations.
- Committed the changes and inspected the diff with `git show --stat` which completed successfully, indicating the intended changes were applied.
- All automated checks performed (`rg` searches and git operations) succeeded; no runtime/build tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c834119f6c83288c3c941bd3a10e7d)