### PR TITLE
Add temporary audit logging for XAU reversal reachability

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1162,6 +1162,10 @@ namespace GeminiV26.Core
                 return;
             }
 
+            int countBefore = symbolSignals?.Count ?? 0;
+            if (isMetalSymbol)
+                _bot.Print($"[TC][XAU] candidates BEFORE filter: {countBefore}");
+
             ApplyTransitionScoreBoost(_ctx, symbolSignals);
 
             _bot.Print(TradeLogIdentity.WithTempId($"[DBG ENTRY] total candidates={symbolSignals.Count}", _ctx));
@@ -1245,6 +1249,10 @@ namespace GeminiV26.Core
                         _ctx));
                     LogCriticalDirectionDrop(_ctx, e);
                 }
+
+                int countAfter = symbolSignals?.Count ?? 0;
+                if (isMetalSymbol)
+                    _bot.Print($"[TC][XAU] candidates AFTER filter: {countAfter}");
 
                 LogEntryTraceSummary(_ctx, symbolSignals);
 

--- a/EntryTypes/METAL/XAU_ReversalEntry.cs
+++ b/EntryTypes/METAL/XAU_ReversalEntry.cs
@@ -49,6 +49,15 @@ namespace GeminiV26.EntryTypes.METAL
         }
         private EntryEvaluation EvaluateSide(EntryContext ctx, TradeDirection dir, bool htfMismatch)
         {
+            // TEMP LOGGING (AUDIT): explicit runtime visibility for XAU reversal reachability.
+            string marketStateLabel =
+                ctx?.MarketState == null
+                    ? "NULL"
+                    : ctx.MarketState.IsTrend ? "Trend"
+                    : ctx.MarketState.IsRange ? "Range"
+                    : ctx.MarketState.IsLowVol ? "LowVol"
+                    : "Neutral";
+
             var reasons = new List<string>(8);
             int setupScore = 0;
 
@@ -167,13 +176,16 @@ namespace GeminiV26.EntryTypes.METAL
                 $"Score={score} Min={MinScore} Decision=ACCEPT | " +
                 string.Join(" | ", reasons);
 
+            bool isValid = score >= MinScore;
+            ctx?.Log?.Invoke($"[XAU_REVERSAL] isValid={isValid} state={marketStateLabel} bias={ctx?.TrendDirection}");
+
             return new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
                 Direction = dir,
                 Score = score,
-                IsValid = score >= MinScore,
+                IsValid = isValid,
                 Reason = note
             };
         }
@@ -227,6 +239,17 @@ namespace GeminiV26.EntryTypes.METAL
             string reason,
             List<string> reasons)
         {
+            // TEMP LOGGING (AUDIT): traces invalid reversal paths with market state + bias context.
+            string marketStateLabel =
+                ctx?.MarketState == null
+                    ? "NULL"
+                    : ctx.MarketState.IsTrend ? "Trend"
+                    : ctx.MarketState.IsRange ? "Range"
+                    : ctx.MarketState.IsLowVol ? "LowVol"
+                    : "Neutral";
+            bool isValid = false;
+            ctx?.Log?.Invoke($"[XAU_REVERSAL] isValid={isValid} state={marketStateLabel} bias={ctx?.TrendDirection}");
+
             string note =
                 $"[XAU_REV] {ctx?.Symbol} dir={dir} " +
                 $"Score={score} Decision=REJECT Reason={reason} | " +


### PR DESCRIPTION
### Motivation
- Provide runtime visibility to audit whether XAU_Reversal candidates are being structurally blocked by MarketState / HTF / TradeCore stages without changing decision logic.
- Make it easier to trace where candidates are killed (entry validation, HTF scoring, TradeCore filters, router, post-selection XAU hard-range gate). 

### Description
- Added temporary audit logging in `EntryTypes/METAL/XAU_ReversalEntry.cs` to print `isValid`, a derived market-state label (`Trend`/`Range`/`LowVol`/`Neutral`/`NULL`) and `bias` on both accept and reject paths (explicitly marked as temporary). 
- Added temporary candidate-count logging in `Core/TradeCore.cs` for metal symbols before and after the pre-router filtering stages to observe how many XAU candidates survive score/gate adjustments (logged only when `isMetalSymbol` is true). 
- No entry/selection logic or score thresholds were changed and no refactoring was performed; changes are audit-only and limited to two files (`EntryTypes/METAL/XAU_ReversalEntry.cs`, `Core/TradeCore.cs`).

### Testing
- Performed repository code searches (`rg`) to locate XAU reversal checks, MarketState detector, HTF engine and TradeCore flow to confirm where `IsRange_M5`, `M1ReversalTrigger` and `ReversalEvidenceScore` are used, and these searches succeeded and validated findings.
- Inspected relevant source files with `sed`/`nl` to verify inserted log statements and to confirm HTF behavior is score-only (soft penalties) and that TradeCore includes an XAU hard-range post-selection block, and these inspections succeeded.
- Attempted to run `dotnet build` but the environment lacks the `dotnet` tool, so a full compile-time test could not be executed (failure due to missing runtime).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9490c27888328b49a1d02ab650a67)