### PR TITLE
Unify instrument executors to use PositionContext.FinalConfidence

### DIFF
--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -128,18 +128,27 @@ namespace GeminiV26.Instruments.AUDNZD
                 _bot.Print($"[AUDNZD EXEC] logicConfidence fallback={logicConfidence}");
             }
 
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
             {
@@ -147,7 +156,7 @@ namespace GeminiV26.Instruments.AUDNZD
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -156,13 +165,13 @@ namespace GeminiV26.Instruments.AUDNZD
             }
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (volumeUnits <= 0)
             {
@@ -203,7 +212,7 @@ namespace GeminiV26.Instruments.AUDNZD
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
@@ -235,10 +244,10 @@ namespace GeminiV26.Instruments.AUDNZD
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad riskConfidence alapján (nem változtatunk működésen)
+                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján (nem változtatunk működésen)
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -122,18 +122,27 @@ namespace GeminiV26.Instruments.AUDUSD
             // =========================================================
             _entryLogic.Evaluate();
             int logicConfidence = _entryLogic.LastLogicConfidence;
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
             {
@@ -141,7 +150,7 @@ namespace GeminiV26.Instruments.AUDUSD
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -150,13 +159,13 @@ namespace GeminiV26.Instruments.AUDUSD
             }
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (volumeUnits <= 0)
             {
@@ -197,7 +206,7 @@ namespace GeminiV26.Instruments.AUDUSD
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
@@ -232,10 +241,10 @@ namespace GeminiV26.Instruments.AUDUSD
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad riskConfidence alapján
+                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -89,22 +89,31 @@ namespace GeminiV26.Instruments.BTCUSD
             _entryLogic.Evaluate(out _, out int logicConfidence);
             int statePenalty = 0;
 
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence)}", entryContext));
 
             // =========================================================
             // SL DISTANCE (ATR)
             // =========================================================
             double slPriceDist =
-                CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+                CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence), entry.Type);
 
             if (slPriceDist <= 0)
                 return;
@@ -116,12 +125,12 @@ namespace GeminiV26.Instruments.BTCUSD
             // =========================================================
             // RISK-BASED VOLUME (CRYPTO POSITION SIZER)
             // =========================================================
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence));
             long volumeUnits = CryptoPositionSizer.Calculate(
                 _bot,
                 riskPercent,
                 slPriceDist,
-                _riskSizer.GetLotCap(riskConfidence));
+                _riskSizer.GetLotCap(PositionContext.ClampRiskConfidence(ctx.FinalConfidence)));
 
             if (volumeUnits < _bot.Symbol.VolumeInUnitsMin)
             {
@@ -136,7 +145,7 @@ namespace GeminiV26.Instruments.BTCUSD
             // TP POLICY
             // =========================================================
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
@@ -159,7 +168,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 return;
 
             _bot.Print(
-                $"[BTC RISK] score={entry.Score} logicConf={logicConfidence} FC={riskConfidence} " +
+                $"[BTC RISK] score={entry.Score} logicConf={logicConfidence} FC={PositionContext.ClampRiskConfidence(ctx.FinalConfidence)} " +
                 $"risk%={riskPercent:F2} slDist={slPriceDist:F2} slPips={slPips:F1} " +
                 $"volUnits={volumeUnits}"
             );
@@ -193,7 +202,7 @@ namespace GeminiV26.Instruments.BTCUSD
             // =========================================================
             // POSITION CONTEXT (SSOT)
             // =========================================================
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = posId,
                 Symbol = result.Position.SymbolName,

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -89,22 +89,31 @@ namespace GeminiV26.Instruments.ETHUSD
             _entryLogic.Evaluate(out _, out int logicConfidence);
             int statePenalty = 0;
 
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence)}", entryContext));
 
             // =========================================================
             // SL DISTANCE (ATR)
             // =========================================================
             double slPriceDist =
-                CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+                CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence), entry.Type);
 
             if (slPriceDist <= 0)
                 return;
@@ -116,12 +125,12 @@ namespace GeminiV26.Instruments.ETHUSD
             // =========================================================
             // RISK-BASED VOLUME (CRYPTO POSITION SIZER)
             // =========================================================
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence));
             long volumeUnits = CryptoPositionSizer.Calculate(
                 _bot,
                 riskPercent,
                 slPriceDist,
-                _riskSizer.GetLotCap(riskConfidence));
+                _riskSizer.GetLotCap(PositionContext.ClampRiskConfidence(ctx.FinalConfidence)));
 
             if (volumeUnits < _bot.Symbol.VolumeInUnitsMin)
             {
@@ -136,7 +145,7 @@ namespace GeminiV26.Instruments.ETHUSD
             // TP POLICY
             // =========================================================
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
@@ -159,7 +168,7 @@ namespace GeminiV26.Instruments.ETHUSD
                 return;
 
             _bot.Print(
-                $"[ETH RISK] score={entry.Score} logicConf={logicConfidence} FC={riskConfidence} " +
+                $"[ETH RISK] score={entry.Score} logicConf={logicConfidence} FC={PositionContext.ClampRiskConfidence(ctx.FinalConfidence)} " +
                 $"risk%={riskPercent:F2} slDist={slPriceDist:F2} slPips={slPips:F1} " +
                 $"volUnits={volumeUnits}"
             );
@@ -193,7 +202,7 @@ namespace GeminiV26.Instruments.ETHUSD
             // =========================================================
             // POSITION CONTEXT (SSOT)
             // =========================================================
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = posId,
                 Symbol = result.Position.SymbolName,

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -122,18 +122,27 @@ namespace GeminiV26.Instruments.EURJPY
             // =========================================================
             _entryLogic.Evaluate();
             int logicConfidence = _entryLogic.LastLogicConfidence;
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
             {
@@ -141,7 +150,7 @@ namespace GeminiV26.Instruments.EURJPY
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -150,13 +159,13 @@ namespace GeminiV26.Instruments.EURJPY
             }
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (volumeUnits <= 0)
             {
@@ -197,7 +206,7 @@ namespace GeminiV26.Instruments.EURJPY
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
@@ -232,10 +241,10 @@ namespace GeminiV26.Instruments.EURJPY
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad riskConfidence alapján
+                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -101,22 +101,31 @@ namespace GeminiV26.Instruments.EURUSD
             // =========================================================
             _entryLogic.Evaluate();
             int logicConfidence = _entryLogic.LastLogicConfidence;
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
             _bot.Print(
-                $"[EUR EXEC] CONF entryScore={entry.Score} logic={logicConfidence} final={finalConfidence} statePenalty={statePenalty} riskConf={riskConfidence}"
+                $"[EUR EXEC] CONF entryScore={entry.Score} logic={logicConfidence} final={ctx.FinalConfidence} statePenalty={statePenalty} riskConf={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}"
             );
 
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
             {
@@ -124,7 +133,7 @@ namespace GeminiV26.Instruments.EURUSD
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -133,13 +142,13 @@ namespace GeminiV26.Instruments.EURUSD
             }
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             _bot.Print(
                 $"[EUR EXEC] RISK risk%={riskPercent:F3} slDist={slPriceDist:F5} volume={volumeUnits}"
@@ -188,7 +197,7 @@ namespace GeminiV26.Instruments.EURUSD
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
@@ -223,8 +232,8 @@ namespace GeminiV26.Instruments.EURUSD
 
                 // maradhat így, hogy ne változzon a működés
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -122,18 +122,27 @@ namespace GeminiV26.Instruments.GBPJPY
             // =========================================================
             _entryLogic.Evaluate();
             int logicConfidence = _entryLogic.LastLogicConfidence;
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
             {
@@ -141,7 +150,7 @@ namespace GeminiV26.Instruments.GBPJPY
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -150,13 +159,13 @@ namespace GeminiV26.Instruments.GBPJPY
             }
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (volumeUnits <= 0)
             {
@@ -197,7 +206,7 @@ namespace GeminiV26.Instruments.GBPJPY
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
@@ -232,10 +241,10 @@ namespace GeminiV26.Instruments.GBPJPY
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad riskConfidence alapján
+                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -111,16 +111,25 @@ namespace GeminiV26.Instruments.GBPUSD
             _entryLogic.Evaluate();
             int logicConfidence = _entryLogic.LastLogicConfidence;
 
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
             // =====================================================
             // HARD ATR GATE (GBPUSD) – NO MICRO VOL
@@ -147,11 +156,11 @@ namespace GeminiV26.Instruments.GBPUSD
                     ? TradeType.Buy
                     : TradeType.Sell;
 
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
             if (riskPercent <= 0)
                 return;
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
             if (slPriceDist <= 0)
                 return;
 
@@ -166,14 +175,14 @@ namespace GeminiV26.Instruments.GBPUSD
             }
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
             // sizing MUST use the same slPriceDist we will actually place
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
             if (volumeUnits <= 0)
                 return;
 
@@ -215,7 +224,7 @@ namespace GeminiV26.Instruments.GBPUSD
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
@@ -240,8 +249,8 @@ namespace GeminiV26.Instruments.GBPUSD
                 BeMode = BeMode.AfterTp1,
 
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight
             };
 

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -87,16 +87,25 @@ namespace GeminiV26.Instruments.GER40
                 }
             }
 
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
             var tradeType =
                 entryContext.FinalDirection == TradeDirection.Long
@@ -106,28 +115,28 @@ namespace GeminiV26.Instruments.GER40
             // =========================
             // RISK POLICY
             // =========================
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
                 return;
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
                 return;
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            double slAtrMult = _riskSizer.GetStopLossAtrMultiplier(riskConfidence, entry.Type);
+            double slAtrMult = _riskSizer.GetStopLossAtrMultiplier(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
-            double lotCap = _riskSizer.GetLotCap(riskConfidence);
+            double lotCap = _riskSizer.GetLotCap(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
             if (volumeUnits <= 0)
                 return;
 
@@ -185,7 +194,7 @@ namespace GeminiV26.Instruments.GER40
             // =========================
             // CONTEXT – TELJES, R-ALAPÚ
             // =========================
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
@@ -216,8 +225,8 @@ namespace GeminiV26.Instruments.GER40
                 Tp1CloseFraction = tp1Ratio,
 
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = volumeUnits,

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -97,16 +97,25 @@ namespace GeminiV26.Instruments.NAS100
                 }
             }
 
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
             // === ORIGINAL LOGIC CONTINUES ===
             var tradeType =
@@ -117,26 +126,26 @@ namespace GeminiV26.Instruments.NAS100
             // =========================
             // RISK POLICY
             // =========================
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
                 return;
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
             if (slPriceDist <= 0)
                 return;
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            double slAtrMult = _riskSizer.GetStopLossAtrMultiplier(riskConfidence, entry.Type);
-            double lotCap = _riskSizer.GetLotCap(riskConfidence);
+            double slAtrMult = _riskSizer.GetStopLossAtrMultiplier(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double lotCap = _riskSizer.GetLotCap(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (volumeUnits <= 0)
                 return;
@@ -195,7 +204,7 @@ namespace GeminiV26.Instruments.NAS100
             // =========================
             // CONTEXT – TELJES, R-ALAPÚ
             // =========================
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
@@ -225,8 +234,8 @@ namespace GeminiV26.Instruments.NAS100
                 Tp1CloseFraction = tp1Ratio,
 
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = volumeUnits,

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -122,18 +122,27 @@ namespace GeminiV26.Instruments.NZDUSD
             // =========================================================
             _entryLogic.Evaluate();
             int logicConfidence = _entryLogic.LastLogicConfidence;
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
             {
@@ -141,7 +150,7 @@ namespace GeminiV26.Instruments.NZDUSD
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -150,13 +159,13 @@ namespace GeminiV26.Instruments.NZDUSD
             }
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (volumeUnits <= 0)
             {
@@ -197,7 +206,7 @@ namespace GeminiV26.Instruments.NZDUSD
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
@@ -232,10 +241,10 @@ namespace GeminiV26.Instruments.NZDUSD
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad riskConfidence alapján
+                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -93,40 +93,49 @@ namespace GeminiV26.Instruments.US30
                 }
             }
 
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
             var tradeType =
                 entryContext.FinalDirection == TradeDirection.Long
                     ? TradeType.Buy
                     : TradeType.Sell;
 
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
                 return;
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
                 return;
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (volumeUnits <= 0)
                 return;
@@ -170,7 +179,7 @@ namespace GeminiV26.Instruments.US30
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={positionKey} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
@@ -204,8 +213,8 @@ namespace GeminiV26.Instruments.US30
                 Adx_M5 = entryContext.Adx_M5,
 
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = volumeUnits,

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -122,18 +122,27 @@ namespace GeminiV26.Instruments.USDCAD
             // =========================================================
             _entryLogic.Evaluate();
             int logicConfidence = _entryLogic.LastLogicConfidence;
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
             {
@@ -141,7 +150,7 @@ namespace GeminiV26.Instruments.USDCAD
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -150,13 +159,13 @@ namespace GeminiV26.Instruments.USDCAD
             }
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (volumeUnits <= 0)
             {
@@ -197,7 +206,7 @@ namespace GeminiV26.Instruments.USDCAD
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
@@ -232,10 +241,10 @@ namespace GeminiV26.Instruments.USDCAD
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad riskConfidence alapján
+                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -122,18 +122,27 @@ namespace GeminiV26.Instruments.USDCHF
             // =========================================================
             _entryLogic.Evaluate();
             int logicConfidence = _entryLogic.LastLogicConfidence;
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
             {
@@ -141,7 +150,7 @@ namespace GeminiV26.Instruments.USDCHF
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -150,13 +159,13 @@ namespace GeminiV26.Instruments.USDCHF
             }
 
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (volumeUnits <= 0)
             {
@@ -197,7 +206,7 @@ namespace GeminiV26.Instruments.USDCHF
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
@@ -232,10 +241,10 @@ namespace GeminiV26.Instruments.USDCHF
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad riskConfidence alapján
+                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -108,16 +108,25 @@ namespace GeminiV26.Instruments.USDJPY
             // =========================================================
             // FINAL CONFIDENCE (entry + logic + market state)
             // =========================================================
-            int finalConfidence = PositionContext.ComputeFinalConfidenceValue(entry.Score, logicConfidence);
-            int riskConfidence = PositionContext.ClampRiskConfidence(finalConfidence + statePenalty);
+            var ctx = new PositionContext
+            {
+                Symbol = _bot.SymbolName,
+                TempId = entryContext.TempId,
+                EntryType = entry.Type.ToString(),
+                EntryReason = entry.Reason,
+                FinalDirection = entryContext.FinalDirection,
+                EntryScore = entry.Score,
+                LogicConfidence = logicConfidence
+            };
+            ctx.ComputeFinalConfidence();
 
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, finalConfidence, statePenalty, riskConfidence), entryContext));
+            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, logicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
 
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
 
             if (statePenalty != 0)
 
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
             var tradeType =
                 entryContext.FinalDirection == TradeDirection.Long
@@ -125,26 +134,26 @@ namespace GeminiV26.Instruments.USDJPY
                     : TradeType.Sell;
 
             // === STOP LOSS DISTANCE ===
-            double slPriceDist = CalculateStopLossPriceDistance(riskConfidence, entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
 
             if (slPriceDist <= 0)
                 return;
 
             // === TP CONFIG ===
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
             // === RISK ===
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (riskPercent <= 0)
                 return;
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, riskConfidence);
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
 
             if (volumeUnits <= 0)
                 return;
@@ -187,7 +196,7 @@ namespace GeminiV26.Instruments.USDJPY
             _bot.Print($"[TRADE LINK] tempId={entryContext.TempId} posId={result.Position.Id} symbol={result.Position.SymbolName}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 
-            var ctx = new PositionContext
+            ctx = new PositionContext
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
@@ -222,10 +231,10 @@ namespace GeminiV26.Instruments.USDJPY
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad riskConfidence alapján
+                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
                 TrailingMode =
-                    riskConfidence >= 85 ? TrailingMode.Loose :
-                    riskConfidence >= 75 ? TrailingMode.Normal :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -172,24 +172,23 @@ namespace GeminiV26.Instruments.XAUUSD
             // -----------------------------------------------------
             ctx.ComputeFinalConfidence();
 
-            int riskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
-            _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, ctx.LogicConfidence, ctx.FinalConfidence, statePenalty, riskConfidence), entryContext));
+                        _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry, ctx.LogicConfidence, ctx.FinalConfidence, statePenalty, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)), entryContext));
             _bot.Print(TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
             if (statePenalty != 0)
-                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={riskConfidence}", entryContext));
+                _bot.Print(TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
 
-            // Trailing mód riskConfidence alapján (FinalConfidence + statePenalty)
+            // Trailing mód PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján (FinalConfidence + statePenalty)
             ctx.TrailingMode =
-                riskConfidence >= 85 ? TrailingMode.Loose :
-                riskConfidence >= 75 ? TrailingMode.Normal :
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
                                              TrailingMode.Tight;
 
             // =====================================================
-            // 4️⃣ SL / TP POLICY (riskConfidence)
+            // 4️⃣ SL / TP POLICY (PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty))
             // =====================================================
             double slPriceDist = _riskSizer.CalculateStopLossPriceDistance(
                 _bot,
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 entry.Type);
 
             if (slPriceDist <= 0)
@@ -201,7 +200,7 @@ namespace GeminiV26.Instruments.XAUUSD
             double tp2Price = _riskSizer.CalculateTp2PriceFromSlDistance(
                 _bot,
                 tradeType,
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 slPriceDist);
 
             if (tp2Price <= 0)
@@ -214,7 +213,7 @@ namespace GeminiV26.Instruments.XAUUSD
             // 5️⃣ TP / R VALUES (EURUSD MINTA SZERINT)
             // =====================================================
             _riskSizer.GetTakeProfit(
-                riskConfidence,
+                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
@@ -230,12 +229,12 @@ namespace GeminiV26.Instruments.XAUUSD
             // =====================================================
             // 6️⃣ VOLUME POLICY – METAL POSITION SIZER (XAU)
             // =====================================================
-            double riskPercent = _riskSizer.GetRiskPercent(riskConfidence);
+            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
             long volumeUnits = MetalPositionSizer.Calculate(
                 _bot,
                 riskPercent,
                 slPriceDist,
-                _riskSizer.GetLotCap(riskConfidence)
+                _riskSizer.GetLotCap(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty))
             );
 
             if (volumeUnits <= 0)


### PR DESCRIPTION
### Motivation
- Ensure a single source-of-truth for execution-time confidence by switching all instrument executors to read execution-time confidence from `PositionContext.FinalConfidence` instead of local `finalConfidence`/`riskConfidence` variables.
- Make `PositionContext` available early in each executor so `EntryScore`, `LogicConfidence` and any inputs required by `ComputeFinalConfidence()` are assigned prior to risk sizing and volume/SL/TP decisions.
- Preserve all existing formulas, thresholds and trading behaviour while removing duplicate local confidence computations.

### Description
- Created and populated a pre-sizing `PositionContext` (`ctx`) in each modified executor, called `ctx.ComputeFinalConfidence()` before any risk/SL/TP/volume/trailing logic, and rewired downstream consumers to use `ctx.FinalConfidence` (with `PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)` where penalties apply).
- Replaced execution-time usage of local `finalConfidence`/`riskConfidence` variables with `ctx.FinalConfidence`-based expressions in risk percent resolution, SL distance selection, TP profile selection, volume sizing, trailing mode selection and execution-time logging.
- Kept all mathematical and policy code unchanged (risk sizer math, ATR multipliers, TP/SL/trailing logic and score weights were not altered). 
- Modified files (16): `Instruments/AUDNZD/AudNzdInstrumentExecutor.cs`, `Instruments/AUDUSD/AudUsdInstrumentExecutor.cs`, `Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs`, `Instruments/ETHUSD/EthUsdInstrumentExecutor.cs`, `Instruments/EURJPY/EurJpyInstrumentExecutor.cs`, `Instruments/EURUSD/EurUsdInstrumentExecutor.cs`, `Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs`, `Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs`, `Instruments/GER40/Ger40InstrumentExecutor.cs`, `Instruments/NAS100/NasInstrumentExecutor.cs`, `Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs`, `Instruments/US30/Us30InstrumentExecutor.cs`, `Instruments/USDCAD/UsdCadInstrumentExecutor.cs`, `Instruments/USDCHF/UsdChfInstrumentExecutor.cs`, `Instruments/USDJPY/UsdJpyInstrumentExecutor.cs`, and `Instruments/XAUUSD/XauInstrumentExecutor.cs`.

### Testing
- Searched for remaining executor-local confidence usages with `rg -n "finalConfidence|riskConfidence" Instruments` and confirmed that no active executor-local `finalConfidence`/`riskConfidence` execution-time usages remain, with remaining matches limited to risk-sizer method signatures and core logging helpers (non-execution/local-variable contexts). (search succeeded)
- Verified each executor calls `ctx.ComputeFinalConfidence()` before risk sizing using `rg -n "ComputeFinalConfidence\(" Instruments`, and confirmed the pre-risk computation is present in each executor. (search succeeded)
- Checked repo-wide occurrences via `rg -n "finalConfidence|riskConfidence" Core Instruments` and confirmed remaining appearances are in core analytics/log parameters and risk-sizer APIs rather than executor-local execution variables. (search succeeded)
- No full compile/run was performed because no `.sln`/`.csproj` files were available in this environment, so build verification was not executed. (build not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c910f1d4908328ac67bb7c4652daa7)