### PR TITLE
Fix entry snapshot logging to use only final accepted trade direction

### DIFF
--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -64,7 +64,7 @@ namespace GeminiV26.Core.Logging
                    $"regime={ResolveRegime(ctx)}\n" +
                    $"setupType={entry?.Type}\n" +
                    $"entryType={entry?.Type}\n" +
-                   $"direction={ctx?.FinalDirection ?? entry?.Direction ?? TradeDirection.None}\n" +
+                   $"direction={ctx.FinalDirection}\n" +
                    $"entryScore={entry?.Score ?? 0}\n" +
                    $"logicConfidence={logicConfidence}\n" +
                    $"finalConfidence={finalConfidence}\n" +

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1338,7 +1338,6 @@ namespace GeminiV26.Core
                     }
                 );
 
-                LogEntrySnapshot(_ctx, selected);
                 _bot.Print(TradeLogIdentity.WithTempId($"[TC] ENTRY WINNER {selected.Type} dir={selected.Direction} score={selected.Score}", _ctx));
                 _bot.Print($"[POS ?] [ENTRY] symbol={selected.Symbol ?? _bot.SymbolName} score={selected.Score} direction={selected.Direction}");
                 _bot.Print(TradeLogIdentity.WithTempId($"[DIR][ROUTED] sym={_bot.SymbolName} type={selected.Type} routedDir={selected.Direction} score={selected.Score}", _ctx));
@@ -1377,6 +1376,8 @@ namespace GeminiV26.Core
                     _bot.Print("BLOCK: direction/entry failed");
                     return;
                 }
+
+                LogEntrySnapshot(_ctx, selected);
 
                 _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_PRE] sym={_bot.SymbolName} finalCtxDir={_ctx.FinalDirection}", _ctx));
                 _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_CONFIRMED] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}", _ctx));
@@ -2133,6 +2134,12 @@ namespace GeminiV26.Core
             if (ctx == null || selected == null)
                 return;
 
+            if (ctx.FinalDirection == TradeDirection.None)
+            {
+                _bot.Print("[SNAPSHOT][SKIP] FinalDirection not set");
+                return;
+            }
+
             int normalizedEntryScore = PositionContext.ClampRiskConfidence(selected.Score);
             int logicConfidence = Math.Max(0, ctx.LogicBiasConfidence);
             int normalizedLogicConfidence = PositionContext.ClampRiskConfidence(logicConfidence);
@@ -2148,6 +2155,7 @@ namespace GeminiV26.Core
             _bot.Print(TradeLogIdentity.WithTempId(
                 $"[SCORE][BLEND] entry={normalizedEntryScore} logic={normalizedLogicConfidence} final={finalConfidence}",
                 ctx));
+            _bot.Print($"[SNAPSHOT][FINAL] dir={ctx.FinalDirection} conf={finalConfidence:F2}");
 
             _bot.Print(TradeLogIdentity.WithTempId(
                 TradeAuditLog.BuildEntrySnapshot(_bot, ctx, selected, normalizedLogicConfidence, finalConfidence, 0, riskFinal),


### PR DESCRIPTION
### Motivation
- Entry snapshots were being emitted before `PassFinalAcceptance(...)` and before `ctx.FinalDirection` was assigned, allowing pre-decision state to leak into logs and enabling a fallback to the candidate `entry.Direction`.
- The intent is to make `FinalDirection` the single source of truth for entry snapshot direction without touching routing, acceptance, or trading logic.

### Description
- Moved `LogEntrySnapshot(_ctx, selected)` so it runs only after `PassFinalAcceptance(...)`, after `_ctx.FinalDirection` is assigned and after direction consistency validation in `Core/TradeCore.cs`.
- Added a guard in `LogEntrySnapshot` to skip logging when `ctx.FinalDirection == TradeDirection.None` with `_bot.Print("[SNAPSHOT][SKIP] FinalDirection not set")` to enforce the precondition.
- Emitted a debug line before snapshot output: `_bot.Print($"[SNAPSHOT][FINAL] dir={ctx.FinalDirection} conf={finalConfidence:F2}")` to surface final direction/confidence.
- Removed the fallback in `Core/Logging/TradeAuditLog.cs` by replacing `ctx?.FinalDirection ?? entry?.Direction` with strict `ctx.FinalDirection`, so snapshots cannot fall back to `entry.Direction`.
- Did not change any trading, routing, or acceptance logic; changes are limited to snapshot timing and direction fallback behavior.

### Testing
- Ran targeted repository searches with `rg` to verify call sites and fallback usages and confirmed the `LogEntrySnapshot` call was relocated and the fallback removed (searches succeeded).
- Inspected the modified regions with `nl`/`sed` to validate the insertion of the guard and debug print and the new call position (inspection succeeded).
- Committed the changes (`git commit`) to the repository to record the update (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c912d4513883288aba3c96a74ac69d)