### PR TITLE
Restore GlobalLogger overloads and fix static DirectionDebug calls

### DIFF
--- a/Core/Logging/GlobalLogger.cs
+++ b/Core/Logging/GlobalLogger.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using cAlgo.API;
 
 namespace GeminiV26.Core.Logging
@@ -6,10 +7,33 @@ namespace GeminiV26.Core.Logging
     {
         public static void Log(Robot bot, string msg)
         {
-            if (bot != null && msg != null)
+            if (msg == null)
+                return;
+
+            if (bot != null)
             {
                 bot.Print(msg);
+                return;
             }
+
+            Debug.WriteLine(msg);
+        }
+
+        public static void Log(string msg)
+        {
+            if (msg == null)
+                return;
+
+            Debug.WriteLine(msg);
+        }
+
+        public static void Log(object source, string msg)
+        {
+            if (msg == null)
+                return;
+
+            string prefix = source == null ? "[LOG]" : $"[{source.GetType().Name}]";
+            Debug.WriteLine($"{prefix} {msg}");
         }
     }
 }

--- a/EntryTypes/DirectionDebug.cs
+++ b/EntryTypes/DirectionDebug.cs
@@ -12,7 +12,7 @@ namespace GeminiV26.EntryTypes
                 return;
 
             ctx.DirectionDebugLogged = true;
-            GlobalLogger.Log(this, $"[DIR DEBUG] symbol={ctx.SymbolName} bias={ctx.LogicBiasDirection} conf={ctx.LogicBiasConfidence}");
+            GlobalLogger.Log(typeof(DirectionDebug), $"[DIR DEBUG] symbol={ctx.SymbolName} bias={ctx.LogicBiasDirection} conf={ctx.LogicBiasConfidence}");
 
             if (SymbolRouting.NormalizeSymbol(ctx.Symbol) == "AUDNZD")
             {
@@ -22,7 +22,7 @@ namespace GeminiV26.EntryTypes
                     Debug.Assert(ctx.LogicBias == entryBias);
                 }
 
-                GlobalLogger.Log(this, $"[AUDNZD TRACE] step3_entry={entryBias} conf={ctx.LogicBiasConfidence}");
+                GlobalLogger.Log(typeof(DirectionDebug), $"[AUDNZD TRACE] step3_entry={entryBias} conf={ctx.LogicBiasConfidence}");
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Restore compile-time compatibility after logger API changes and remove static-context compile errors caused by using `this` inside `DirectionDebug`.

### Description
- Reworked `GlobalLogger` to keep `Log(Robot, string)` resilient to a `null` `Robot` and fall back to `Debug.WriteLine` when needed.
- Added `Log(string)` and `Log(object, string)` overloads to restore call-site compatibility across the codebase.
- Replaced `this` with `typeof(DirectionDebug)` in `EntryTypes/DirectionDebug.cs` to fix calls from a static context.

### Testing
- Attempted to run `dotnet build` but the environment lacks the `dotnet` CLI, so a full automated build could not be executed and therefore did not complete (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9735df6248328b6af18d9a6ca32f7)