### PR TITLE
Guarantee logic-bias direction for crypto entries and enforce fallback confidence

### DIFF
--- a/Core/Entry/CryptoDirectionFallback.cs
+++ b/Core/Entry/CryptoDirectionFallback.cs
@@ -5,6 +5,8 @@ namespace GeminiV26.Core.Entry
 {
     internal static class CryptoDirectionFallback
     {
+        private static readonly int MinimumFallbackConfidence = (int)Math.Ceiling(EntryDecisionPolicy.MinScoreThreshold * 0.6);
+
         public static bool ApplyIfEligible(EntryContext ctx, EntryEvaluation eval, string reason)
         {
             if (ctx == null || eval == null)
@@ -14,19 +16,14 @@ namespace GeminiV26.Core.Entry
             if (eval.Direction != TradeDirection.None || biasDirection == TradeDirection.None)
                 return false;
 
-            if (IsHardNoDirectionReason(reason))
-                return false;
-
             bool patternDetected = DetectPattern(ctx, biasDirection);
-            bool structurePresent = patternDetected || HasContinuationStructure(ctx, biasDirection);
-            if (!structurePresent)
-                return false;
 
             eval.Direction = biasDirection;
             eval.RawDirection = biasDirection;
             eval.FallbackDirectionUsed = true;
             eval.PatternDetected = patternDetected;
-            eval.RawLogicConfidence = Math.Max(15, Math.Min(35, ctx.LogicBiasConfidence > 0 ? ctx.LogicBiasConfidence : 20));
+            int sourceConfidence = ctx.LogicBiasConfidence > 0 ? ctx.LogicBiasConfidence : MinimumFallbackConfidence;
+            eval.RawLogicConfidence = Math.Max(MinimumFallbackConfidence, Math.Min(100, sourceConfidence));
             eval.LogicConfidence = eval.RawLogicConfidence;
 
             if (eval.Score <= 0)
@@ -62,28 +59,5 @@ namespace GeminiV26.Core.Entry
             return impulseDetected || breakoutDetected || pullbackValid;
         }
 
-        private static bool HasContinuationStructure(EntryContext ctx, TradeDirection direction)
-        {
-            bool hasFlag = direction == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5;
-            bool hasRange = ctx.IsRange_M5 && ctx.RangeBarCount_M5 >= 10;
-            return hasFlag || hasRange;
-        }
-
-        private static bool IsHardNoDirectionReason(string reason)
-        {
-            if (string.IsNullOrWhiteSpace(reason))
-                return false;
-
-            string normalized = reason.ToUpperInvariant();
-            return normalized.Contains("CTX_NOT_READY")
-                || normalized.Contains("NO_LOGIC_BIAS")
-                || normalized.Contains("HTF_MISMATCH")
-                || normalized.Contains("DISABLED")
-                || normalized.Contains("NO_RANGE")
-                || normalized.Contains("NO_FLAG_WINDOW")
-                || normalized.Contains("LATE_FLAG")
-                || normalized.Contains("ATR_ZERO")
-                || normalized.Contains("NO_RECENT_IMPULSE");
-        }
     }
 }

--- a/Core/Entry/EntryRouter.cs
+++ b/Core/Entry/EntryRouter.cs
@@ -54,13 +54,26 @@ namespace GeminiV26.Core.Entry
                         if (eval.RawLogicConfidence <= 0)
                             eval.RawLogicConfidence = ctx?.LogicBiasConfidence ?? 0;
 
-                        if (!eval.PatternDetected)
-                            eval.PatternDetected = CryptoDirectionFallback.DetectPattern(ctx, eval.RawDirection != TradeDirection.None ? eval.RawDirection : eval.LogicBiasDirection);
-
                         if (eval.RawDirection == TradeDirection.None && eval.LogicBiasDirection != TradeDirection.None)
                         {
                             CryptoDirectionFallback.ApplyIfEligible(ctx, eval, eval.Reason);
                             eval.RawDirection = eval.Direction;
+                        }
+
+                        if (!eval.PatternDetected)
+                            eval.PatternDetected = CryptoDirectionFallback.DetectPattern(ctx, eval.RawDirection != TradeDirection.None ? eval.RawDirection : eval.LogicBiasDirection);
+
+                        if (eval.LogicBiasDirection != TradeDirection.None && eval.RawDirection == TradeDirection.None)
+                        {
+                            ctx?.Print(
+                                $"[CRITICAL][DIRECTION_BROKEN] symbol={ctx?.Symbol} entryType={eval.Type} logicBiasDirection={eval.LogicBiasDirection} rawDirection={eval.RawDirection} reason={eval.Reason ?? "NA"}");
+
+                            // Defensive hard guarantee: direction can never remain None when logic bias exists.
+                            eval.Direction = eval.LogicBiasDirection;
+                            eval.RawDirection = eval.LogicBiasDirection;
+                            eval.FallbackDirectionUsed = true;
+                            if (eval.RawLogicConfidence <= 0)
+                                eval.RawLogicConfidence = ctx?.LogicBiasConfidence ?? 0;
                         }
 
                         eval.SetupType = eval.Type.ToString();
@@ -84,7 +97,8 @@ namespace GeminiV26.Core.Entry
 
                         ctx?.Print(
                             $"[ENTRY_TRACE][DIRECTION_SOURCE] symbol={ctx?.Symbol} entryType={eval.Type} biasDirection={eval.LogicBiasDirection} rawDirection={eval.RawDirection} " +
-                            $"fallbackUsed={eval.FallbackDirectionUsed.ToString().ToLowerInvariant()} patternDetected={eval.PatternDetected.ToString().ToLowerInvariant()}");
+                            $"fallbackUsed={eval.FallbackDirectionUsed.ToString().ToLowerInvariant()} confidence={eval.RawLogicConfidence} stage=POST_LOGIC " +
+                            $"patternDetected={eval.PatternDetected.ToString().ToLowerInvariant()}");
 
                         eval = EntryDecisionPolicy.Normalize(eval);
                         eval.FinalScoreSnapshot = eval.Score;

--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -26,13 +26,14 @@ namespace GeminiV26.EntryTypes.Crypto
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 20)
                 return Invalid(ctx, "CTX_NOT_READY");
 
-            if (ctx.LogicBias == TradeDirection.None)
+            TradeDirection logicBiasDirection = ctx.LogicBiasDirection;
+            if (logicBiasDirection == TradeDirection.None)
                 return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
 
             if (ctx.AtrM5 <= 0)
                 return Invalid(ctx, "ATR_ZERO");
 
-            int directionalBarsSinceImpulse = ctx.LogicBias switch
+            int directionalBarsSinceImpulse = logicBiasDirection switch
             {
                 TradeDirection.Long => ctx.BarsSinceImpulseLong_M5,
                 TradeDirection.Short => ctx.BarsSinceImpulseShort_M5,
@@ -105,16 +106,16 @@ namespace GeminiV26.EntryTypes.Crypto
 
             var profile = CryptoInstrumentMatrix.Get(ctx.Symbol);
 
-            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
-                return Invalid(ctx, TradeDirection.None, "HTF_MISMATCH", 0);
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != logicBiasDirection)
+                return Invalid(ctx, logicBiasDirection, "HTF_MISMATCH", 0);
 
-            if (ctx.LogicBias == TradeDirection.Long)
+            if (logicBiasDirection == TradeDirection.Long)
             {
                 var eval = EvaluateSide(ctx, TradeDirection.Long, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
                 EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
                 return EntryDecisionPolicy.Normalize(eval);
             }
-            else if (ctx.LogicBias == TradeDirection.Short)
+            else if (logicBiasDirection == TradeDirection.Short)
             {
                 var eval = EvaluateSide(ctx, TradeDirection.Short, hi, lo, hasValidRange, rangeAtr, lastClosed, profile?.MaxFlagAtrMult ?? 0);
                 EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -21,19 +21,20 @@ namespace GeminiV26.EntryTypes.Crypto
             var originalTrendDirection = ctx.TrendDirection;
             try
             {
-                if (ctx.LogicBias == TradeDirection.None)
+                TradeDirection logicBiasDirection = ctx.LogicBiasDirection;
+                if (logicBiasDirection == TradeDirection.None)
                     return Block(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
 
-                if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
-                    return Block(ctx, "HTF_MISMATCH", 0, TradeDirection.None);
+                if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != logicBiasDirection)
+                    return Block(ctx, "HTF_MISMATCH", 0, logicBiasDirection);
 
-                if (ctx.LogicBias == TradeDirection.Long)
+                if (logicBiasDirection == TradeDirection.Long)
                 {
                     var eval = EvaluateDirectional(ctx, TradeDirection.Long);
                     EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
                     return EntryDecisionPolicy.Normalize(eval);
                 }
-                else if (ctx.LogicBias == TradeDirection.Short)
+                else if (logicBiasDirection == TradeDirection.Short)
                 {
                     var eval = EvaluateDirectional(ctx, TradeDirection.Short);
                     EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -16,7 +16,8 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
-            if (ctx.LogicBias == TradeDirection.None)
+            TradeDirection logicBiasDirection = ctx.LogicBiasDirection;
+            if (logicBiasDirection == TradeDirection.None)
                 return Invalid(ctx, "NO_LOGIC_BIAS", TradeDirection.None, 0);
 
             var crypto = CryptoInstrumentMatrix.Get(ctx.Symbol);
@@ -27,16 +28,16 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MIN_RANGE_BARS)
                 return Invalid(ctx, "NO_RANGE");
 
-            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
-                return Invalid(ctx, "HTF_MISMATCH", TradeDirection.None, 0);
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != logicBiasDirection)
+                return Invalid(ctx, "HTF_MISMATCH", logicBiasDirection, 0);
 
-            if (ctx.LogicBias == TradeDirection.Long)
+            if (logicBiasDirection == TradeDirection.Long)
             {
                 var eval = EvaluateSide(ctx, TradeDirection.Long);
                 EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
                 return EntryDecisionPolicy.Normalize(eval);
             }
-            else if (ctx.LogicBias == TradeDirection.Short)
+            else if (logicBiasDirection == TradeDirection.Short)
             {
                 var eval = EvaluateSide(ctx, TradeDirection.Short);
                 EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -16,22 +16,23 @@ namespace GeminiV26.EntryTypes.Crypto
             if (ctx == null || !ctx.IsReady)
                 return Invalid(ctx, "CTX_NOT_READY");
 
-            if (ctx.LogicBias == TradeDirection.None)
+            TradeDirection logicBiasDirection = ctx.LogicBiasDirection;
+            if (logicBiasDirection == TradeDirection.None)
                 return Invalid(ctx, "NO_LOGIC_BIAS", TradeDirection.None, 0);
 
             if (!ctx.IsVolatilityAcceptable_Crypto)
                 return Invalid(ctx, "CRYPTO_VOL_DISABLED");
 
-            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias)
-                return Invalid(ctx, "HTF_MISMATCH", TradeDirection.None, 0);
+            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != logicBiasDirection)
+                return Invalid(ctx, "HTF_MISMATCH", logicBiasDirection, 0);
 
-            if (ctx.LogicBias == TradeDirection.Long)
+            if (logicBiasDirection == TradeDirection.Long)
             {
                 var eval = EvaluateSide(ctx, TradeDirection.Long);
                 EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
                 return EntryDecisionPolicy.Normalize(eval);
             }
-            else if (ctx.LogicBias == TradeDirection.Short)
+            else if (logicBiasDirection == TradeDirection.Short)
             {
                 var eval = EvaluateSide(ctx, TradeDirection.Short);
                 EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);


### PR DESCRIPTION
### Motivation
- Logs showed cases where `LogicBiasDirection != None` but `RawDirection == None`, causing `ENTRY_NO_SIGNAL` and a dead pipeline state.  
- The fallback was too restricted or executed too late, allowing downstream scoring/gates to clear direction away.  
- The goal is a structural fix: whenever logic bias exists, a usable `rawDirection` must be produced and preserved through SCORE/GATES/FINAL stages with diagnostic visibility.

### Description
- Changed `CryptoDirectionFallback.ApplyIfEligible` to always apply when `ctx.LogicBiasDirection` exists and `eval.Direction` is `None`, removed previous pattern/structure and hard-reason gating, and ensured both `Direction` and `RawDirection` are set.  
- Added a fallback confidence floor `MinimumFallbackConfidence = ceil(EntryDecisionPolicy.MinScoreThreshold * 0.6)` and assign `RawLogicConfidence` at least to this floor so fallback directions have usable confidence.  
- Reordered and hardened router post-evaluation flow in `EntryRouter` so fallback runs immediately after snapshotting `LogicBiasDirection`/`RawDirection`; added a defensive hard-guard that logs `[CRITICAL][DIRECTION_BROKEN]` and force-assigns `Direction`/`RawDirection` when bias exists but direction would otherwise remain `None`.  
- Extended the `[ENTRY_TRACE][DIRECTION_SOURCE]` log to include `confidence` and `stage=POST_LOGIC`, and updated crypto entry modules (`BTC_PullbackEntry`, `BTC_FlagEntry`, `BTC_RangeBreakoutEntry`, `Crypto_ImpulseEntry`) to capture `logicBiasDirection` early and preserve that context on HTF-mismatch/invalid paths.

### Testing
- Ran static checks with `git diff --check` and it completed without formatting errors.  
- Verified presence of trace/guard keywords with `rg -n "DIRECTION_BROKEN|stage=POST_LOGIC|MinimumFallbackConfidence|ApplyIfEligible"` and confirmed the new hooks are present.  
- Performed repository searches to confirm all four crypto entry modules were updated to use `logicBiasDirection`, and those searches succeeded.  
- No runtime/unit build was executed in this change set; only static validations and pattern checks were run and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8357963dc83288108414e006d1dc6)