### PR TITLE
Add per-tick logging and MFE/MAE trace across exit managers

### DIFF
--- a/Core/TradeLifecycleTracker.cs
+++ b/Core/TradeLifecycleTracker.cs
@@ -11,6 +11,8 @@ namespace GeminiV26.Core
             if (ctx.FinalDirection == TradeDirection.None)
                 return;
 
+            System.Console.WriteLine($"[MFE_TICK] time={System.DateTime.UtcNow:HH:mm:ss.fff} price={currentPrice}");
+
             double rMove;
             double riskDistance = ctx.RiskPriceDistance;
 

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.AUDNZD
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.AUDUSD
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -248,6 +248,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -232,6 +232,7 @@ namespace GeminiV26.Instruments.ETHUSD
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.EURJPY
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.EURUSD
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.GBPJPY
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.GBPUSD
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.GER40
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.NAS100
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.NZDUSD
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.US30
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.USDCAD
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.USDCHF
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -215,6 +215,7 @@ namespace GeminiV26.Instruments.USDJPY
                 double currentPrice = ctx.FinalDirection == TradeDirection.Long
                     ? sym.Bid
                     : sym.Ask;
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -273,6 +273,7 @@ namespace GeminiV26.Instruments.XAUUSD
                     ? sym.Bid
                     : sym.Ask;
                 // Keep MFE/MAE lifecycle tracking independent from TP1/TVM gating.
+                _bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}");
                 TradeLifecycleTracker.UpdateMfeMae(ctx, currentPrice);
 
                 double rDist = GetRiskDistance(pos, ctx);


### PR DESCRIPTION
### Motivation

- Improve observability of per-tick processing and MFE/MAE lifecycle calculations to aid debugging of exit logic and trade lifecycle metrics.

### Description

- Inserted `_bot.Print($"[ONTICK] time={_bot.Server.Time:HH:mm:ss.fff}")` in multiple `*ExitManager` files immediately before calling `TradeLifecycleTracker.UpdateMfeMae` so each exit manager emits an on-tick timestamp when processing a context.
- Added a tracing line in `TradeLifecycleTracker.UpdateMfeMae` that writes `"[MFE_TICK] time=... price=..."` to the console to record MFE/MAE evaluation ticks and the price used.
- Changes are logging-only and do not modify the MFE/MAE calculation logic or exit gating behavior.

### Testing

- Ran a solution build with `dotnet build` to ensure the code compiles successfully and no build errors were introduced.
- Executed the test suite with `dotnet test` and all existing automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c94bc7190483289d656f76974e3ffc)