### PR TITLE
Add MFE/MAE lifecycle audit logs at update, TP1, and close

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -3161,6 +3161,8 @@ namespace GeminiV26.Core
                     exitPrice),
                 ctx,
                 pos));
+            if (ctx != null)
+                _bot.Print($"[CLOSE] final MFE={ctx.MfeR} MAE={ctx.MaeR}");
             _bot.Print(TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={args.Reason}\ndetail=broker_closed_event", ctx, pos));
 
             _logger.OnTradeClosed(

--- a/Core/TradeViabilityMonitor.cs
+++ b/Core/TradeViabilityMonitor.cs
@@ -243,6 +243,9 @@ namespace GeminiV26.Core
 
             if (adverseR > ctx.MaeR)
                 ctx.MaeR = adverseR;
+
+            _bot.Print($"[MFE] value={ctx.MfeR} price={currentPrice}");
+            _bot.Print($"[MAE] value={ctx.MaeR} price={currentPrice}");
         }
 
         private bool EvaluateEarlyPhase(

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.AUDNZD
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.AUDUSD
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -445,6 +445,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
             // 2) TP1 state
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -416,6 +416,7 @@ namespace GeminiV26.Instruments.ETHUSD
                 Math.Max(0, pos.VolumeInUnits - closeUnits);
 
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.EURJPY
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.EURUSD
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.GBPJPY
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print($"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.GBPUSD
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print($"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.GER40
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print($"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.NAS100
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.NZDUSD
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.US30
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.USDCAD
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.USDCHF
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print($"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -359,6 +359,7 @@ namespace GeminiV26.Instruments.USDJPY
             ctx.Tp1ClosedVolumeInUnits = closeUnits;
             ctx.RemainingVolumeInUnits = Math.Max(0, pos.VolumeInUnits - closeUnits);
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -437,6 +437,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
             // TP1 state (SSOT) – csak itt állítjuk
             ctx.Tp1Hit = true;
+            _bot.Print("[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
             _bot.Print(TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeVolume}", ctx, pos));
 


### PR DESCRIPTION
### Motivation

- Add non-invasive, temporary logging to trace MFE/MAE lifecycle through the full trade lifecycle for auditing and debugging without changing strategy logic.
- Instrument points of interest: MFE/MAE updates, TP1 execution (partial close), and final close so we can confirm whether excursions continue to be tracked after TP1.

### Description

- Added per-update audit prints in `TradeViabilityMonitor.UpdateMfeMae` to emit `"[MFE] value={ctx.MfeR} price={currentPrice}"` and `"[MAE] value={ctx.MaeR} price={currentPrice}"` after each MFE/MAE evaluation.
- Added a TP1 checkpoint log `"[TP1] hit → MFE continues tracking"` immediately after `ctx.Tp1Hit = true` in all active instrument exit managers (16 exit manager files updated) so TP1 events are visible in runtime logs.
- Added a close-time checkpoint in `Core/TradeCore.cs` to print `"[CLOSE] final MFE={ctx.MfeR} MAE={ctx.MaeR}"` right before the exit decision is written and CSVs are produced.
- No strategy/behavioral logic was modified; the changes are logging-only and intended for short-term audit use.

### Testing

- Verified presence of new log lines using ripgrep searches for the inserted markers, which located the `UpdateMfeMae` prints, the TP1 messages across exit managers, and the close print in `TradeCore` (searches succeeded).
- Confirmed commit of changes (`git` commit completed) and file diffs contain only logging additions.
- Attempted a full build with `dotnet build` but it failed due to missing `dotnet` in the environment (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c940d8520c8328ab3f0d6b6791bd93)