### PR TITLE
Make MFE/MAE tracker logs visible via cTrader bot prints

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -24,6 +24,7 @@
 // =========================================================
 
 using System;
+using cAlgo.API;
 using Gemini.Memory;
 using GeminiV26.Core.Entry;
 
@@ -44,6 +45,7 @@ namespace GeminiV26.Core
         public long PositionId { get; set; }
 
         public string Symbol { get; set; } = string.Empty;
+        public Robot Bot { get; set; }
 
         public string TempId { get; set; } = string.Empty;
 

--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -225,6 +225,7 @@ namespace GeminiV26.Core.Runtime
                 {
                     PositionId = positionKey,
                     Symbol = position.SymbolName,
+                    Bot = _bot,
                     TempId = position.Comment ?? string.Empty,
                     EntryType = "REHYDRATED",
                     EntryReason = "Startup rehydrate from live open position",
@@ -381,6 +382,7 @@ namespace GeminiV26.Core.Runtime
             {
                 PositionId = positionKey,
                 Symbol = position.SymbolName,
+                    Bot = _bot,
                 TempId = position.Comment ?? string.Empty,
                 EntryType = "REHYDRATED",
                 EntryReason = "Startup rehydrate from live open position",

--- a/Core/TradeLifecycleTracker.cs
+++ b/Core/TradeLifecycleTracker.cs
@@ -8,10 +8,13 @@ namespace GeminiV26.Core
         {
             if (ctx == null || ctx.EntryPrice <= 0 || ctx.RiskPriceDistance <= 0)
                 return;
+            if (ctx.Bot == null)
+                return;
             if (ctx.FinalDirection == TradeDirection.None)
                 return;
 
-            System.Console.WriteLine($"[MFE_TICK] time={System.DateTime.UtcNow:HH:mm:ss.fff} price={currentPrice}");
+            ctx.Bot.Print($"[MFE_TRACKER] active dir={ctx.FinalDirection} entry={ctx.EntryPrice} risk={ctx.RiskPriceDistance}");
+            ctx.Bot.Print($"[MFE_TICK] time={System.DateTime.UtcNow:HH:mm:ss.fff} price={currentPrice}");
 
             double rMove;
             double riskDistance = ctx.RiskPriceDistance;
@@ -26,6 +29,9 @@ namespace GeminiV26.Core
 
             if (rMove < ctx.MaeR)
                 ctx.MaeR = rMove;
+
+            ctx.Bot.Print($"[MFE] value={ctx.MfeR:F2} price={currentPrice}");
+            ctx.Bot.Print($"[MAE] value={ctx.MaeR:F2} price={currentPrice}");
 
         }
     }

--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -131,6 +131,7 @@ namespace GeminiV26.Instruments.AUDNZD
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -216,6 +217,7 @@ namespace GeminiV26.Instruments.AUDNZD
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -125,6 +125,7 @@ namespace GeminiV26.Instruments.AUDUSD
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -210,6 +211,7 @@ namespace GeminiV26.Instruments.AUDUSD
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -92,6 +92,7 @@ namespace GeminiV26.Instruments.BTCUSD
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -206,6 +207,7 @@ namespace GeminiV26.Instruments.BTCUSD
             {
                 PositionId = posId,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
 
                 EntryType = entry.Type.ToString(),

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -92,6 +92,7 @@ namespace GeminiV26.Instruments.ETHUSD
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -206,6 +207,7 @@ namespace GeminiV26.Instruments.ETHUSD
             {
                 PositionId = posId,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
 
                 EntryType = entry.Type.ToString(),

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -125,6 +125,7 @@ namespace GeminiV26.Instruments.EURJPY
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -210,6 +211,7 @@ namespace GeminiV26.Instruments.EURJPY
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -104,6 +104,7 @@ namespace GeminiV26.Instruments.EURUSD
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -201,6 +202,7 @@ namespace GeminiV26.Instruments.EURUSD
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -125,6 +125,7 @@ namespace GeminiV26.Instruments.GBPJPY
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -210,6 +211,7 @@ namespace GeminiV26.Instruments.GBPJPY
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -114,6 +114,7 @@ namespace GeminiV26.Instruments.GBPUSD
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -228,6 +229,7 @@ namespace GeminiV26.Instruments.GBPUSD
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -90,6 +90,7 @@ namespace GeminiV26.Instruments.GER40
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -198,6 +199,7 @@ namespace GeminiV26.Instruments.GER40
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -100,6 +100,7 @@ namespace GeminiV26.Instruments.NAS100
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -208,6 +209,7 @@ namespace GeminiV26.Instruments.NAS100
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -125,6 +125,7 @@ namespace GeminiV26.Instruments.NZDUSD
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -210,6 +211,7 @@ namespace GeminiV26.Instruments.NZDUSD
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -96,6 +96,7 @@ namespace GeminiV26.Instruments.US30
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -183,6 +184,7 @@ namespace GeminiV26.Instruments.US30
             {
                 PositionId = positionKey,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -125,6 +125,7 @@ namespace GeminiV26.Instruments.USDCAD
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -210,6 +211,7 @@ namespace GeminiV26.Instruments.USDCAD
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -125,6 +125,7 @@ namespace GeminiV26.Instruments.USDCHF
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -210,6 +211,7 @@ namespace GeminiV26.Instruments.USDCHF
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -111,6 +111,7 @@ namespace GeminiV26.Instruments.USDJPY
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,
@@ -200,6 +201,7 @@ namespace GeminiV26.Instruments.USDJPY
             {
                 PositionId = result.Position.Id,
                 Symbol = result.Position.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -374,6 +374,7 @@ namespace GeminiV26.Instruments.XAUUSD
                             {
                                 EventTimestamp = DateTime.UtcNow,
                                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                                 EventType = "EXIT_TVM",
                                 PositionId = ctx.PositionId,
                                 Confidence = ctx.FinalConfidence,
@@ -476,6 +477,7 @@ namespace GeminiV26.Instruments.XAUUSD
             {
                 EventTimestamp = DateTime.UtcNow,
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 EventType = "EXIT_TP1",
                 PositionId = ctx.PositionId,
                 Confidence = ctx.FinalConfidence,
@@ -646,6 +648,7 @@ namespace GeminiV26.Instruments.XAUUSD
                 {
                     PositionId = pos.Id,
                     Symbol = pos.SymbolName,
+                    Bot = bot,
                     TempId = pos.Comment ?? string.Empty,
                     EntryPrice = pos.EntryPrice,
 

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -136,6 +136,7 @@ namespace GeminiV26.Instruments.XAUUSD
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
+                Bot = _bot,
                 TempId = entryContext.TempId,
                 EntryType = entry.Type.ToString(),
                 EntryReason = entry.Reason,


### PR DESCRIPTION
### Motivation
- MFE/MAE tick updates were not visible in runtime logs because the tracker used `Console.WriteLine` and/or lacked a valid cTrader `Bot` reference on `PositionContext`.
- Minimal surface change is required to route tracker diagnostics into the cTrader runtime logger without touching trading logic or behavior.

### Description
- Replaced `Console.WriteLine` usage in `TradeLifecycleTracker.UpdateMfeMae(...)` with cTrader-visible logging via `ctx.Bot.Print(...)` and added a guard `if (ctx.Bot == null) return;` and a diagnostic `[MFE_TRACKER]` line. (file: `Core/TradeLifecycleTracker.cs`).
- Added a `Robot Bot { get; set; }` property to `PositionContext` to carry a cTrader bot instance for runtime logging. (file: `Core/PositionContext.cs`).
- Populated `Bot = _bot` when creating `PositionContext` in rehydrate and executor paths so `ctx.Bot` is non-null; examples include `Instruments/EURUSD/EurUsdInstrumentExecutor.cs` and `Core/Runtime/RehydrateService.cs`, and similar fixes applied across instrument executors and XAU exit/rehydrate flows. (multiple `Instruments/*` and `Core/Runtime/RehydrateService.cs`).
- Emitted the required runtime lines ` [MFE_TRACKER]`, `[MFE_TICK]`, `[MFE]`, and `[MAE]` via `ctx.Bot.Print(...)` at tick and after MFE/MAE updates. (file: `Core/TradeLifecycleTracker.cs`).

### Testing
- Performed static verification by searching for `Bot = _bot` and `UpdateMfeMae` changes and confirmed the `Bot` property was added and `PositionContext` creation sites were updated; these grep-based checks succeeded.
- Attempted to run `dotnet build GeminiV26.sln` but the environment lacks the SDK (`dotnet: command not found`), so no compile/test run was executed here.
- Changes were committed locally with a message indicating the logger-path fix and context plumbing was applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c951d5e9848328b419b4fb34d9d53b)