### PR TITLE
Wrap GlobalLogger calls with string.Format to fix CS1501 errors

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -933,14 +933,14 @@ namespace GeminiV26.Core
             _ctx.MarketState = BuildEntryMarketState(fxState, cryptoState, xauState, indexState);
             if (_ctx.MarketState != null)
             {
-                GlobalLogger.Log(
+                GlobalLogger.Log(string.Format(
                     "[ENTRY MARKETSTATE ASSIGN] sym={0} trend={1} momentum={2} lowVol={3} adx={4:F1} atrPts={5:F2}",
                     rawSym,
                     _ctx.MarketState.IsTrend,
                     _ctx.MarketState.IsMomentum,
                     _ctx.MarketState.IsLowVol,
                     _ctx.MarketState.Adx,
-                    _ctx.MarketState.AtrPoints);
+                    _ctx.MarketState.AtrPoints));
             }
 
             _ctx.LastUpdateUtc = DateTime.UtcNow;

--- a/Instruments/METAL/MetalMarketStateDetector.cs
+++ b/Instruments/METAL/MetalMarketStateDetector.cs
@@ -80,7 +80,7 @@ namespace GeminiV26.Instruments.METAL
             if (adx > 40)
                 hardRange = false;
 
-            GlobalLogger.Log(
+            GlobalLogger.Log(string.Format(
                 "[XAU MSD] atrPips={0:F1} adx={1:F1} emaDistATR={2:F2} lowVol={3} trend={4} momentum={5} compression={6} hardRange={7} spike={8}",
                 atrPips,
                 adx,
@@ -90,7 +90,7 @@ namespace GeminiV26.Instruments.METAL
                 momentum,
                 compression,
                 hardRange,
-                isSpike);
+                isSpike));
 
             return new MetalMarketState
             {


### PR DESCRIPTION
### Motivation
- The `GlobalLogger.Log` API accepts a single `string` parameter and existing multi-argument `GlobalLogger.Log(...)` calls caused `CS1501` build errors.

### Description
- Converted two multi-argument `GlobalLogger.Log(...)` calls into `GlobalLogger.Log(string.Format(...))` in `Instruments/METAL/MetalMarketStateDetector.cs` and `Core/TradeCore.cs` so the logger receives a single formatted `string` parameter.

### Testing
- Attempted `dotnet build -v minimal` but the build could not be run in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c96ab4b8288328844c6cd20dfbca44)