### PR TITLE
Relax HTF-aligned short Crypto flag structure and add score floor

### DIFF
--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -355,6 +355,44 @@ namespace GeminiV26.EntryTypes.Crypto
                 $"[CRYPTO][HTF_SCORE] htf={htfDirection} logic={dir} delta={htfDelta} scoreAfter={scoreAfterHtf}");
 
             bool followThrough = continuationSignal;
+            bool impulseDetected = ctx.HasImpulse_M5 || barsSinceImpulse <= MaxBarsSinceImpulse;
+            bool continuationDetected = continuationSignal;
+            bool pullbackDetected = structuredPB;
+            bool flagCompressionDetected = hasFlag && hasValidRange && rangeAtr > 0 && rangeAtr <= 1.00;
+            bool isHtfAlignedShort = htfAligned && dir == TradeDirection.Short;
+
+            bool structureValid = hasStructure;
+            if (isHtfAlignedShort)
+            {
+                structureValid =
+                    impulseDetected &&
+                    (continuationDetected || pullbackDetected || flagCompressionDetected);
+                ctx.Log?.Invoke(
+                    $"[CRYPTO][FLAG_STRUCTURE_RELAX] dir=Short htfAlign=true impulse={impulseDetected.ToString().ToLowerInvariant()} continuation={continuationDetected.ToString().ToLowerInvariant()} pullback={pullbackDetected.ToString().ToLowerInvariant()} compression={flagCompressionDetected.ToString().ToLowerInvariant()} finalStructure={structureValid.ToString().ToLowerInvariant()}");
+            }
+
+            if (!structureValid)
+                return Invalid(ctx, dir, "INVALID_STRUCTURE", score);
+
+            int scoreAfterStructure = score;
+
+            bool momentumAligned =
+                hasVolatility ||
+                ctx.LastClosedBarInTrendDirection ||
+                continuationDetected ||
+                breakoutDetected;
+            bool originalMomentumAligned = momentumAligned;
+            if (isHtfAlignedShort)
+            {
+                momentumAligned = momentumAligned || impulseDetected;
+                ctx.Log?.Invoke(
+                    $"[CRYPTO][FLAG_MOMENTUM_OVERRIDE] originalMomentum={originalMomentumAligned.ToString().ToLowerInvariant()} impulseDetected={impulseDetected.ToString().ToLowerInvariant()} finalMomentum={momentumAligned.ToString().ToLowerInvariant()}");
+            }
+
+            if (!momentumAligned)
+                return Invalid(ctx, dir, "INVALID_MOMENTUM", score);
+
+            int scoreAfterMomentum = score;
 
             if (breakoutDetected)
                 triggerScore += 1;
@@ -374,11 +412,33 @@ namespace GeminiV26.EntryTypes.Crypto
             if (!minimalTrigger)
                 score -= 10;
 
-            if (!breakoutDetected)
-                score -= 8;
+            int originalEarlyBreakPenalty = !breakoutDetected ? -8 : 0;
+            int appliedEarlyBreakPenalty = originalEarlyBreakPenalty;
+            if (isHtfAlignedShort && appliedEarlyBreakPenalty < -5)
+                appliedEarlyBreakPenalty = -5;
+            score += appliedEarlyBreakPenalty;
+            if (originalEarlyBreakPenalty != 0)
+            {
+                ctx.Log?.Invoke(
+                    $"[CRYPTO][FLAG_EARLY_BREAK_ADJUST] originalPenalty={originalEarlyBreakPenalty} appliedPenalty={appliedEarlyBreakPenalty}");
+            }
 
             if (score < 30 && baseScore >= 40)
                 score = 30;
+
+            if (isHtfAlignedShort && structureValid)
+            {
+                int baseFloorScore = score;
+                score = Math.Max(score, 35);
+                if (continuationDetected)
+                    score = Math.Max(score, 40);
+                ctx.Log?.Invoke(
+                    $"[CRYPTO][FLAG_SCORE_FLOOR] baseScore={baseFloorScore} finalScore={score} htfAlign=true continuation={continuationDetected.ToString().ToLowerInvariant()}");
+            }
+
+            int scoreAfterPenalty = score;
+            ctx.Log?.Invoke(
+                $"[CRYPTO][FLAG_FINAL_SCORE] base={baseScore} afterStructure={scoreAfterStructure} afterMomentum={scoreAfterMomentum} afterPenalty={scoreAfterPenalty} final={score}");
 
             ctx.Log?.Invoke(
                 $"[CRYPTO][FLAG_SCORE] base={baseScore} afterRegime={scoreAfterRegime} afterHtf={scoreAfterHtf} final={score}");


### PR DESCRIPTION
### Motivation
- Crypto short flag setups aligned to HTF were being rejected because structure and momentum checks were too strict, and final scores could collapse to 0 or negative causing router rejections.
- The change aims to allow valid HTF-aligned short continuation/pullback/compression setups into the pipeline without global refactors and without touching shared modules.

### Description
- Modified only `EntryTypes/CRYPTO/BTC_FlagEntry.cs` to apply localized relaxations and score adjustments for HTF-aligned short flags.
- Relaxed structure validity for HTF-aligned shorts to accept a flag when `impulseDetected == true` AND one of `continuationDetected || pullbackDetected || flagCompressionDetected`, and added log `[CRYPTO][FLAG_STRUCTURE_RELAX]` with the structure decision details.
- Relaxed momentum requirement for HTF-aligned shorts by allowing `momentumAligned = momentumAligned || impulseDetected` and added log `[CRYPTO][FLAG_MOMENTUM_OVERRIDE]` showing original and final momentum state.
- Introduced a score floor for HTF-aligned short flags with valid structure: `score = max(score, 35)` and `score = max(score, 40)` when `continuationDetected == true`, plus log `[CRYPTO][FLAG_SCORE_FLOOR]` showing base and final score.
- Softened the early-break penalty for HTF-aligned shorts by capping the applied penalty to `-5` (instead of `-8`) and added log `[CRYPTO][FLAG_EARLY_BREAK_ADJUST]` showing original vs applied penalty.
- Always emit final score trace `[CRYPTO][FLAG_FINAL_SCORE]` showing `base / afterStructure / afterMomentum / afterPenalty / final` so score evolution is observable.
- Scope guardrails followed: only `EntryTypes/CRYPTO/BTC_FlagEntry.cs` was changed and no shared scoring, TradeCore, Router, ExitManager, RiskSizer, or pipeline modifications were made.

### Testing
- Attempted to run the solution build with `dotnet build -nologo`, but the environment lacks the `dotnet` tool so the build could not be executed: `dotnet: command not found` (failure).
- No automated unit or integration tests were executed due to missing .NET tooling in the environment.
- Local static inspection was performed (searches and file preview) to confirm the inserted logging and control-flow changes were placed as intended (informational only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8f5d68688832899ebec1068798d12)