### PR TITLE
Separate TP1 touch detection from execution audit logs

### DIFF
--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.AUDNZD
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.AUDNZD
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.AUDUSD
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.AUDUSD
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -302,7 +302,7 @@ namespace GeminiV26.Instruments.BTCUSD
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
 
                         // Legacy viselkedés:
@@ -428,6 +428,7 @@ namespace GeminiV26.Instruments.BTCUSD
             if (!closeResult.IsSuccessful)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[BTCUSD][TP1][FAIL] partial close failed pos={pos.Id}", ctx, pos));
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
             }
 
@@ -435,6 +436,9 @@ namespace GeminiV26.Instruments.BTCUSD
                 $"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} " +
                 $"direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} " +
                 $"closedUnits={closeUnits}", ctx, pos));
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -287,7 +287,7 @@ namespace GeminiV26.Instruments.ETHUSD
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -402,7 +402,13 @@ namespace GeminiV26.Instruments.ETHUSD
             var closeResult = _bot.ClosePosition(pos, closeUnits);
 
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
 

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.EURJPY
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.EURJPY
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.EURUSD
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.EURUSD
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.GBPJPY
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.GBPJPY
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.GBPUSD
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.GBPUSD
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.GER40
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.GER40
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.NAS100
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.NAS100
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.NZDUSD
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.NZDUSD
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.US30
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.US30
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.USDCAD
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.USDCAD
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.USDCHF
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.USDCHF
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -265,7 +265,7 @@ namespace GeminiV26.Instruments.USDJPY
                     if (reached)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -348,7 +348,13 @@ namespace GeminiV26.Instruments.USDJPY
 
             var closeResult = _bot.ClosePosition(pos, closeUnits);
             if (!closeResult.IsSuccessful)
+            {
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
+            }
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeUnits} price={executionPrice}");
 
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -331,7 +331,7 @@ namespace GeminiV26.Instruments.XAUUSD
                     if (hit)
                     {
                         _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][TP1] symbol={pos.SymbolName} positionId={pos.Id} price={tp1Price:0.#####}", ctx, pos));
-                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][HIT]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
+                        _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][TOUCHED]\npos={pos.Id}\ntp1={tp1Price:0.#####}", ctx, pos));
                         ExecuteTp1(pos, ctx, rDist);
                         continue;
                     }
@@ -426,10 +426,14 @@ namespace GeminiV26.Instruments.XAUUSD
             if (!closeResult.IsSuccessful)
             {
                 _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} tp1={ctx.Tp1Price} rawUnits={rawUnitsD} flooredUnits={flooredUnits} closeVolume={closeVolume} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}", ctx, pos));
+                _bot.Print("[TP1][FAIL] execution failed");
                 return;
             }
 
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE executed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} closedUnits={closeVolume}", ctx, pos));
+
+            double executionPrice = IsLong(ctx) ? sym.Bid : sym.Ask;
+            _bot.Print($"[TP1][EXECUTED] volumeClosed={closeVolume} price={executionPrice}");
 
             // TP1 state (SSOT) – csak itt állítjuk
             ctx.Tp1Hit = true;


### PR DESCRIPTION
### Motivation
- Market touching a TP1 price was logged as a TP1 execution event, causing audit ambiguity between price touch and actual partial-close execution.  
- The goal is to keep touch analytics while ensuring `ctx.Tp1Hit` only reflects real executed state.  
- Add explicit success/failure execution logs so the event flow is auditable and unambiguous.  

### Description
- Renamed the market-detection log `"[TP1][HIT]"` to `"[TP1][TOUCHED]"` in all instrument `ExitManager` implementations so a price touch is recorded separately from execution.  
- Added an explicit execution-success log immediately after a successful partial close: `_bot.Print($

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c915cdcc748328aa6d86d2611027fb)