### PR TITLE
Enforce active HTF SSOT across EntryTypes (use ActiveHtfDirection/ActiveHtfConfidence)

### DIFF
--- a/EntryTypes/CRYPTO/BTC_FlagEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_FlagEntry.cs
@@ -340,7 +340,7 @@ namespace GeminiV26.EntryTypes.Crypto
             ctx.Log?.Invoke(
                 $"[CRYPTO][REGIME_ADJUST] regime={regime} delta={regimeDelta} scoreAfter={scoreAfterRegime}");
 
-            var htfDirection = ctx.CryptoHtfAllowedDirection;
+            var htfDirection = ctx.ActiveHtfDirection;
             bool htfAligned = htfDirection == TradeDirection.None || htfDirection == dir;
             int htfDelta = htfAligned ? +6 : -6;
             score += htfDelta;
@@ -353,7 +353,7 @@ namespace GeminiV26.EntryTypes.Crypto
             bool continuationDetected = continuationSignal;
             bool pullbackDetected = structuredPB;
             bool compressionDetected = hasFlag && hasValidRange && rangeAtr > 0 && rangeAtr <= 1.00;
-            bool isHtfAlignedShort = dir == TradeDirection.Short && ctx.CryptoHtfAllowedDirection == TradeDirection.Short;
+            bool isHtfAlignedShort = dir == TradeDirection.Short && ctx.ActiveHtfDirection == TradeDirection.Short;
             bool weakStructure =
                 continuationDetected ||
                 pullbackDetected ||
@@ -537,14 +537,14 @@ namespace GeminiV26.EntryTypes.Crypto
             if (evaluation == null)
                 return;
 
-            var sourceAllowedDirection = ctx?.CryptoHtfAllowedDirection ?? TradeDirection.None;
+            var sourceAllowedDirection = ctx?.ActiveHtfDirection ?? TradeDirection.None;
             evaluation.HtfTraceSourceStage = "SOURCE";
             evaluation.HtfTraceSourceModule = "CRYPTO_ENTRY";
-            evaluation.HtfTraceSourceState = ctx?.CryptoHtfReason ?? "N/A";
+            evaluation.HtfTraceSourceState = "N/A";
             evaluation.HtfTraceSourceAllowedDirection = sourceAllowedDirection;
             evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
             evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
-            evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
+            evaluation.HtfConfidence01 = ctx?.ActiveHtfConfidence ?? 0.0;
         }
 
     }

--- a/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_PullbackEntry.cs
@@ -93,8 +93,8 @@ namespace GeminiV26.EntryTypes.Crypto
             // =========================
             // HTF DIRECTIONAL BIAS (score-only)
             // =========================
-            var allow = ctx.CryptoHtfAllowedDirection;
-            var htfConf = ctx.CryptoHtfConfidence01;
+            var allow = ctx.ActiveHtfDirection;
+            var htfConf = ctx.ActiveHtfConfidence;
 
             if (dir != TradeDirection.Long && dir != TradeDirection.Short)
                 return Block(ctx, "NO_TREND_DIR", score);
@@ -872,7 +872,7 @@ namespace GeminiV26.EntryTypes.Crypto
             ctx.Log?.Invoke(
                 $"[CRYPTO][REGIME_ADJUST] regime={regime} delta={regimeDelta} scoreAfter={scoreAfterRegime}");
 
-            var htfDirection = ctx.CryptoHtfAllowedDirection;
+            var htfDirection = ctx.ActiveHtfDirection;
             int htfDelta = 0;
             if (htfDirection == dir)
                 htfDelta = +8;
@@ -942,14 +942,14 @@ namespace GeminiV26.EntryTypes.Crypto
             if (evaluation == null)
                 return;
 
-            var sourceAllowedDirection = ctx?.CryptoHtfAllowedDirection ?? TradeDirection.None;
+            var sourceAllowedDirection = ctx?.ActiveHtfDirection ?? TradeDirection.None;
             evaluation.HtfTraceSourceStage = "SOURCE";
             evaluation.HtfTraceSourceModule = "CRYPTO_ENTRY";
-            evaluation.HtfTraceSourceState = ctx?.CryptoHtfReason ?? "N/A";
+            evaluation.HtfTraceSourceState = "N/A";
             evaluation.HtfTraceSourceAllowedDirection = sourceAllowedDirection;
             evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
             evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
-            evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
+            evaluation.HtfConfidence01 = ctx?.ActiveHtfConfidence ?? 0.0;
         }
 
         private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)

--- a/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
+++ b/EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs
@@ -175,7 +175,7 @@ namespace GeminiV26.EntryTypes.Crypto
             ctx.Log?.Invoke(
                 $"[CRYPTO][REGIME_ADJUST] entryType=Breakout regime={regime} delta={regimeDelta} scoreAfter={scoreAfterRegime}");
 
-            var htfDirection = ctx.CryptoHtfAllowedDirection;
+            var htfDirection = ctx.ActiveHtfDirection;
             int htfDelta = htfDirection == dir ? +8 : -10;
             score += htfDelta;
             scoreAfterHtf = score;
@@ -245,14 +245,14 @@ namespace GeminiV26.EntryTypes.Crypto
             if (evaluation == null)
                 return;
 
-            var sourceAllowedDirection = ctx?.CryptoHtfAllowedDirection ?? TradeDirection.None;
+            var sourceAllowedDirection = ctx?.ActiveHtfDirection ?? TradeDirection.None;
             evaluation.HtfTraceSourceStage = "SOURCE";
             evaluation.HtfTraceSourceModule = "CRYPTO_ENTRY";
-            evaluation.HtfTraceSourceState = ctx?.CryptoHtfReason ?? "N/A";
+            evaluation.HtfTraceSourceState = "N/A";
             evaluation.HtfTraceSourceAllowedDirection = sourceAllowedDirection;
             evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
             evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
-            evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
+            evaluation.HtfConfidence01 = ctx?.ActiveHtfConfidence ?? 0.0;
         }
 
     }

--- a/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
+++ b/EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs
@@ -113,7 +113,7 @@ namespace GeminiV26.EntryTypes.Crypto
             ctx.Log?.Invoke(
                 $"[CRYPTO][REGIME_ADJUST] entryType=Impulse regime={regime} delta={regimeDelta} scoreAfter={scoreAfterRegime}");
 
-            var htfDirection = ctx.CryptoHtfAllowedDirection;
+            var htfDirection = ctx.ActiveHtfDirection;
             int htfDelta = htfDirection == dir ? +8 : -10;
             score += htfDelta;
             scoreAfterHtf = score;
@@ -173,14 +173,14 @@ namespace GeminiV26.EntryTypes.Crypto
             if (evaluation == null)
                 return;
 
-            var sourceAllowedDirection = ctx?.CryptoHtfAllowedDirection ?? TradeDirection.None;
+            var sourceAllowedDirection = ctx?.ActiveHtfDirection ?? TradeDirection.None;
             evaluation.HtfTraceSourceStage = "SOURCE";
             evaluation.HtfTraceSourceModule = "CRYPTO_ENTRY";
-            evaluation.HtfTraceSourceState = ctx?.CryptoHtfReason ?? "N/A";
+            evaluation.HtfTraceSourceState = "N/A";
             evaluation.HtfTraceSourceAllowedDirection = sourceAllowedDirection;
             evaluation.HtfTraceSourceAlign = sourceAllowedDirection == candidateDirection;
             evaluation.HtfTraceSourceCandidateDirection = candidateDirection;
-            evaluation.HtfConfidence01 = ctx?.CryptoHtfConfidence01 ?? 0.0;
+            evaluation.HtfConfidence01 = ctx?.ActiveHtfConfidence ?? 0.0;
         }
 
     }

--- a/EntryTypes/EntryDirectionQuality.cs
+++ b/EntryTypes/EntryDirectionQuality.cs
@@ -290,20 +290,20 @@ namespace GeminiV26.EntryTypes
             switch (instrumentClass)
             {
                 case InstrumentClass.FX:
-                    htfDirection = ctx.FxHtfAllowedDirection;
-                    htfConfidence = ctx.FxHtfConfidence01;
+                    htfDirection = ctx.ActiveHtfDirection;
+                    htfConfidence = ctx.ActiveHtfConfidence;
                     break;
                 case InstrumentClass.CRYPTO:
-                    htfDirection = ctx.CryptoHtfAllowedDirection;
-                    htfConfidence = ctx.CryptoHtfConfidence01;
+                    htfDirection = ctx.ActiveHtfDirection;
+                    htfConfidence = ctx.ActiveHtfConfidence;
                     break;
                 case InstrumentClass.INDEX:
-                    htfDirection = ctx.IndexHtfAllowedDirection;
-                    htfConfidence = ctx.IndexHtfConfidence01;
+                    htfDirection = ctx.ActiveHtfDirection;
+                    htfConfidence = ctx.ActiveHtfConfidence;
                     break;
                 case InstrumentClass.METAL:
-                    htfDirection = ctx.MetalHtfAllowedDirection;
-                    htfConfidence = ctx.MetalHtfConfidence01;
+                    htfDirection = ctx.ActiveHtfDirection;
+                    htfConfidence = ctx.ActiveHtfConfidence;
                     break;
             }
         }

--- a/EntryTypes/FX/FX_FlagEntry.cs
+++ b/EntryTypes/FX/FX_FlagEntry.cs
@@ -148,7 +148,7 @@ using GeminiV26.Instruments.FX;
             ctx.Log?.Invoke(
                 $"[FX_FLAG START] sym={ctx.Symbol} sess={ctx.Session} candDir={flagDir} " +
                 $"trendDir={ctx.TrendDirection} " +
-                $"htf={ctx.FxHtfAllowedDirection}/{ctx.FxHtfConfidence01:F2} " +
+                $"htf={ctx.ActiveHtfDirection}/{ctx.ActiveHtfConfidence:F2} " +
                 $"ema50>200={(ctx.Ema50_M5 > ctx.Ema200_M5)} " +
                 $"ema8>21={(ctx.Ema8_M5 > ctx.Ema21_M5)} " +
                 $"ema21Slope={ctx.Ema21Slope_M5:F4} " +
@@ -239,8 +239,8 @@ using GeminiV26.Instruments.FX;
 
             // --- HTF transition hardening ---
             bool htfTransitionZone =
-                ctx.FxHtfAllowedDirection == TradeDirection.None &&
-                ctx.FxHtfConfidence01 >= 0.50;
+                ctx.ActiveHtfDirection == TradeDirection.None &&
+                ctx.ActiveHtfConfidence >= 0.50;
 
             if (htfTransitionZone)
                 minBoost += 2;
@@ -277,11 +277,11 @@ using GeminiV26.Instruments.FX;
                     ApplyPenalty(1);
                 }
 
-                if (ctx.FxHtfAllowedDirection == TradeDirection.None && ctx.FxHtfConfidence01 >= 0.50)
+                if (ctx.ActiveHtfDirection == TradeDirection.None && ctx.ActiveHtfConfidence >= 0.50)
                 {
                     ApplyPenalty(2);
                     minBoost += 1;
-                    ctx.Log?.Invoke($"[FX_FLAG][HTF][BIAS] candDir={flagDir} state=Transition impact=ScoreOnly penalty=2 conf={ctx.FxHtfConfidence01:F2}");
+                    ctx.Log?.Invoke($"[FX_FLAG][HTF][BIAS] candDir={flagDir} state=Transition impact=ScoreOnly penalty=2 conf={ctx.ActiveHtfConfidence:F2}");
                 }
             }
 
@@ -697,7 +697,7 @@ using GeminiV26.Instruments.FX;
             {
                 ApplyPenalty(3);
                 minBoost += 2;
-                ctx.Log?.Invoke($"[FX_FLAG][HTF][BIAS] candDir={flagDir} state=Transition impact=ScoreOnly penalty=3 conf={ctx.FxHtfConfidence01:F2}");
+                ctx.Log?.Invoke($"[FX_FLAG][HTF][BIAS] candDir={flagDir} state=Transition impact=ScoreOnly penalty=3 conf={ctx.ActiveHtfConfidence:F2}");
             }
 
             bool softM1 =
@@ -774,10 +774,10 @@ using GeminiV26.Instruments.FX;
                     minBoost += 2;
 
                 if (fx.RequireHtfAlignmentForContinuation &&
-                    ctx.FxHtfAllowedDirection != TradeDirection.None &&
-                    ctx.FxHtfAllowedDirection != flagDir)
+                    ctx.ActiveHtfDirection != TradeDirection.None &&
+                    ctx.ActiveHtfDirection != flagDir)
                 {
-                    double conf = ctx.FxHtfConfidence01;
+                    double conf = ctx.ActiveHtfConfidence;
 
                     int penalty =
                         conf >= 0.75 ? 6 :
@@ -829,9 +829,9 @@ using GeminiV26.Instruments.FX;
 
                 ApplyPenalty(finalPenalty);
 
-                if (ctx.FxHtfAllowedDirection != TradeDirection.None &&
-                    flagDir != ctx.FxHtfAllowedDirection &&
-                    ctx.FxHtfConfidence01 >= 0.55)
+                if (ctx.ActiveHtfDirection != TradeDirection.None &&
+                    flagDir != ctx.ActiveHtfDirection &&
+                    ctx.ActiveHtfConfidence >= 0.55)
                 {
                     ApplyPenalty(2);
                 }
@@ -850,12 +850,12 @@ using GeminiV26.Instruments.FX;
             }
 
             // HTF CONFLICT – SOFT ONLY
-            bool htfHasDir = ctx.FxHtfAllowedDirection != TradeDirection.None;
-            bool htfConflict = htfHasDir && flagDir != ctx.FxHtfAllowedDirection;
+            bool htfHasDir = ctx.ActiveHtfDirection != TradeDirection.None;
+            bool htfConflict = htfHasDir && flagDir != ctx.ActiveHtfDirection;
 
             if (htfConflict)
             {
-                double conf = ctx.FxHtfConfidence01;
+                double conf = ctx.ActiveHtfConfidence;
 
                 int penalty =
                     conf >= 0.75 ? 6 :
@@ -892,7 +892,7 @@ using GeminiV26.Instruments.FX;
                     if (!transitionLong)
                     {
                         ApplyPenalty(8);
-                        if (ctx.FxHtfConfidence01 > 0.65) ApplyPenalty(3);
+                        if (ctx.ActiveHtfConfidence > 0.65) ApplyPenalty(3);
                     }
                     else ApplyReward(4);
                 }
@@ -917,8 +917,8 @@ using GeminiV26.Instruments.FX;
                     {
                         ApplyPenalty(8);
 
-                        if (ctx.FxHtfConfidence01 > 0.65 &&
-                            ctx.FxHtfAllowedDirection == TradeDirection.Long)
+                        if (ctx.ActiveHtfConfidence > 0.65 &&
+                            ctx.ActiveHtfDirection == TradeDirection.Long)
                         {
                             ApplyPenalty(3);
                         }
@@ -1024,7 +1024,7 @@ using GeminiV26.Instruments.FX;
 
             if (score < min)
                 return Invalid(ctx, flagDir,
-                    $"LOW_SCORE({score}<{min}) htf={ctx.FxHtfAllowedDirection}/{ctx.FxHtfConfidence01:F2} session={ctx.Session} boost={minBoost} flagDir={flagDir}({flagDirReason})",
+                    $"LOW_SCORE({score}<{min}) htf={ctx.ActiveHtfDirection}/{ctx.ActiveHtfConfidence:F2} session={ctx.Session} boost={minBoost} flagDir={flagDir}({flagDirReason})",
                     score);
 
             // ✅ IMPORTANT: NO HARD GATE on ctx.TrendDirection anymore

--- a/EntryTypes/FX/FX_MicroStructureEntry.cs
+++ b/EntryTypes/FX/FX_MicroStructureEntry.cs
@@ -66,7 +66,7 @@ namespace GeminiV26.EntryTypes.FX
 
             ctx.Log?.Invoke(
                 $"[FX_MICRO START] sym={ctx.Symbol} dir={dir} " +
-                $"htf={ctx.FxHtfAllowedDirection}/{ctx.FxHtfConfidence01:F2} " +
+                $"htf={ctx.ActiveHtfDirection}/{ctx.ActiveHtfConfidence:F2} " +
                 $"impulse={ctx.HasImpulse_M5} atrExp={ctx.IsAtrExpanding_M5} range={ctx.IsRange_M5}"
             );
 
@@ -117,11 +117,11 @@ namespace GeminiV26.EntryTypes.FX
             // -----------------------------------------------------
             // HTF ALIGNMENT (soft)
             // -----------------------------------------------------
-            if (ctx.FxHtfAllowedDirection == dir)
+            if (ctx.ActiveHtfDirection == dir)
             {
                 score += 5;
             }
-            else if (ctx.FxHtfAllowedDirection != TradeDirection.None)
+            else if (ctx.ActiveHtfDirection != TradeDirection.None)
             {
                 score -= 10;
             }

--- a/EntryTypes/FX/FX_PullbackEntry.cs
+++ b/EntryTypes/FX/FX_PullbackEntry.cs
@@ -294,12 +294,12 @@ namespace GeminiV26.EntryTypes.FX
             }
 
             bool htfMismatch =
-                ctx.FxHtfAllowedDirection != TradeDirection.None &&
-                ctx.FxHtfAllowedDirection != dir;
+                ctx.ActiveHtfDirection != TradeDirection.None &&
+                ctx.ActiveHtfDirection != dir;
 
             if (htfMismatch)
             {
-                double conf = ctx.FxHtfConfidence01;
+                double conf = ctx.ActiveHtfConfidence;
                 int htfPenalty = (int)(conf * 10);
 
                 ApplyPenalty(ref score, ref penalty, htfPenalty, penaltyBudget, ctx, "HTF_MISMATCH");

--- a/EntryTypes/FX/FX_ReversalEntry.cs
+++ b/EntryTypes/FX/FX_ReversalEntry.cs
@@ -89,19 +89,19 @@ namespace GeminiV26.EntryTypes.FX
             // =========================
             // FX HTF bias – Reversal weighting (soft)
             // =========================
-            if (ctx.FxHtfAllowedDirection != TradeDirection.None &&
-                ctx.FxHtfConfidence01 > 0.0)
+            if (ctx.ActiveHtfDirection != TradeDirection.None &&
+                ctx.ActiveHtfConfidence > 0.0)
             {
-                if (dir != ctx.FxHtfAllowedDirection)
+                if (dir != ctx.ActiveHtfDirection)
                 {
                     // Reversal HTF ellen: enyhe büntetés
-                    int htfPenalty = (int)(4 + 3 * ctx.FxHtfConfidence01);
+                    int htfPenalty = (int)(4 + 3 * ctx.ActiveHtfConfidence);
                     score -= htfPenalty;
                 }
                 else
                 {
                     // Reversal HTF irányába: enyhe jutalom (ritkább, de értékes)
-                    int htfBonus = (int)(2 + 2 * ctx.FxHtfConfidence01);
+                    int htfBonus = (int)(2 + 2 * ctx.ActiveHtfConfidence);
                     score += htfBonus;
                 }
             }

--- a/EntryTypes/FX/FxDirectionValidation.cs
+++ b/EntryTypes/FX/FxDirectionValidation.cs
@@ -21,14 +21,14 @@ namespace GeminiV26.EntryTypes.FX
             if (logicBias == TradeDirection.None)
                 return 0;
 
-            var htfDirection = ctx.FxHtfAllowedDirection;
+            var htfDirection = ctx.ActiveHtfDirection;
             if (htfDirection == TradeDirection.None || htfDirection == logicBias)
                 return 0;
 
             if (ctx.LogicBiasConfidence >= 60)
                 return 0;
 
-            double htfConfidence = ctx.FxHtfConfidence01;
+            double htfConfidence = ctx.ActiveHtfConfidence;
             int penalty = 6;
             if (htfConfidence >= 0.80)
                 penalty += 4;

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -145,12 +145,12 @@ namespace GeminiV26.EntryTypes.INDEX
             double triggerScore = 0;
             const int maxPenalty = 22;
             bool continuationAuthority = HasContinuationAuthority(ctx, dir);
-            bool sourceHtfAlign = IsAlignedWithAllowedDirection(ctx?.IndexHtfAllowedDirection ?? TradeDirection.None, dir);
-            string sourceHtfState = ctx?.IndexHtfReason ?? "N/A";
+            bool sourceHtfAlign = IsAlignedWithAllowedDirection(ctx?.ActiveHtfDirection ?? TradeDirection.None, dir);
+            string sourceHtfState = "N/A";
 
             ctx.Log?.Invoke(
                 $"[AUDIT][HTF TRACE][SOURCE] symbol={ctx?.Symbol} entryType={Type} candidateDirection={dir} " +
-                $"rawHtfState={sourceHtfState} allowedDirection={ctx?.IndexHtfAllowedDirection ?? TradeDirection.None} " +
+                $"rawHtfState={sourceHtfState} allowedDirection={ctx?.ActiveHtfDirection ?? TradeDirection.None} " +
                 $"htfAlign={sourceHtfAlign} sourceModule=IndexHtfBiasEngine");
 
             if (hasHtfMismatch)
@@ -541,12 +541,12 @@ namespace GeminiV26.EntryTypes.INDEX
             }
 
             // HTF = soft only
-            if (ctx.IndexHtfAllowedDirection != TradeDirection.None)
+            if (ctx.ActiveHtfDirection != TradeDirection.None)
             {
-                if (ctx.IndexHtfAllowedDirection == dir)
+                if (ctx.ActiveHtfDirection == dir)
                     ApplyReward(3);
                 else
-                    ApplyPenalty(ctx.IndexHtfConfidence01 >= 0.70 ? 5 : 3);
+                    ApplyPenalty(ctx.ActiveHtfConfidence >= 0.70 ? 5 : 3);
             }
 
             score = (int)Math.Round(score * scoreMultiplier);
@@ -619,7 +619,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 HtfTraceSourceStage = "Index_FlagEntry.EvaluateDir",
                 HtfTraceSourceModule = "IndexHtfBiasEngine",
                 HtfTraceSourceState = sourceHtfState,
-                HtfTraceSourceAllowedDirection = ctx?.IndexHtfAllowedDirection ?? TradeDirection.None,
+                HtfTraceSourceAllowedDirection = ctx?.ActiveHtfDirection ?? TradeDirection.None,
                 HtfTraceSourceAlign = sourceHtfAlign,
                 HtfTraceSourceCandidateDirection = dir
             };
@@ -688,15 +688,15 @@ namespace GeminiV26.EntryTypes.INDEX
                 $"ADX={ctx?.Adx_M5:F1} Impulse={hasImpulse} ATR={ctx?.AtrM5:F1}"
             );
 
-            bool sourceHtfAlign = IsAlignedWithAllowedDirection(ctx?.IndexHtfAllowedDirection ?? TradeDirection.None, dir);
-            string sourceHtfState = ctx?.IndexHtfReason ?? "N/A";
+            bool sourceHtfAlign = IsAlignedWithAllowedDirection(ctx?.ActiveHtfDirection ?? TradeDirection.None, dir);
+            string sourceHtfState = "N/A";
 
             if (!string.IsNullOrWhiteSpace(reason) && reason.Contains("HTF_MISMATCH"))
             {
                 ctx?.Log?.Invoke(
                     $"[AUDIT][HTF TRACE][REJECT] symbol={ctx?.Symbol} entryType={EntryType.Index_Flag} candidateDirection={dir} " +
                     $"rejectReason={reason} currentHtfState={sourceHtfState} " +
-                    $"currentAllowedDirection={ctx?.IndexHtfAllowedDirection ?? TradeDirection.None} " +
+                    $"currentAllowedDirection={ctx?.ActiveHtfDirection ?? TradeDirection.None} " +
                     $"currentHtfAlign={sourceHtfAlign} module=Index_FlagEntry");
             }
 
@@ -711,7 +711,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 HtfTraceSourceStage = "Index_FlagEntry.EvaluateDir",
                 HtfTraceSourceModule = "IndexHtfBiasEngine",
                 HtfTraceSourceState = sourceHtfState,
-                HtfTraceSourceAllowedDirection = ctx?.IndexHtfAllowedDirection ?? TradeDirection.None,
+                HtfTraceSourceAllowedDirection = ctx?.ActiveHtfDirection ?? TradeDirection.None,
                 HtfTraceSourceAlign = sourceHtfAlign,
                 HtfTraceSourceCandidateDirection = dir
             };

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -288,8 +288,8 @@ namespace GeminiV26.EntryTypes.METAL
             }
 
             bool isAgainst =
-                ctx.MetalHtfAllowedDirection != TradeDirection.None &&
-                ctx.MetalHtfAllowedDirection != dir;
+                ctx.ActiveHtfDirection != TradeDirection.None &&
+                ctx.ActiveHtfDirection != dir;
 
             if (isAgainst)
             {

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -234,8 +234,8 @@ namespace GeminiV26.EntryTypes.METAL
             // HTF (soft only)
             // =========================
             bool against =
-                ctx.MetalHtfAllowedDirection != TradeDirection.None &&
-                ctx.MetalHtfAllowedDirection != dir;
+                ctx.ActiveHtfDirection != TradeDirection.None &&
+                ctx.ActiveHtfDirection != dir;
 
             if (against)
             {


### PR DESCRIPTION
### Motivation
- Entry-layer code still read per-asset HTF fields (e.g., `ctx.FxHtf*`, `ctx.CryptoHtf*`, `ctx.MetalHtf*`, `ctx.IndexHtf*`) which breaks the HTF single-source-of-truth and can cause drift between decision and core/logging layers.
- This change is a narrow, mechanical patch to eliminate direct per-asset HTF reads inside `EntryTypes/*` and force all entry logic to use the active HTF snapshot fields without changing decision thresholds or branching.

### Description
- Replaced all direct per-asset HTF direction and confidence reads in `EntryTypes/*` with `ctx.ActiveHtfDirection` and `ctx.ActiveHtfConfidence` respectively, preserving all existing logic, thresholds, comparisons, and scoring.
- Replaced null-safe per-asset references (e.g., `ctx?.CryptoHtfAllowedDirection`) with the corresponding `ctx?.ActiveHtfDirection` usages and similarly for confidence values.
- Removed entry-layer reads of per-asset HTF reason/state by setting trace state assignments to a neutral `"N/A"` where appropriate to avoid asset-specific dependency while keeping trace fields populated for auditing.
- Files modified: 13 files under `EntryTypes/*`; number of token replacements performed: 72; confirmation: there are zero remaining direct `ctx.<Asset>...Htf...` field accesses in `EntryTypes` (per automated scans); skipped cases: none in active code access, only identifier or module names (e.g., `FxDirectionValidation`, `IndexHtfBiasEngine`) remain in text/identifiers but do not read per-asset HTF fields.

### Testing
- Ran targeted regex to detect direct per-asset HTF field accesses with `rg -n "ctx\.(Fx|Crypto|Metal|Index)[A-Za-z0-9_]*Htf|ctx\?\.(Fx|Crypto|Metal|Index)[A-Za-z0-9_]*Htf" EntryTypes`, which returned zero matches indicating removal of direct per-asset HTF field reads.
- Ran `rg -n "ActiveHtfDirection|ActiveHtfConfidence" EntryTypes` to verify active HTF fields are now used across entry modules, which returned multiple usages throughout `EntryTypes`.
- Ran additional scans to remove per-asset HTF reason reads and confirm trace fields are set to `"N/A"` where replaced, which succeeded.
- Attempted `dotnet build` (`dotnet build -v minimal`) in the environment but the `dotnet` tool is not available so a project build could not be executed in this environment (failure due to missing runtime/tool).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c91f0188048328b37c99c280040efd)