### PR TITLE
Add temporary memory penalty source log in final acceptance gate

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2730,6 +2730,7 @@ namespace GeminiV26.Core
                 return false;
 
             int recommendedTimingPenalty = ctx.MemoryAssessment?.RecommendedTimingPenalty ?? ctx.MemoryTimingPenalty;
+            _bot.Print($"[MEM] penalty={recommendedTimingPenalty} source={(ctx.MemoryAssessment != null ? "assessment" : "fallback")}");
             if (recommendedTimingPenalty <= -10)
             {
                 _bot.Print(TradeLogIdentity.WithTempId(


### PR DESCRIPTION
### Motivation
- Add a short diagnostic trace to `PassFinalAcceptance` to record the effective memory timing penalty and whether it came from the `MemoryAssessment` or the context fallback so memory influence (missing/neutral cases) can be audited without changing any logic.

### Description
- Inserted `_bot.Print($"[MEM] penalty={recommendedTimingPenalty} source={(ctx.MemoryAssessment != null ? "assessment" : "fallback")}");` at the start of `PassFinalAcceptance` immediately before the existing `<= -10` timing block; no refactor or logic change was made.

### Testing
- Executed repository inspections and validations (`rg` searches for `RecommendedTimingPenalty|MemoryTimingPenalty|MemoryAssessment`, `sed`/file views of `MemoryAssessment`, `MarketMemoryEngine`, `EntryContextBuilder`, and `Core/TradeCore.cs`) and committed the change with `git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9477597748328a570f4c5e218765e)