### PR TITLE
Direction-specific breakout/structure checks and invalid-direction guard in TradeCore

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2553,9 +2553,14 @@ namespace GeminiV26.Core
                 if (rangeHigh > rangeLow)
                 {
                     double close = ctx.M5.ClosePrices[lastClosedM5];
-                    diagnostics.BreakoutClose =
-                        close > rangeHigh + buffer ||
-                        close < rangeLow - buffer;
+                    if (candidate.Direction == TradeDirection.Long)
+                    {
+                        diagnostics.BreakoutClose = close > rangeHigh + buffer;
+                    }
+                    else if (candidate.Direction == TradeDirection.Short)
+                    {
+                        diagnostics.BreakoutClose = close < rangeLow - buffer;
+                    }
                 }
 
                 double prevHigh = ctx.M5.HighPrices[lastClosedM5 - 1];
@@ -2563,16 +2568,30 @@ namespace GeminiV26.Core
                 double currentHigh = ctx.M5.HighPrices[lastClosedM5];
                 double currentLow = ctx.M5.LowPrices[lastClosedM5];
 
-                diagnostics.StructureBreak =
-                    currentHigh > prevHigh ||
-                    currentLow < prevLow ||
-                    ctx.BrokeLastSwingHigh_M5 ||
-                    ctx.BrokeLastSwingLow_M5;
+                if (candidate.Direction == TradeDirection.Long)
+                {
+                    diagnostics.StructureBreak =
+                        currentHigh > prevHigh ||
+                        ctx.BrokeLastSwingHigh_M5;
+                }
+                else if (candidate.Direction == TradeDirection.Short)
+                {
+                    diagnostics.StructureBreak =
+                        currentLow < prevLow ||
+                        ctx.BrokeLastSwingLow_M5;
+                }
             }
 
             diagnostics.M1Break =
                 ctx.HasBreakout_M1 &&
                 ctx.BreakoutDirection == candidate.Direction;
+
+            if (candidate.Direction == TradeDirection.None)
+            {
+                diagnostics.WaitReason = "INVALID_TRIGGER_DIRECTION";
+                diagnostics.TriggerConfirmed = false;
+                return diagnostics;
+            }
 
             diagnostics.TriggerConfirmed =
                 diagnostics.BreakoutClose ||


### PR DESCRIPTION
### Motivation
- Prevent signals from being set by price moves on the opposite side of the intended entry direction to reduce false triggers.
- Ensure structure-break detection only evaluates the side relevant to the candidate `Direction` to align with long/short logic.
- Explicitly handle an invalid `TradeDirection.None` case to avoid treating undefined directions as confirmed triggers.

### Description
- Change `diagnostics.BreakoutClose` to be evaluated only for longs (`close > rangeHigh + buffer`) or shorts (`close < rangeLow - buffer`) based on `candidate.Direction` instead of checking both sides unconditionally.
- Change `diagnostics.StructureBreak` to check only the relevant side for longs (`currentHigh > prevHigh` or `ctx.BrokeLastSwingHigh_M5`) or shorts (`currentLow < prevLow` or `ctx.BrokeLastSwingLow_M5`).
- Add a guard that sets `diagnostics.WaitReason = "INVALID_TRIGGER_DIRECTION"` and returns with `TriggerConfirmed = false` when `candidate.Direction == TradeDirection.None`.
- Preserve existing `M1Break` logic and the final `TriggerConfirmed` aggregation that combines breakout, structure, and M1 checks.

### Testing
- Built the project using `dotnet build` and the solution compiled successfully. 
- Ran the unit test suite with `dotnet test` and all tests passed. 
- Verified that the modified logic returns `TriggerConfirmed = false` for a `TradeDirection.None` candidate in unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c927d0314483288eef40107333c91d)