### PR TITLE
Fix invalid PositionContext member reference in TradeLifecycleTracker

### DIFF
--- a/Core/TradeLifecycleTracker.cs
+++ b/Core/TradeLifecycleTracker.cs
@@ -9,7 +9,7 @@ namespace GeminiV26.Core
             System.Console.WriteLine($"[MFE_CALL] time={System.DateTime.UtcNow:HH:mm:ss.fff} ctxNull={ctx == null} price={currentPrice}");
             if (ctx != null)
             {
-                System.Console.WriteLine($"[MFE_CTX] hasBot={(ctx.Bot != null)} entry={ctx.EntryPrice} side={ctx.Side}");
+                System.Console.WriteLine($"[MFE_CTX] hasBot={(ctx.Bot != null)} entry={ctx.EntryPrice} side={ctx.FinalDirection}");
             }
 
             if (ctx == null)


### PR DESCRIPTION
### Motivation
- Fix a definition error in `TradeLifecycleTracker.UpdateMfeMae` where `PositionContext` was referenced with a non-existent `Side` member, causing a compilation issue.

### Description
- Replace the invalid `ctx.Side` usage with `ctx.FinalDirection` in the debug log line in `Core/TradeLifecycleTracker.cs` without changing any runtime logic.

### Testing
- Attempted to run `dotnet build -nologo`, but the `dotnet` CLI is not available in this environment so the build could not be executed; the change is a single-line logging fix and was committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c960b98f048328be08ae6599950991)