### PR TITLE
Fix XAU ExitManager EventRecord compile error

### DIFF
--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -374,7 +374,6 @@ namespace GeminiV26.Instruments.XAUUSD
                             {
                                 EventTimestamp = DateTime.UtcNow,
                                 Symbol = _bot.SymbolName,
-                Bot = _bot,
                                 EventType = "EXIT_TVM",
                                 PositionId = ctx.PositionId,
                                 Confidence = ctx.FinalConfidence,
@@ -477,7 +476,6 @@ namespace GeminiV26.Instruments.XAUUSD
             {
                 EventTimestamp = DateTime.UtcNow,
                 Symbol = _bot.SymbolName,
-                Bot = _bot,
                 EventType = "EXIT_TP1",
                 PositionId = ctx.PositionId,
                 Confidence = ctx.FinalConfidence,


### PR DESCRIPTION
### Motivation
- Remove a compilation break introduced by object initializers referencing a non-existent `Bot` property on `EventRecord`, while keeping all exit/logging behavior intact.

### Description
- Deleted the invalid `Bot = _bot` assignments from the two `EventRecord` initializers for `EXIT_TVM` and `EXIT_TP1` in `Instruments/XAUUSD/XauExitManager.cs` without changing any exit logic.

### Testing
- Verified the fix with `rg -n "new EventRecord|Bot\s*=\s*_bot" Instruments/XAUUSD/XauExitManager.cs`, which confirmed the offending `Bot` assignments were removed (search returned only `new EventRecord` occurrences).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c953bff5348328800706f9c51ca368)