### PR TITLE
Unify HTF snapshot usage to single EntryContext source

### DIFF
--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -871,6 +871,10 @@ namespace GeminiV26.Core.Entry
                 LogHtfAuditFlow(ctx, symbol, InstrumentClass.METAL, htf.State.ToString(), htf.AllowedDirection, htf.Confidence01, htf.Reason);
             }
 
+            _bot.Print($"[HTF][SNAPSHOT] dir={ctx.HtfDirection} conf={ctx.HtfConfidence:F2}");
+            if (ctx.HtfDirection == TradeDirection.None)
+                _bot.Print("[HTF][WARN] Missing HTF snapshot");
+
             ctx.IsReady = true;
             _bot.Print($"[CTX][MEMORY_READY] symbol={symbol} hasMemory={ctx.HasMemory}");
             LogEntryMemorySnapshot(ctx, symbol);

--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -21,8 +21,8 @@ namespace GeminiV26.Core.Logging
 
         public static string BuildDirectionSnapshot(EntryContext ctx, EntryEvaluation entry)
         {
-            TradeDirection htfDirection = ResolveHtfDirection(ctx);
-            int htfConfidence = ResolveHtfConfidence(ctx);
+            TradeDirection htfDirection = ctx?.HtfDirection ?? TradeDirection.None;
+            int htfConfidence = (int)Math.Round((ctx?.HtfConfidence ?? 0.0) * 100.0, MidpointRounding.AwayFromZero);
 
             return "[DIR]\n" +
                    $"logicBias={ctx?.LogicBiasDirection ?? TradeDirection.None}\n" +
@@ -53,8 +53,8 @@ namespace GeminiV26.Core.Logging
         {
             string symbol = entry?.Symbol ?? ctx?.Symbol ?? bot?.SymbolName ?? "UNKNOWN";
             string attemptId = ctx?.EntryAttemptId ?? string.Empty;
-            TradeDirection htfDirection = ResolveHtfDirection(ctx);
-            int htfConfidence = ResolveHtfConfidence(ctx);
+            TradeDirection htfDirection = ctx?.HtfDirection ?? TradeDirection.None;
+            int htfConfidence = (int)Math.Round((ctx?.HtfConfidence ?? 0.0) * 100.0, MidpointRounding.AwayFromZero);
 
             return "[ENTRY SNAPSHOT]\n" +
                    $"symbol={symbol}\n" +
@@ -206,33 +206,6 @@ namespace GeminiV26.Core.Logging
             if (barsSinceStart <= 6)
                 return "SOFT";
             return "NONE";
-        }
-
-        private static TradeDirection ResolveHtfDirection(EntryContext ctx)
-        {
-            if (ctx == null)
-                return TradeDirection.None;
-            if (ctx.FxHtfAllowedDirection != TradeDirection.None)
-                return ctx.FxHtfAllowedDirection;
-            if (ctx.CryptoHtfAllowedDirection != TradeDirection.None)
-                return ctx.CryptoHtfAllowedDirection;
-            if (ctx.IndexHtfAllowedDirection != TradeDirection.None)
-                return ctx.IndexHtfAllowedDirection;
-            if (ctx.MetalHtfAllowedDirection != TradeDirection.None)
-                return ctx.MetalHtfAllowedDirection;
-            return TradeDirection.None;
-        }
-
-        private static int ResolveHtfConfidence(EntryContext ctx)
-        {
-            if (ctx == null)
-                return 0;
-
-            double confidence01 = Math.Max(
-                Math.Max(ctx.FxHtfConfidence01, ctx.CryptoHtfConfidence01),
-                Math.Max(ctx.IndexHtfConfidence01, ctx.MetalHtfConfidence01));
-
-            return (int)Math.Round(confidence01 * 100.0, MidpointRounding.AwayFromZero);
         }
 
         private static string ToLower(bool value) => value ? "true" : "false";

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1187,44 +1187,27 @@ namespace GeminiV26.Core
         // Handles FX / Crypto / Metals / Index policies without filtering
         // =====================================================
 
-        if (isFxSymbol && _fxBias != null)
+        if (isFxSymbol)
         {
-            var bias = _fxBias.Get(_bot.SymbolName);
-
-            _ctx.FxHtfAllowedDirection = bias.AllowedDirection;
-            _ctx.FxHtfConfidence01 = bias.Confidence01;
-            _ctx.FxHtfReason = bias.Reason;
-
+            var bias = BuildHtfSnapshotFromContext(_ctx, InstrumentClass.FX);
             _bot.Print(TradeLogIdentity.WithTempId($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}", _ctx));
             ApplyHtfBiasScoreOnly(symbolSignals, bias, "FX");
         }
-        else if (isCryptoSymbol && _cryptoBias != null)
+        else if (isCryptoSymbol)
         {
-            var bias = _cryptoBias.Get(_bot.SymbolName);
-            _ctx.CryptoHtfAllowedDirection = bias.AllowedDirection;
-            _ctx.CryptoHtfConfidence01 = bias.Confidence01;
-            _ctx.CryptoHtfReason = bias.Reason;
-
+            var bias = BuildHtfSnapshotFromContext(_ctx, InstrumentClass.CRYPTO);
             _bot.Print(TradeLogIdentity.WithTempId($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}", _ctx));
             ApplyHtfBiasScoreOnly(symbolSignals, bias, "CRYPTO");
         }
-        else if (isMetalSymbol && _metalBias != null)
+        else if (isMetalSymbol)
         {
-            var bias = _metalBias.Get(_bot.SymbolName);
-            _ctx.MetalHtfAllowedDirection = bias.AllowedDirection;
-            _ctx.MetalHtfConfidence01 = bias.Confidence01;
-            _ctx.MetalHtfReason = bias.Reason;
-
+            var bias = BuildHtfSnapshotFromContext(_ctx, InstrumentClass.METAL);
             _bot.Print(TradeLogIdentity.WithTempId($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}", _ctx));
             ApplyHtfBiasScoreOnly(symbolSignals, bias, "XAU");
         }
-        else if (isIndexSymbol && _indexBias != null)
+        else if (isIndexSymbol)
         {
-            var bias = _indexBias.Get(_bot.SymbolName);
-            _ctx.IndexHtfAllowedDirection = bias.AllowedDirection;
-            _ctx.IndexHtfConfidence01 = bias.Confidence01;
-            _ctx.IndexHtfReason = bias.Reason;
-
+            var bias = BuildHtfSnapshotFromContext(_ctx, InstrumentClass.INDEX);
             _bot.Print(TradeLogIdentity.WithTempId($"[DIR][HTF] sym={_bot.SymbolName} allow={bias.AllowedDirection} conf={bias.Confidence01:0.00} reason={bias.Reason}", _ctx));
             ApplyHtfBiasScoreOnly(symbolSignals, bias, "INDEX");
         }
@@ -1378,6 +1361,9 @@ namespace GeminiV26.Core
                 }
 
                 LogEntrySnapshot(_ctx, selected);
+                _bot.Print(TradeLogIdentity.WithTempId($"[HTF][PASS] dir={_ctx.HtfDirection} conf={_ctx.HtfConfidence:F2}", _ctx));
+                if (_ctx.HtfDirection == TradeDirection.None)
+                    _bot.Print(TradeLogIdentity.WithTempId("[HTF][WARN] Missing HTF snapshot", _ctx));
 
                 _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_PRE] sym={_bot.SymbolName} finalCtxDir={_ctx.FinalDirection}", _ctx));
                 _bot.Print(TradeLogIdentity.WithTempId($"[DIR][EXEC_CONFIRMED] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}", _ctx));
@@ -3543,6 +3529,46 @@ namespace GeminiV26.Core
                 return "Transition";
 
             return setup;
+        }
+
+        private static HtfBiasSnapshot BuildHtfSnapshotFromContext(EntryContext ctx, InstrumentClass instrumentClass)
+        {
+            var snapshot = new HtfBiasSnapshot();
+            if (ctx == null)
+                return snapshot;
+
+            if (instrumentClass == InstrumentClass.FX)
+            {
+                snapshot.AllowedDirection = ctx.FxHtfAllowedDirection;
+                snapshot.Confidence01 = ctx.FxHtfConfidence01;
+                snapshot.Reason = ctx.FxHtfReason ?? string.Empty;
+                return snapshot;
+            }
+
+            if (instrumentClass == InstrumentClass.CRYPTO)
+            {
+                snapshot.AllowedDirection = ctx.CryptoHtfAllowedDirection;
+                snapshot.Confidence01 = ctx.CryptoHtfConfidence01;
+                snapshot.Reason = ctx.CryptoHtfReason ?? string.Empty;
+                return snapshot;
+            }
+
+            if (instrumentClass == InstrumentClass.METAL)
+            {
+                snapshot.AllowedDirection = ctx.MetalHtfAllowedDirection;
+                snapshot.Confidence01 = ctx.MetalHtfConfidence01;
+                snapshot.Reason = ctx.MetalHtfReason ?? string.Empty;
+                return snapshot;
+            }
+
+            if (instrumentClass == InstrumentClass.INDEX)
+            {
+                snapshot.AllowedDirection = ctx.IndexHtfAllowedDirection;
+                snapshot.Confidence01 = ctx.IndexHtfConfidence01;
+                snapshot.Reason = ctx.IndexHtfReason ?? string.Empty;
+            }
+
+            return snapshot;
         }
 
         private void ApplyHtfBiasScoreOnly(List<EntryEvaluation> symbolSignals, HtfBiasSnapshot bias, string assetTag)


### PR DESCRIPTION
### Motivation

- HTF was being set in `EntryContextBuilder`, overwritten in `TradeCore`, and recomputed/aggregated in `TradeAuditLog`, causing mixed HTF states and non-deterministic logs.
- The goal is to ensure HTF is computed once (in the builder), stored in `EntryContext` and then used and logged verbatim everywhere else.

### Description

- Removed direct re-fetch/overwrite of HTF in `TradeCore` and instead derive a score-only `HtfBiasSnapshot` from the immutable `EntryContext` via a new helper `BuildHtfSnapshotFromContext` so the core no longer calls bias engines to reset `ctx` fields.
- Replaced HTF aggregation in `TradeAuditLog` with direct logging from the snapshot fields by reading `ctx.HtfDirection` and `ctx.HtfConfidence` (removed multi-source resolution helpers).
- Added debug trace points: `_bot.Print("[HTF][SNAPSHOT] dir={ctx.HtfDirection} conf={ctx.HtfConfidence:F2}")` in `EntryContextBuilder`, `_bot.Print("[HTF][PASS] dir={_ctx.HtfDirection} conf={_ctx.HtfConfidence:F2}")` in `TradeCore` before execution, and a safety warning `_bot.Print("[HTF][WARN] Missing HTF snapshot")` when direction is `None`.

### Testing

- Performed static code searches (`rg`) to verify `TradeCore` no longer performs bias `.Get(...)` re-fetches and that logger aggregation helpers were removed; the searches returned the expected updated references (no remaining re-fetch usages in `TradeCore`).
- Inspected diffs of the three modified files (`Core/Entry/EntryContextBuilder.cs`, `Core/TradeCore.cs`, `Core/Logging/TradeAuditLog.cs`) to confirm only usage/flow and logging changes were applied and HTF calculation logic itself was left intact.
- All automated static checks executed during the change (search/diff validations) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9140070548328ae8313bf9dff9e6d)