### PR TITLE
Soft late-trigger degradation using tracked trigger bar index

### DIFF
--- a/Core/Entry/ArmedSetup.cs
+++ b/Core/Entry/ArmedSetup.cs
@@ -9,6 +9,7 @@ namespace GeminiV26.Core.Entry
         public double Score { get; set; }
         public DateTime DetectedAt { get; set; }
         public int BarsSince { get; set; }
+        public int TriggerBarIndex { get; set; } = -1;
 
         public EntryType EntryType { get; set; }
         public string Reason { get; set; } = string.Empty;

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2493,14 +2493,30 @@ namespace GeminiV26.Core
 
                 if (!trigger.TriggerConfirmed)
                 {
-                    UpsertArmedSetup(candidate, barsSinceBreak);
+                    UpsertArmedSetup(candidate, barsSinceBreak, false, currentBarIndex);
                     _bot.Print($"[SETUP DETECTED] symbol={candidate.Symbol} score={candidate.Score} state=ARMED type={candidate.Type} dir={candidate.Direction}");
                     _bot.Print($"[TRIGGER WAIT] symbol={candidate.Symbol} reason={trigger.WaitReason} type={candidate.Type} dir={candidate.Direction} impact=score_only");
                 }
                 else
                 {
-                    UpsertArmedSetup(candidate, barsSinceBreak);
+                    UpsertArmedSetup(candidate, barsSinceBreak, true, currentBarIndex);
                     _bot.Print($"[TRIGGER CONFIRMED] symbol={candidate.Symbol} breakoutClose={trigger.BreakoutClose.ToString().ToLowerInvariant()} structureBreak={trigger.StructureBreak.ToString().ToLowerInvariant()} m1Break={trigger.M1Break.ToString().ToLowerInvariant()} type={candidate.Type} dir={candidate.Direction}");
+                }
+
+                if (candidate.TriggerConfirmed && _armedSetups.TryGetValue(GetArmedSetupKey(candidate), out var armed))
+                {
+                    int barsSinceTrigger = armed.TriggerBarIndex >= 0
+                        ? Math.Max(0, currentBarIndex - armed.TriggerBarIndex)
+                        : 0;
+
+                    if (barsSinceTrigger > 1)
+                    {
+                        int scoreBefore = candidate.Score;
+                        candidate.Score = Math.Max(0, (int)Math.Round(candidate.Score * 0.75, MidpointRounding.AwayFromZero));
+                        _bot.Print(TradeLogIdentity.WithTempId(
+                            $"[TRIGGER][LATE_PENALTY] symbol={candidate.Symbol ?? _bot.SymbolName} type={candidate.Type} dir={candidate.Direction} barsSinceTrigger={barsSinceTrigger} score={scoreBefore}->{candidate.Score}",
+                            ctx));
+                    }
                 }
 
                 if (candidate.TriggerConfirmed)
@@ -2795,12 +2811,20 @@ namespace GeminiV26.Core
             }
         }
 
-        private void UpsertArmedSetup(EntryEvaluation candidate, int barsSinceBreak)
+        private void UpsertArmedSetup(EntryEvaluation candidate, int barsSinceBreak, bool triggerConfirmed, int currentBarIndex)
         {
             if (candidate == null)
                 return;
 
             string key = GetArmedSetupKey(candidate);
+            _armedSetups.TryGetValue(key, out var existing);
+            int triggerBarIndex = -1;
+            if (triggerConfirmed)
+            {
+                triggerBarIndex = existing?.TriggerBarIndex >= 0
+                    ? existing.TriggerBarIndex
+                    : currentBarIndex;
+            }
             _armedSetups[key] = new ArmedSetup
             {
                 Symbol = candidate.Symbol ?? _bot.SymbolName,
@@ -2808,6 +2832,7 @@ namespace GeminiV26.Core
                 Score = candidate.Score,
                 DetectedAt = _bot.Server.Time,
                 BarsSince = barsSinceBreak,
+                TriggerBarIndex = triggerBarIndex,
                 EntryType = candidate.Type,
                 Reason = candidate.Reason ?? string.Empty
             };


### PR DESCRIPTION
### Motivation
- Reduce late entries by tracking when a trigger was first confirmed and applying a controlled, non-blocking score degradation for managed setups that remain triggered across bars.

### Description
- Add `TriggerBarIndex` to `Core/Entry/ArmedSetup.cs` to store the bar index where a trigger was first confirmed (`int TriggerBarIndex { get; set; } = -1`).
- Change `UpsertArmedSetup` in `Core/TradeCore.cs` to accept `triggerConfirmed` and `currentBarIndex`, set `TriggerBarIndex` when a trigger is first confirmed, preserve it while confirmed, and reset it when trigger is not confirmed.
- In `UpdateExecutionStateMachine` (managed triggers path) compute `barsSinceTrigger = currentBarIndex - armed.TriggerBarIndex` and, when `barsSinceTrigger > 1`, apply a soft penalty by reducing `candidate.Score` to ~75% (`candidate.Score = (int)Math.Round(candidate.Score * 0.75)`) while clamping to zero, without rejecting or blocking the trade.
- Add logging: `TradeLogIdentity` message with tag `[TRIGGER][LATE_PENALTY]` that includes `barsSinceTrigger` and `scoreBefore->scoreAfter`.
- No changes to stale-trigger hard block (`>3` bars), direction logic, routing logic, acceptance gates, or global scoring architecture.

### Testing
- Attempted `dotnet build -v minimal` in the environment, but `dotnet` is not available so a build could not be executed.
- No automated unit/integration tests were run in this environment due to missing build tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9359d26ec8328b9ca31ec4c6fee8b)