### PR TITLE
Fix TradeLifecycleTracker compile errors

### DIFF
--- a/Core/TradeLifecycleTracker.cs
+++ b/Core/TradeLifecycleTracker.cs
@@ -1,4 +1,4 @@
-using cAlgo.API;
+using GeminiV26.Core.Entry;
 
 namespace GeminiV26.Core
 {
@@ -22,8 +22,6 @@ namespace GeminiV26.Core
             if (rMove < ctx.MaeR)
                 ctx.MaeR = rMove;
 
-            ctx.Bot?.Print($"[MFE] value={ctx.MfeR:F2} price={currentPrice}");
-            ctx.Bot?.Print($"[MAE] value={ctx.MaeR:F2} price={currentPrice}");
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Resolve compile-time errors in `Core/TradeLifecycleTracker.cs` (missing `TradeDirection` reference and invalid `PositionContext.Bot` usage) while preserving the intended MFE/MAE tracking logic.

### Description
- Added `using GeminiV26.Core.Entry;` to resolve `TradeDirection`.
- Removed stale `ctx.Bot?.Print(...)` calls because `PositionContext` does not expose a `Bot` property; the MFE/MAE update logic is otherwise unchanged.

### Testing
- Verified the change with quick file inspections and text searches using `sed`, `nl`, and `rg` to ensure the import is present and `ctx.Bot` references are gone, and static checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c944bb53ec8328818ea4ca9ea36370)