### PR TITLE
Fix static logger call in Index_BreakoutEntry

### DIFF
--- a/EntryTypes/INDEX/Index_BreakoutEntry.cs
+++ b/EntryTypes/INDEX/Index_BreakoutEntry.cs
@@ -364,7 +364,7 @@ namespace GeminiV26.EntryTypes.INDEX
             int score,
             TradeDirection dir)
         {
-            GlobalLogger.Log(this, 
+            GlobalLogger.Log(typeof(Index_BreakoutEntry), 
                 $"[IDX_BREAKOUT][REJECT] {reason} | score={score} | dir={dir}");
 
             return new EntryEvaluation


### PR DESCRIPTION
### Motivation
- Resolve a compile-time error caused by using `this` inside a static method, which is invalid in C# and prevented successful compilation.

### Description
- In `EntryTypes/INDEX/Index_BreakoutEntry.cs` replace `GlobalLogger.Log(this, ...)` with `GlobalLogger.Log(typeof(Index_BreakoutEntry), ...)` inside the static `Reject(...)` helper so the logger call uses a valid static-type reference.

### Testing
- No automated build or test was executed in this workspace because the repository in this environment does not contain a `.sln`/`.csproj` to run `dotnet build`; change is limited to the logger argument and does not modify runtime logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9746545408328a3a9cca9722ac63f)