### PR TITLE
Relax BTC crypto entry gating and add local regime/HTF scoring with debug traces

### DIFF
--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -10,15 +10,14 @@ namespace GeminiV26.EntryTypes.Crypto
     {
         public EntryType Type => EntryType.Crypto_Flag;
 
-        private const int MaxBarsSinceImpulse = 18;
+        private const int MaxBarsSinceImpulse = 22;
         private const int MinFlagBars = 3;
-        private const int MaxFlagBars = 7;
+        private const int MaxFlagBars = 9;
 
         private const double BreakBufferAtr = 0.03;
         private const double MaxDistFromEmaAtr = 1.2;
 
         private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
-        private const int HtfAgainstPenalty = 8;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
@@ -42,7 +41,7 @@ namespace GeminiV26.EntryTypes.Crypto
 
             bool hasDirectionalImpulse = directionalBarsSinceImpulse <= MaxBarsSinceImpulse;
 
-            if (!ctx.HasImpulse_M5 && !hasDirectionalImpulse && ctx.BarsSinceImpulse_M5 > 14)
+            if (!ctx.HasImpulse_M5 && !hasDirectionalImpulse && ctx.BarsSinceImpulse_M5 > 18)
                 return Invalid(ctx, "NO_RECENT_IMPULSE");
 
             if (directionalBarsSinceImpulse > MaxBarsSinceImpulse)
@@ -151,6 +150,20 @@ namespace GeminiV26.EntryTypes.Crypto
             int score = 0;
             int setupScore = 0;
             double triggerScore = 0;
+            int baseScore;
+            int scoreAfterRegime;
+            int scoreAfterHtf;
+
+            TradeDirection impulseDirection = ctx.ImpulseDirection;
+            if (impulseDirection == TradeDirection.None)
+                impulseDirection = dir;
+            int barsSinceImpulse = Math.Max(0, ctx.BarsSinceImpulse_M5);
+            bool isSameDirection = (dir == impulseDirection);
+            bool shouldBlock = (barsSinceImpulse < 1) && !isSameDirection;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][IMPULSE_GATE] entryType=Flag barsSinceImpulse={barsSinceImpulse} impulseDir={impulseDirection} entryDir={dir} sameDir={isSameDirection.ToString().ToLowerInvariant()} blocked={shouldBlock.ToString().ToLowerInvariant()}");
+            if (shouldBlock)
+                return Invalid(ctx, dir, "IMPULSE_LOCK_IMMEDIATE_COUNTER", score);
 
             if (!ctx.HasImpulse_M5)
             {
@@ -166,7 +179,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 ctx.AdxSlope_M5 <= 1.5;
 
             if (!compression)
-                score -= 6;
+                score -= 2;
 
             if (rangeAtr > 0)
             {
@@ -196,7 +209,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 ctx.IsValidFlagStructure_M5;
 
             bool structuredPB =
-                ctx.PullbackBars_M5 >= 2 &&
+                ctx.PullbackBars_M5 >= 1 &&
                 ctx.IsPullbackDecelerating_M5;
 
             string flagState = hasFlag ? "OK" : "FLAG_WEAK_OR_FORMING";
@@ -266,7 +279,11 @@ namespace GeminiV26.EntryTypes.Crypto
                 hasFlag || structuredPB;
 
             if (!hasStructure)
+            {
                 setupScore -= 30;
+                ctx.Log?.Invoke(
+                    "[CRYPTO][STRUCT_FILTER] entryType=Flag reason=NO_FLAG_OR_STRUCTURED_PULLBACK blocked=false");
+            }
             else
                 setupScore += 15;
 
@@ -287,12 +304,6 @@ namespace GeminiV26.EntryTypes.Crypto
 
             if (strongCandle) score += 6;
 
-            if (ctx.TrendDirection != TradeDirection.None &&
-                dir != ctx.TrendDirection)
-            {
-                score -= HtfAgainstPenalty;
-            }
-
             bool missingImpulse =
                 string.Equals(ctx.Transition?.Reason, "MissingImpulse", StringComparison.Ordinal);
 
@@ -303,8 +314,30 @@ namespace GeminiV26.EntryTypes.Crypto
                     $"symbol={ctx.Symbol} entry={EntryType.Crypto_Flag} penalty=6 score={score}");
             }
 
-            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
             score += setupScore;
+            baseScore = score;
+
+            bool trendRegime =
+                ctx.MarketState?.IsTrend == true ||
+                (!ctx.IsRange_M5 && ctx.Adx_M5 >= 18.0);
+            string regime = trendRegime ? "Trend" : "NonTrend";
+            bool regimeMismatch = !trendRegime;
+
+            int regimeDelta = regimeMismatch ? -25 : +5;
+            score += regimeDelta;
+            scoreAfterRegime = score;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][REGIME_ADJUST] entryType=Flag regime={regime} delta={regimeDelta} scoreAfter={scoreAfterRegime}");
+
+            var htfDirection = ctx.CryptoHtfAllowedDirection;
+            int htfDelta = htfDirection == dir ? +8 : -10;
+            score += htfDelta;
+            scoreAfterHtf = score;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][HTF_SCORE] entryType=Flag entryDir={dir} htfDir={htfDirection} delta={htfDelta} scoreAfter={scoreAfterHtf}");
+
+            ctx.Log?.Invoke(
+                $"[CRYPTO][FINAL_SCORE] entryType=Flag baseScore={baseScore} afterRegime={scoreAfterRegime} afterHtf={scoreAfterHtf} finalScore={score}");
 
             bool followThrough = continuationSignal;
 
@@ -393,19 +426,6 @@ namespace GeminiV26.EntryTypes.Crypto
             evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
             evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
             evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
-        }
-
-        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
-        {
-            return EntryDirectionQuality.Apply(
-                ctx,
-                direction,
-                score,
-                new DirectionQualityRequest
-                {
-                    TypeTag = "BTC_FlagEntry",
-                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
-                });
         }
 
     }

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -8,7 +8,7 @@ namespace GeminiV26.EntryTypes.Crypto
     {
         public EntryType Type => EntryType.Crypto_RangeBreakout;
         private const int MIN_SCORE = EntryDecisionPolicy.MinScoreThreshold;
-        private const int MIN_RANGE_BARS = 15;
+        private const int MIN_RANGE_BARS = 10;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
@@ -26,7 +26,11 @@ namespace GeminiV26.EntryTypes.Crypto
                 return Invalid(ctx, "DISABLED");
 
             if (!ctx.IsRange_M5 || ctx.RangeBarCount_M5 < MIN_RANGE_BARS)
+            {
+                ctx.Log?.Invoke(
+                    "[CRYPTO][STRUCT_FILTER] entryType=Breakout reason=NO_RANGE blocked=true");
                 return Invalid(ctx, "NO_RANGE");
+            }
 
             double htfConf = ctx.ResolveAssetHtfConfidence01();
             var htfDir = ctx.ResolveAssetHtfAllowedDirection();
@@ -61,6 +65,20 @@ namespace GeminiV26.EntryTypes.Crypto
         {
             int score = 25;
             int setupScore = 0;
+            int baseScore;
+            int scoreAfterRegime;
+            int scoreAfterHtf;
+
+            TradeDirection impulseDirection = ctx.ImpulseDirection;
+            if (impulseDirection == TradeDirection.None)
+                impulseDirection = dir;
+            int barsSinceImpulse = System.Math.Max(0, ctx.BarsSinceImpulse_M5);
+            bool isSameDirection = (dir == impulseDirection);
+            bool shouldBlock = (barsSinceImpulse < 1) && !isSameDirection;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][IMPULSE_GATE] entryType=Breakout barsSinceImpulse={barsSinceImpulse} impulseDir={impulseDirection} entryDir={dir} sameDir={isSameDirection.ToString().ToLowerInvariant()} blocked={shouldBlock.ToString().ToLowerInvariant()}");
+            if (shouldBlock)
+                return Invalid(ctx, "IMPULSE_LOCK_IMMEDIATE_COUNTER", dir, score);
 
             if (!ctx.IsVolatilityAcceptable_Crypto)
                 score -= 15;
@@ -79,14 +97,18 @@ namespace GeminiV26.EntryTypes.Crypto
                 ctx.IsValidFlagStructure_M5;
 
             bool structuredPB =
-                ctx.PullbackBars_M5 >= 2 &&
+                ctx.PullbackBars_M5 >= 1 &&
                 ctx.IsPullbackDecelerating_M5;
 
             bool hasStructure =
                 hasFlag || structuredPB;
 
             if (!hasStructure)
+            {
                 setupScore -= 30;
+                ctx.Log?.Invoke(
+                    "[CRYPTO][STRUCT_FILTER] entryType=Breakout reason=NO_FLAG_OR_STRUCTURED_PULLBACK blocked=false");
+            }
             else
                 setupScore += 15;
 
@@ -102,7 +124,7 @@ namespace GeminiV26.EntryTypes.Crypto
             // =========================
             // BREAK STRENGTH
             // =========================
-            if (ctx.RangeBreakAtrSize_M5 > 1.2)
+            if (ctx.RangeBreakAtrSize_M5 > 1.4)
                 return Invalid(ctx, "OVEREXTENDED_BREAK", dir, 0);
 
             score += 10;
@@ -139,8 +161,29 @@ namespace GeminiV26.EntryTypes.Crypto
             bool followThrough = ctx.M1TriggerInTrendDirection || (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
             score = TriggerScoreModel.Apply(ctx, $"BTC_RANGE_BREAKOUT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_RANGE_BREAK_TRIGGER");
 
-            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, false);
             score += setupScore;
+            baseScore = score;
+
+            bool trendRegime =
+                ctx.MarketState?.IsTrend == true ||
+                (!ctx.IsRange_M5 && ctx.Adx_M5 >= 18.0);
+            string regime = trendRegime ? "Trend" : "NonTrend";
+            bool regimeMismatch = !trendRegime;
+            int regimeDelta = regimeMismatch ? -25 : +5;
+            score += regimeDelta;
+            scoreAfterRegime = score;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][REGIME_ADJUST] entryType=Breakout regime={regime} delta={regimeDelta} scoreAfter={scoreAfterRegime}");
+
+            var htfDirection = ctx.CryptoHtfAllowedDirection;
+            int htfDelta = htfDirection == dir ? +8 : -10;
+            score += htfDelta;
+            scoreAfterHtf = score;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][HTF_SCORE] entryType=Breakout entryDir={dir} htfDir={htfDirection} delta={htfDelta} scoreAfter={scoreAfterHtf}");
+
+            ctx.Log?.Invoke(
+                $"[CRYPTO][FINAL_SCORE] entryType=Breakout baseScore={baseScore} afterRegime={scoreAfterRegime} afterHtf={scoreAfterHtf} finalScore={score}");
 
             if (setupScore <= 0)
                 score = System.Math.Min(score, MIN_SCORE - 10);
@@ -210,19 +253,6 @@ namespace GeminiV26.EntryTypes.Crypto
             evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
             evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
             evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
-        }
-
-        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
-        {
-            return EntryDirectionQuality.Apply(
-                ctx,
-                direction,
-                score,
-                new DirectionQualityRequest
-                {
-                    TypeTag = "BTC_RangeBreakoutEntry",
-                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
-                });
         }
 
     }

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -20,9 +20,6 @@ namespace GeminiV26.EntryTypes.Crypto
             if (logicBiasDirection == TradeDirection.None)
                 return Invalid(ctx, "NO_LOGIC_BIAS", TradeDirection.None, 0);
 
-            if (!ctx.IsVolatilityAcceptable_Crypto)
-                return Invalid(ctx, "CRYPTO_VOL_DISABLED");
-
             double htfConf = ctx.ResolveAssetHtfConfidence01();
             var htfDir = ctx.ResolveAssetHtfAllowedDirection();
             bool htfMismatch =
@@ -55,13 +52,35 @@ namespace GeminiV26.EntryTypes.Crypto
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir)
         {
             int score = 60;
+            int baseScore;
+            int scoreAfterRegime;
+            int scoreAfterHtf;
+
+            TradeDirection impulseDirection = ctx.ImpulseDirection;
+            if (impulseDirection == TradeDirection.None)
+                impulseDirection = dir;
+            int barsSinceImpulse = Math.Max(0, ctx.BarsSinceImpulse_M5);
+            bool isSameDirection = (dir == impulseDirection);
+            bool shouldBlock = (barsSinceImpulse < 1) && !isSameDirection;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][IMPULSE_GATE] entryType=Impulse barsSinceImpulse={barsSinceImpulse} impulseDir={impulseDirection} entryDir={dir} sameDir={isSameDirection.ToString().ToLowerInvariant()} blocked={shouldBlock.ToString().ToLowerInvariant()}");
+            if (shouldBlock)
+                return Invalid(ctx, "IMPULSE_LOCK_IMMEDIATE_COUNTER", dir, score);
+
+            if (!ctx.IsVolatilityAcceptable_Crypto)
+            {
+                score -= 8;
+                ctx.Log?.Invoke(
+                    "[CRYPTO][STRUCT_FILTER] entryType=Impulse reason=LOW_CRYPTO_VOL blocked=false");
+            }
+
             bool directionalImpulse = ctx.ImpulseDirection == dir;
             bool directionalTrend = ctx.TrendDirection == dir;
 
             if (!directionalImpulse && !directionalTrend &&
                 (ctx.ImpulseDirection != TradeDirection.None || ctx.TrendDirection != TradeDirection.None))
             {
-                score -= 18;
+                score -= 10;
             }
 
             if (directionalImpulse)
@@ -81,9 +100,28 @@ namespace GeminiV26.EntryTypes.Crypto
             bool followThrough = breakoutDetected || (ctx.IsAtrExpanding_M5 && (directionalImpulse || directionalTrend));
 
             score = TriggerScoreModel.Apply(ctx, $"CRYPTO_IMPULSE_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_IMPULSE_TRIGGER");
+            baseScore = score;
 
+            bool trendRegime =
+                ctx.MarketState?.IsTrend == true ||
+                (!ctx.IsRange_M5 && ctx.Adx_M5 >= 18.0);
+            string regime = trendRegime ? "Trend" : "NonTrend";
+            bool regimeMismatch = !trendRegime;
+            int regimeDelta = regimeMismatch ? -25 : +5;
+            score += regimeDelta;
+            scoreAfterRegime = score;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][REGIME_ADJUST] entryType=Impulse regime={regime} delta={regimeDelta} scoreAfter={scoreAfterRegime}");
 
-            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
+            var htfDirection = ctx.CryptoHtfAllowedDirection;
+            int htfDelta = htfDirection == dir ? +8 : -10;
+            score += htfDelta;
+            scoreAfterHtf = score;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][HTF_SCORE] entryType=Impulse entryDir={dir} htfDir={htfDirection} delta={htfDelta} scoreAfter={scoreAfterHtf}");
+
+            ctx.Log?.Invoke(
+                $"[CRYPTO][FINAL_SCORE] entryType=Impulse baseScore={baseScore} afterRegime={scoreAfterRegime} afterHtf={scoreAfterHtf} finalScore={score}");
 
             if (score < MinScore)
                 return Invalid(ctx, $"LOW_SCORE_{dir}_{score}", dir, score);
@@ -143,19 +181,6 @@ namespace GeminiV26.EntryTypes.Crypto
             evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
             evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
             evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
-        }
-
-        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
-        {
-            return EntryDirectionQuality.Apply(
-                ctx,
-                direction,
-                score,
-                new DirectionQualityRequest
-                {
-                    TypeTag = "Crypto_ImpulseEntry",
-                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
-                });
         }
 
     }


### PR DESCRIPTION
### Motivation
- Align CRYPTO entry types with the relaxed, functional behavior already used in `BTC_PullbackEntry` so crypto signals are less over-filtered while preserving safety constraints. 
- Keep all changes local to the crypto entry classes and avoid touching guarded/shared components.

### Description
- Modified `BTC_FlagEntry`, `BTC_RangeBreakoutEntry`, and `Crypto_ImpulseEntry` to implement the relaxed impulse gate that only blocks immediate counter-direction trades and always allows same-direction continuation, emitting `[CRYPTO][IMPULSE_GATE]` logs with `entryType`, bars-since-impulse, directions and blocked status. 
- Relaxed local structural thresholds and penalties: increased `MaxBarsSinceImpulse` and `MaxFlagBars` in `BTC_FlagEntry`, lowered `MIN_RANGE_BARS` in `BTC_RangeBreakoutEntry`, raised `RangeBreakAtr` tolerance, reduced strict compression/maturity penalties and softened hard volatility rejection in `Crypto_ImpulseEntry` (penalty-only with a `[CRYPTO][STRUCT_FILTER]` log). 
- Replaced dependency on external/global scoring for these entry classes with local single-pass regime scoring (`-25` / `+5`) and a single HTF adjustment (`+8` / `-10`), and added the required debug traces: `[CRYPTO][REGIME_ADJUST]`, `[CRYPTO][HTF_SCORE]`, and `[CRYPTO][FINAL_SCORE]` including `entryType` and intermediate scores. 
- Kept all changes confined to the three CRYPTO entry files only (`EntryTypes/CRYPTO/BTC_FlagEntry.cs`, `EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs`, `EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs`) and did not alter `TradeCore`, `EntryRouter`, `ExitManager`, `RiskSizer`, or global scoring utilities.

### Testing
- Attempted build with `dotnet build`, which could not run in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`). (failed)
- Performed static verification and line inspections using `rg` and file listing to confirm only the three intended files were modified and required log lines and local scoring were added. (succeeded)
- Verified repository state with `git status --short` and confirmed the modified files are staged/committed locally. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8e9a581c88328ad23b7455dee26d3)