### PR TITLE
Make crypto HTF mismatch checks soft-log only

### DIFF
--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -106,8 +106,19 @@ namespace GeminiV26.EntryTypes.Crypto
 
             var profile = CryptoInstrumentMatrix.Get(ctx.Symbol);
 
-            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != logicBiasDirection)
-                return Invalid(ctx, logicBiasDirection, "HTF_MISMATCH", 0);
+            double htfConf = ctx.ResolveAssetHtfConfidence01();
+            var htfDir = ctx.ResolveAssetHtfAllowedDirection();
+            bool htfMismatch =
+                htfConf >= 0.6 &&
+                htfDir != TradeDirection.None &&
+                logicBiasDirection != TradeDirection.None &&
+                htfDir != logicBiasDirection;
+
+            if (htfMismatch)
+            {
+                ctx.Log?.Invoke(
+                    $"[CRYPTO][HTF_SOFT] mismatch allowed | dir={logicBiasDirection} htf={htfDir} conf={htfConf:0.00}");
+            }
 
             if (logicBiasDirection == TradeDirection.Long)
             {
@@ -326,6 +337,16 @@ namespace GeminiV26.EntryTypes.Crypto
 
             if (score < MinScore)
                 return Invalid(ctx, dir, $"LOW_SCORE({score})", score);
+
+            double finalHtfConf = ctx.ResolveAssetHtfConfidence01();
+            var finalHtfDir = ctx.ResolveAssetHtfAllowedDirection();
+            bool htfMismatch =
+                finalHtfConf >= 0.6 &&
+                finalHtfDir != TradeDirection.None &&
+                dir != TradeDirection.None &&
+                finalHtfDir != dir;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][ENTRY_FINAL] dir={dir} score={score} htfMismatch={htfMismatch}");
 
             var eval = new EntryEvaluation
             {

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -25,8 +25,19 @@ namespace GeminiV26.EntryTypes.Crypto
                 if (logicBiasDirection == TradeDirection.None)
                     return Block(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
 
-                if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != logicBiasDirection)
-                    return Block(ctx, "HTF_MISMATCH", 0, logicBiasDirection);
+                double htfConf = ctx.ResolveAssetHtfConfidence01();
+                var htfDir = ctx.ResolveAssetHtfAllowedDirection();
+                bool htfMismatch =
+                    htfConf >= 0.6 &&
+                    htfDir != TradeDirection.None &&
+                    logicBiasDirection != TradeDirection.None &&
+                    htfDir != logicBiasDirection;
+
+                if (htfMismatch)
+                {
+                    ctx.Log?.Invoke(
+                        $"[CRYPTO][HTF_SOFT] mismatch allowed | dir={logicBiasDirection} htf={htfDir} conf={htfConf:0.00}");
+                }
 
                 if (logicBiasDirection == TradeDirection.Long)
                 {
@@ -90,10 +101,8 @@ namespace GeminiV26.EntryTypes.Crypto
 
             if (allow != TradeDirection.None && dir != allow)
             {
-                const int SoftConflictPenalty = 4;
-                score -= SoftConflictPenalty;
                 Console.WriteLine(
-                    $"[BTC_PULLBACK][HTF_SOFT_CONFLICT] conf={htfConf:0.00} allow={allow} keepDir={dir} scoreAdj=-{SoftConflictPenalty}"
+                    $"[BTC_PULLBACK][HTF_SOFT_CONFLICT] conf={htfConf:0.00} allow={allow} keepDir={dir}"
                 );
             }
             else if (allow == TradeDirection.None)
@@ -885,6 +894,16 @@ namespace GeminiV26.EntryTypes.Crypto
             // =========================
             if (score < dynamicMinScore)
                 return Block(ctx, $"SCORE_TOO_LOW_{score}_MIN_{dynamicMinScore}", score, dir);
+
+            double finalHtfConf = ctx.ResolveAssetHtfConfidence01();
+            var finalHtfDir = ctx.ResolveAssetHtfAllowedDirection();
+            bool htfMismatch =
+                finalHtfConf >= 0.6 &&
+                finalHtfDir != TradeDirection.None &&
+                dir != TradeDirection.None &&
+                finalHtfDir != dir;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][ENTRY_FINAL] dir={dir} score={score} htfMismatch={htfMismatch}");
 
             var eval = new EntryEvaluation
             {

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -28,8 +28,19 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MIN_RANGE_BARS)
                 return Invalid(ctx, "NO_RANGE");
 
-            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != logicBiasDirection)
-                return Invalid(ctx, "HTF_MISMATCH", logicBiasDirection, 0);
+            double htfConf = ctx.ResolveAssetHtfConfidence01();
+            var htfDir = ctx.ResolveAssetHtfAllowedDirection();
+            bool htfMismatch =
+                htfConf >= 0.6 &&
+                htfDir != TradeDirection.None &&
+                logicBiasDirection != TradeDirection.None &&
+                htfDir != logicBiasDirection;
+
+            if (htfMismatch)
+            {
+                ctx.Log?.Invoke(
+                    $"[CRYPTO][HTF_SOFT] mismatch allowed | dir={logicBiasDirection} htf={htfDir} conf={htfConf:0.00}");
+            }
 
             if (logicBiasDirection == TradeDirection.Long)
             {
@@ -139,6 +150,18 @@ namespace GeminiV26.EntryTypes.Crypto
 
             if (!eval.IsValid)
                 eval.Reason += $"LowScore({score});";
+            else
+            {
+                double htfConf = ctx.ResolveAssetHtfConfidence01();
+                var htfDir = ctx.ResolveAssetHtfAllowedDirection();
+                bool htfMismatch =
+                    htfConf >= 0.6 &&
+                    htfDir != TradeDirection.None &&
+                    dir != TradeDirection.None &&
+                    htfDir != dir;
+                ctx.Log?.Invoke(
+                    $"[CRYPTO][ENTRY_FINAL] dir={dir} score={score} htfMismatch={htfMismatch}");
+            }
 
             return eval;
         }

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -23,8 +23,19 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!ctx.IsVolatilityAcceptable_Crypto)
                 return Invalid(ctx, "CRYPTO_VOL_DISABLED");
 
-            if (ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != logicBiasDirection)
-                return Invalid(ctx, "HTF_MISMATCH", logicBiasDirection, 0);
+            double htfConf = ctx.ResolveAssetHtfConfidence01();
+            var htfDir = ctx.ResolveAssetHtfAllowedDirection();
+            bool htfMismatch =
+                htfConf >= 0.6 &&
+                htfDir != TradeDirection.None &&
+                logicBiasDirection != TradeDirection.None &&
+                htfDir != logicBiasDirection;
+
+            if (htfMismatch)
+            {
+                ctx.Log?.Invoke(
+                    $"[CRYPTO][HTF_SOFT] mismatch allowed | dir={logicBiasDirection} htf={htfDir} conf={htfConf:0.00}");
+            }
 
             if (logicBiasDirection == TradeDirection.Long)
             {
@@ -76,6 +87,16 @@ namespace GeminiV26.EntryTypes.Crypto
 
             if (score < MinScore)
                 return Invalid(ctx, $"LOW_SCORE_{dir}_{score}", dir, score);
+
+            double htfConf = ctx.ResolveAssetHtfConfidence01();
+            var htfDir = ctx.ResolveAssetHtfAllowedDirection();
+            bool htfMismatch =
+                htfConf >= 0.6 &&
+                htfDir != TradeDirection.None &&
+                dir != TradeDirection.None &&
+                htfDir != dir;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][ENTRY_FINAL] dir={dir} score={score} htfMismatch={htfMismatch}");
 
             var eval = new EntryEvaluation
             {


### PR DESCRIPTION
### Motivation
- Remove all hard HTF rejection logic from crypto entry implementations so HTF becomes informational only. 
- Ensure HTF no longer returns `Invalid()` / `Block()` / zeroes score or invalidates candidates in entry files. 
- Target only the specified crypto entry types to keep changes minimal and surgical.

### Description
- Replaced hard `HTF_MISMATCH` gating in `BTC_FlagEntry`, `BTC_PullbackEntry`, `BTC_RangeBreakoutEntry`, and `Crypto_ImpulseEntry` with a soft `htfMismatch` check that logs `[CRYPTO][HTF_SOFT] mismatch allowed` and does not return or block. 
- Converted any entry-local HTF score adjustment in `BTC_PullbackEntry` soft-conflict section to log-only (removed direct `score -= SoftConflictPenalty` in that section). 
- Added final debug logging immediately before returning a valid evaluation in the evaluated paths that include `score`, using `ctx.Log?.Invoke($"[CRYPTO][ENTRY_FINAL] dir={dir} score={score} htfMismatch={htfMismatch}")` to record HTF state without changing evaluation values. 
- Changes were restricted to logic inside the four listed `EntryTypes/CRYPTO/*` files and did not alter method signatures, class names, or other modules.

### Testing
- Searched for `HTF_MISMATCH` with `rg` in the four modified files and found no matches, confirming hard rejection markers were removed. (passed)
- Searched for the new log markers with `rg` for `"[CRYPTO][HTF_SOFT] mismatch allowed"` and `"[CRYPTO][ENTRY_FINAL]"` and confirmed they exist in all four target files. (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c83d7dda7083289bac81316a763dd2)