### PR TITLE
Use GlobalLogger.Log instead of bot Print in market detectors and exit manager

### DIFF
--- a/Instruments/BTCUSD/BtcUsdMarketStateDetector.cs
+++ b/Instruments/BTCUSD/BtcUsdMarketStateDetector.cs
@@ -82,7 +82,7 @@ namespace GeminiV26.Instruments.BTCUSD
             }
             isChop = wicky >= lb;
 
-            _bot.Print(
+            GeminiV26.Core.Logging.GlobalLogger.Log(
                 $"[BTC MSD] atrRaw={atrRaw:F2} pipSize={_bot.Symbol.PipSize} atrPips={atrPips:F1} adx={adx:F1} wickRatio={wickRatio:F2} " +
                 $"lowVol={isLowVol} extremeVol={isExtremeVol} trend={isTrend} strongTrend={isStrongTrend} chop={isChop}"
             );

--- a/Instruments/Common/BaseExitManager.cs
+++ b/Instruments/Common/BaseExitManager.cs
@@ -58,7 +58,7 @@ namespace GeminiV26.Instruments.Common
                 ctx.IsRehydrated = true;
                 Contexts[pos.Id] = ctx;
 
-                Bot.Print($"[{pos.SymbolName} REHYDRATE] pos={pos.Id}");
+                GlobalLogger.Log($"[{pos.SymbolName} REHYDRATE] pos={pos.Id}");
             }
         }
 

--- a/Instruments/ETHUSD/EthUsdMarketStateDetector.cs
+++ b/Instruments/ETHUSD/EthUsdMarketStateDetector.cs
@@ -82,7 +82,7 @@ namespace GeminiV26.Instruments.ETHUSD
             }
             isChop = wicky >= lb;
 
-            _bot.Print(
+            GeminiV26.Core.Logging.GlobalLogger.Log(
                 $"[ETH MSD] atrRaw={atrRaw:F2} pipSize={_bot.Symbol.PipSize} atrPips={atrPips:F1} adx={adx:F1} wickRatio={wickRatio:F2} " +
                 $"lowVol={isLowVol} extremeVol={isExtremeVol} trend={isTrend} strongTrend={isStrongTrend} chop={isChop}"
             );


### PR DESCRIPTION
### Motivation
- Standardize logging by replacing per-bot `Print` calls with the centralized `GlobalLogger.Log` to unify output and improve observability.

### Description
- Replaced `_bot.Print(...)` with `GeminiV26.Core.Logging.GlobalLogger.Log(...)` in `Instruments/BTCUSD/BtcUsdMarketStateDetector.cs` and `Instruments/ETHUSD/EthUsdMarketStateDetector.cs`.
- Replaced `Bot.Print(...)` with `GlobalLogger.Log(...)` in `Instruments/Common/BaseExitManager.cs` within the `RehydrateFromLivePositions` flow.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c96c0f76f083288fdfb01732ad982f)