### PR TITLE
Fix CS0136 variable shadowing in BTC_PullbackEntry

### DIFF
--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -641,12 +641,12 @@ namespace GeminiV26.EntryTypes.Crypto
                         score -= 10;
                     }
 
-                    TradeDirection impulseDirection =
+                    TradeDirection breakoutImpulseDirection =
                         ctx.ImpulseDirection != TradeDirection.None ? ctx.ImpulseDirection : dir;
 
                     bool breakoutAligned =
-                        (impulseDirection == TradeDirection.Long && bars[lastClosed].Close > compressionHigh) ||
-                        (impulseDirection == TradeDirection.Short && bars[lastClosed].Close < compressionLow);
+                        (breakoutImpulseDirection == TradeDirection.Long && bars[lastClosed].Close > compressionHigh) ||
+                        (breakoutImpulseDirection == TradeDirection.Short && bars[lastClosed].Close < compressionLow);
 
                     if (!breakoutAligned)
                     {


### PR DESCRIPTION
### Motivation
- Resolve a C# compiler error caused by redeclaring a local variable name that shadows an outer-scope variable in `EntryTypes/CRYPTO/BTC_PullbackEntry.cs`.

### Description
- In `EntryTypes/CRYPTO/BTC_PullbackEntry.cs` renamed the inner-scope `impulseDirection` to `breakoutImpulseDirection` and updated the breakout alignment checks to use `breakoutImpulseDirection` to remove the shadowed declaration.

### Testing
- Attempted to run `dotnet build` but the environment lacks the .NET CLI (`dotnet: command not found`), so no build/test could be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8e8f15a588328a307714d5231fd11)