### PR TITLE
Add temporary direction-flow trace log and audit FinalDirection SSOT

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1334,6 +1334,11 @@ namespace GeminiV26.Core
 
                 _ctx.RoutedDirection = selected.Direction;
                 _ctx.FinalDirection = selected.Direction;
+                var logicDir = _ctx.LogicBiasDirection;
+                var evalDir = selected.Direction;
+                var routedDir = _ctx.RoutedDirection;
+                var finalDir = _ctx.FinalDirection;
+                _bot.Print($"[DIR] logic={logicDir} eval={evalDir} routed={routedDir} final={finalDir}");
                 _ctx.EntryScore = PositionContext.ClampRiskConfidence(selected.Score);
                 _ctx.LogicBiasConfidence = PositionContext.ClampRiskConfidence(Math.Max(0, _ctx.LogicBiasConfidence));
                 _ctx.FinalConfidence = PositionContext.ComputeFinalConfidenceValue(_ctx.EntryScore, _ctx.LogicBiasConfidence);


### PR DESCRIPTION
### Motivation
- Provide transient observability to verify the direction single-source-of-truth (`FinalDirection`) and detect any mismatches in the pipeline without changing runtime logic.

### Description
- Added a temporary diagnostic print in `Core/TradeCore.cs` at the moment the router-selected entry is promoted into context SSOT fields to log `logicDir`, `evalDir`, `routedDir`, and `finalDir` (no decision logic changed).

### Testing
- Performed repository-wide code searches (`rg`) and file inspections (`nl`) to trace uses of `TrendDirection`, `LogicBiasDirection`, `EntryEvaluation.Direction`, `RoutedDirection`, and `FinalDirection` and confirmed the expected flow (`EntryLogic → EntryType → Router → TradeCore → FinalDirection → Executor`), and all commands completed successfully.
- Applied the patch programmatically and validated the update by inspecting `Core/TradeCore.cs` and the produced diff to confirm the inserted `_bot.Print` line and surrounding context were added; the patch verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c94696b650832881aa74d9ca573145)