### PR TITLE
Fix logging regression compile breaks

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -357,20 +357,6 @@ namespace GeminiV26.Core.Entry
 
         public string SymbolName => Symbol;
 
-        public void Log(string message)
-        {
-            if (string.IsNullOrWhiteSpace(message))
-                return;
-
-            if (Log != null)
-            {
-                Log(TradeLogIdentity.WithTempId(message, this));
-                return;
-            }
-
-            GlobalLogger.Log(TradeLogIdentity.WithTempId(message, this));
-        }
-
         public int GetBarsSinceImpulse(TradeDirection direction)
         {
             return direction switch

--- a/Instruments/BTCUSD/BtcUsdMarketStateDetector.cs
+++ b/Instruments/BTCUSD/BtcUsdMarketStateDetector.cs
@@ -58,7 +58,6 @@ namespace GeminiV26.Instruments.BTCUSD
             bool isTrend = adx >= _profile.MinAdxTrend;
             bool isStrongTrend = adx >= _profile.MinAdxStrong;
 
-            GlobalLogger.Log(
             bool isChop = false;
             int lb = Math.Max(1, _profile.ChopLookbackBars);
             int start = Math.Max(0, i - lb + 1);

--- a/Instruments/ETHUSD/EthUsdMarketStateDetector.cs
+++ b/Instruments/ETHUSD/EthUsdMarketStateDetector.cs
@@ -58,7 +58,6 @@ namespace GeminiV26.Instruments.ETHUSD
             bool isTrend = adx >= _profile.MinAdxTrend;
             bool isStrongTrend = adx >= _profile.MinAdxStrong;
 
-            GlobalLogger.Log(
             bool isChop = false;
             int lb = Math.Max(1, _profile.ChopLookbackBars);
             int start = Math.Max(0, i - lb + 1);


### PR DESCRIPTION
### Motivation
- A global logging change introduced an `EntryContext.Log(string)` method that collided with the existing `Action<string> Log` member and left stray `GlobalLogger.Log(` fragments in some detectors, causing widespread compile-time failures.

### Description
- Removed the accidental `EntryContext.Log(string)` method and deleted the stray `GlobalLogger.Log(` fragments in `Instruments/BTCUSD/BtcUsdMarketStateDetector.cs` and `Instruments/ETHUSD/EthUsdMarketStateDetector.cs` to restore valid syntax and preserve `ctx.Log?.Invoke(...)` usage.

### Testing
- Verified changes by inspecting diffs (`git diff`) and searching for remaining malformed `GlobalLogger.Log(` occurrences with `rg`, and attempted `dotnet build` which could not run in this environment because the `dotnet` CLI is not installed (so no full compile was executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c969345a18832894d7294e4bdfb7a7)