### PR TITLE
Standardize confidence flow: rename PendingEntryMeta.Confidence→EntryScore, stop executor logic re-eval, introduce adjustedRiskConfidence, update risk sizers, add audit

### DIFF
--- a/AUDIT_CONFIDENCE_ARCH_2026-03-29.md
+++ b/AUDIT_CONFIDENCE_ARCH_2026-03-29.md
@@ -1,0 +1,141 @@
+# Gemini V26 Confidence Architecture Audit (Code-Level)
+Date: 2026-03-29 (UTC)
+Scope: runtime confidence flow, authority, recompute/override audit
+
+## A. Confidence Inventory
+
+### A1) Canonical confidence pipeline types
+
+| Value | File | Owner | Kind | Proven role |
+|---|---|---|---|---|
+| `EntryScore` | `Core/PositionContext.cs` | `PositionContext` | input | Entry/setup quality input (0-100) to canonical formula. |
+| `LogicConfidence` | `Core/PositionContext.cs` | `PositionContext` | input | Instrument logic confidence input (0-100) to canonical formula. |
+| `FinalConfidence` | `Core/PositionContext.cs` | `PositionContext` | final | Canonical combined confidence, computed once and private-set. |
+| `_isFinalConfidenceComputed` | `Core/PositionContext.cs` | `PositionContext` | guard | Immutability guard for `ComputeFinalConfidence()`. |
+| `ComputeFinalConfidenceValue(entryScore, logicConfidence)` | `Core/PositionContext.cs` | static | formula | Implements `0.7*EntryScore + 0.3*LogicConfidence` with clamp+round. |
+| `ComputeFinalConfidence()` | `Core/PositionContext.cs` | method | compute | Computes once; subsequent calls no-op. |
+| `Confidence` (obsolete) | `Core/PositionContext.cs` | alias | legacy alias | Read-only alias to `FinalConfidence`. |
+
+### A2) Entry-layer / candidate-layer confidence-like values
+
+| Value | File | Owner | Kind | Proven role |
+|---|---|---|---|---|
+| `Score` | `Core/Entry/EntryEvaluation.cs` | `EntryEvaluation` | intermediate candidate | Candidate quality score used for router selection and gating, not authoritative runtime trade confidence. |
+| `LogicConfidence` | `Core/Entry/EntryEvaluation.cs` | `EntryEvaluation` | intermediate | Instrument bias confidence copied into candidate object. |
+| `RawLogicConfidence` | `Core/Entry/EntryEvaluation.cs` | `EntryEvaluation` | diagnostic/intermediate | Trace of source logic confidence before downstream normalization/fallback. |
+| `BaseScore`, `AfterHtfScoreAdjustment`, `AfterPenaltyScore`, `FinalScoreSnapshot`, `ScoreThresholdSnapshot`, `PreQualityScore`, `PostQualityScore`, `PostCapScore` | `Core/Entry/EntryEvaluation.cs` | `EntryEvaluation` | diagnostic/intermediate | Score trace fields for observability; non-authoritative for post-entry lifecycle. |
+| `LogicBiasConfidence` | `Core/Entry/EntryContext.cs` | `EntryContext` | intermediate | TradeCore-level logic confidence used during routing / selection phase. |
+| `EntryScore`, `FinalConfidence`, `RiskConfidence` | `Core/Entry/EntryContext.cs` | `EntryContext` | snapshot/intermediate | Pre-exec snapshot fields; not immutable and not protected as SSOT. |
+| `LogicConfidence` (obsolete alias) | `Core/Entry/EntryContext.cs` | `EntryContext` | legacy alias | Alias to `LogicBiasConfidence`. |
+| `Htf*Confidence01`, `ActiveHtfConfidence` | `Core/Entry/EntryContext.cs` | `EntryContext` | context signal | HTF alignment confidence (0..1), not canonical trade confidence. |
+| `MinimumFallbackConfidence`, `eval.RawLogicConfidence`, `eval.LogicConfidence` | `Core/Entry/CryptoDirectionFallback.cs` | fallback helper | derived candidate | Direction fallback assigns logic confidence for candidate-level continuity. |
+
+### A3) TradeCore / metadata / analytics confidence-like values
+
+| Value | File | Owner | Kind | Proven role |
+|---|---|---|---|---|
+| `_ctx.LogicBiasConfidence` | `Core/TradeCore.cs` | `EntryContext` in TradeCore | intermediate | Filled from instrument EntryLogic outputs before entry routing. |
+| `_ctx.FinalConfidence` | `Core/TradeCore.cs` | `EntryContext` in TradeCore | derived snapshot | Computed from `selected.Score` + `_ctx.LogicBiasConfidence`; pre-exec snapshot only. |
+| `_ctx.RiskConfidence` | `Core/TradeCore.cs` | `EntryContext` in TradeCore | derived snapshot | Clone/clamp of `_ctx.FinalConfidence` used for logs/snapshots. |
+| `PendingEntryMeta.Confidence` | `Core/Trade/TradeMetaStore.cs` | pending metadata | legacy/misleading | Stores `selected.Score` under name `Confidence`. |
+| `TradeAuditLog` output fields `entryScore`, `logicConfidence`, `finalConfidence`, `riskFinal` | `Core/Logging/TradeAuditLog.cs` | logging | diagnostics | Log payload uses EntryContext snapshot fields before executor computes PositionContext. |
+| `TradeCloseSnapshot.Score` / `Confidence` | `Core/Analytics/TradeStatsTracker.cs` | analytics DTO | informational | Analytics-only close snapshot fields. |
+| `TradeMemoryRecord.Confidence` | `core/memory/TradeMemoryRecord.cs` | memory DTO | informational | Historical memory feature; not runtime authority. |
+
+### A4) Risk/management confidence-like values
+
+| Value | File | Owner | Kind | Proven role |
+|---|---|---|---|---|
+| `finalConfidence` parameters in `IInstrumentRiskSizer` | `Risk/IInstrumentRiskSizer.cs` | risk interface | consumer input | Risk sizing interface contract says FinalConfidence-only input. |
+| `score` params in risk sizers (e.g., EUR) | `Instruments/EURUSD/EurUsdInstrumentRiskSizer.cs` | instrument risk sizer impl | misleading name | Parameter name is `score` but receives post-penalty confidence from executors. |
+| `statePenalty` in executors | `Instruments/*/*InstrumentExecutor.cs` | executors | derived risk-shaping | Soft market-state adjustment added to FinalConfidence before risk/trailing calls. |
+| `riskFinal` (log token) | executor logs + `TradeAuditLog` | logs | derived/log alias | Label for penalty-adjusted or snapshot risk input; not canonical FinalConfidence. |
+| `RiskProfile.Score` | `Risk/RiskProfile.cs` | legacy model | legacy | Legacy risk model class still names main input `Score`. |
+| `ConfidenceTradeModel` method arg `confidence` | `Core/ConfidenceTradeModel.cs` | utility | consumer | Generic confidence-based TP/trailing/BE mapping utility. |
+
+## B. Confidence Authority Map
+
+Raw inputs (entry stage)
+1. Entry-type candidate score: `EntryEvaluation.Score`.  
+2. Instrument logic output: `IEntryLogic.LastLogicConfidence` (or instrument-specific evaluate out-param).  
+
+Intermediate (selection stage)
+3. TradeCore writes `_ctx.LogicBiasConfidence` from instrument logic.  
+4. TradeCore selects candidate and sets `_ctx.EntryScore = selected.Score`.  
+5. TradeCore computes `_ctx.FinalConfidence` and `_ctx.RiskConfidence` on `EntryContext` (snapshot only).
+
+Authoritative (execution stage)
+6. Executors create **new `PositionContext`** with `EntryScore` + (possibly re-evaluated) `LogicConfidence` and call `ctx.ComputeFinalConfidence()`.  
+7. `PositionContext.FinalConfidence` becomes authoritative for that position object (private setter + compute guard).
+
+Consumers
+8. Risk sizing / SL-TP / trailing consume either:  
+   - `ctx.FinalConfidence` (BTC/ETH style), or  
+   - `ClampRiskConfidence(ctx.FinalConfidence + statePenalty)` (most executors).  
+9. Exit managers consume `PositionContext` values; many branches read `ctx.FinalConfidence` thresholds.
+
+## C. Proven Runtime Flow
+
+1. `TradeCore` evaluates instrument entry logic and derives `logicConfidence` for `_ctx.LogicBiasConfidence`.  
+2. Entry router evaluates entry types and candidates produce `EntryEvaluation.Score`.  
+3. After routing, TradeCore sets `_ctx.EntryScore`, computes `_ctx.FinalConfidence = ComputeFinalConfidenceValue(_ctx.EntryScore, _ctx.LogicBiasConfidence)`, and sets `_ctx.RiskConfidence`.  
+4. Executor receives `EntryEvaluation entry` + `EntryContext entryContext`.  
+5. Executor usually **re-runs entry logic** (`_entryLogic.Evaluate(...)`) and obtains (possibly new) `logicConfidence`.  
+6. Executor creates `PositionContext` with `EntryScore=entry.Score`, `LogicConfidence=<executor logic>`, calls `ctx.ComputeFinalConfidence()`.  
+7. Executor applies risk with either `ctx.FinalConfidence` or penalty-shaped `ClampRiskConfidence(ctx.FinalConfidence + statePenalty)`.  
+8. After order fill, executor often creates a second `PositionContext` again and calls `ctx.ComputeFinalConfidence()` again on that second instance before storing in `_positionContexts`.
+
+## D. Violations / Drift
+
+1. **FinalConfidence authority split (EntryContext vs PositionContext):** TradeCore computes `_ctx.FinalConfidence` on `EntryContext`, then executors recompute canonical value again on `PositionContext` (different object, potentially different `LogicConfidence`).
+2. **Executor-side logic re-evaluation:** Most executors call `_entryLogic.Evaluate()` during execution, so LogicConfidence source can diverge from TradeCore-time value.
+3. **Risk shaping in confidence space:** most executors compute risk/trailing using `FinalConfidence + statePenalty`; this is separate shaping but currently unnamed as separate risk variable.
+4. **Misleading naming:**
+   - `PendingEntryMeta.Confidence` stores `selected.Score`.
+   - `RiskProfile.Score` legacy model and risk sizer parameter names still use `score` while semantically used as confidence.
+   - `riskFinal` logs can refer to different concepts depending on stage.
+5. **Rehydrate edge inconsistency:** `XauExitManager.RehydrateFromLivePositions` creates `PositionContext` without setting `EntryScore`/`LogicConfidence` and calls `ComputeFinalConfidence()` (result defaults to 0).
+
+## E. Executor Findings
+
+### Per-executor recompute/re-eval matrix
+
+- Re-runs entry logic + computes FinalConfidence twice (pre-order + final stored context):
+  - AUDNZD, AUDUSD, BTCUSD, ETHUSD, EURJPY, EURUSD, GBPJPY, GBPUSD, GER40, NAS100, NZDUSD, US30, USDCAD, USDCHF, USDJPY.
+- XAU executor computes FinalConfidence once on PositionContext, but uses `entry.LogicConfidence` fallback to `entry.Score` (if logic missing) and applies state penalty on top for risk/trailing.
+
+Classification:
+- Re-running entry logic in executors: **divergence risk**.
+- Recreating PositionContext and recomputing in same method: **duplication** (not a direct immutability breach because object instance changes).
+- Using `FinalConfidence + statePenalty` for risk/trailing: **acceptable only if explicitly treated as separate derived risk input**; currently naming is partially ambiguous.
+
+## F. Naming / Legacy Issues
+
+- `PositionContext.Confidence` (obsolete alias): **acceptable but should be removed later**.
+- `EntryContext.LogicConfidence` alias to `LogicBiasConfidence`: **confusing**.
+- `PendingEntryMeta.Confidence = selected.Score`: **dangerous (semantic mismatch)**.
+- `RiskProfile.Score`: **legacy / confusing**.
+- `EurUsdInstrumentRiskSizer` etc parameter `score` for confidence input: **confusing**.
+- `TradeAuditLog` `riskFinal` label and EntryContext snapshot `finalConfidence`: **confusing unless explicitly documented as pre-exec snapshot**.
+
+## G. Final Verdict
+
+1. **All confidence values and roles:** documented above; canonical runtime value is `PositionContext.FinalConfidence` after `ComputeFinalConfidence()`.
+2. **Authoritative flow today:** TradeCore precomputes snapshot confidence in `EntryContext`, then executors recompute canonical confidence in `PositionContext` (often with fresh logic eval), then risk/management consume canonical or penalty-shaped variant.
+3. **Formula compliance:** `PositionContext.ComputeFinalConfidenceValue` exactly implements `0.7*EntryScore + 0.3*LogicConfidence` with clamp and round.
+4. **Immutability after compute:** Within a given `PositionContext` instance, yes (`private set` + `_isFinalConfidenceComputed`). At architecture level, there is duplication because new contexts are created and recomputed.
+5. **Executor override/bypass:** No direct `FinalConfidence = ...` assignment in executors; however most executors recalculate inputs (`LogicConfidence`) by rerunning entry logic and then compute a fresh final value.
+6. **Single SSOT vs competing sources:** Multiple confidence-bearing sources coexist (`EntryContext` snapshot, `PositionContext` canonical, metadata/analytics aliases). Canonical trade lifecycle source is `PositionContext`, but competing pre-exec/snapshot sources still exist.
+7. **Fix first (priority):**
+   1) Stop executor re-evaluation of entry logic; consume routed `entryContext.LogicBiasConfidence` (or a frozen value from TradeCore).
+   2) Introduce explicit variable naming for penalty-shaped risk input (e.g., `AdjustedRiskConfidence`) and never label it `FinalConfidence`/`riskFinal` without context.
+   3) Rename/remap misleading legacy fields (`PendingEntryMeta.Confidence`, risk sizer `score` params, `RiskProfile.Score`).
+   4) Fix XAU rehydrate path to set neutral EntryScore/LogicConfidence before compute (as done in `RehydrateService`).
+
+## H. Minimal Fix Plan
+
+1. In executors, replace `_entryLogic.Evaluate()` usage with frozen routed logic confidence (`entryContext.LogicBiasConfidence`) unless explicitly unavailable; keep fallback only when null/missing.
+2. In executors, create local `adjustedRiskConfidence = ClampRiskConfidence(ctx.FinalConfidence + statePenalty)` and use this name for risk/trailing/TP routing.
+3. In `PendingEntryMeta`, rename `Confidence` to `EntryScore` (or add new field + deprecate old).
+4. In XAU rehydrate path, set `EntryScore = 50`, `LogicConfidence = 50` before `ComputeFinalConfidence()`.
+5. In risk sizers, rename method parameter identifiers from `score` to `finalConfidence` (no behavior change).

--- a/Core/Trade/TradeMetaStore.cs
+++ b/Core/Trade/TradeMetaStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GeminiV26.Core
@@ -45,6 +46,15 @@ namespace GeminiV26.Core
     {
         public string EntryType;
         public string EntryReason;
-        public int? Confidence;
+
+        // Canonical pending value: Entry candidate score snapshot at routing time.
+        public int? EntryScore;
+
+        [Obsolete("LEGACY alias - use EntryScore")]
+        public int? Confidence
+        {
+            get => EntryScore;
+            set => EntryScore = value;
+        }
     }
 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1325,7 +1325,7 @@ namespace GeminiV26.Core
                     {
                         EntryType = selected.Type.ToString(),
                         EntryReason = selected.Reason,
-                        Confidence = Convert.ToInt32(selected.Score)
+                        EntryScore = Convert.ToInt32(selected.Score)
                     }
                 );
 
@@ -3216,7 +3216,7 @@ namespace GeminiV26.Core
                     ExitPrice = pos.EntryPrice + pos.Pips * sym.PipSize * (pos.TradeType == TradeType.Buy ? 1 : -1),
                     Profit = pos.NetProfit,
                     Score = null,
-                    Confidence = meta?.Confidence,
+                    Confidence = meta?.EntryScore,
                     SetupType = ResolveSetupType(meta?.EntryType),
                     MarketRegime = ResolveMarketRegime(entryCtx),
                     MfeR = ctx?.MfeR ?? 0.0,
@@ -3240,7 +3240,7 @@ namespace GeminiV26.Core
                 TransitionQuality = entryCtx?.TransitionValid == true
                     ? entryCtx.Transition?.QualityScore ?? 0.0
                     : 0.0,
-                Confidence = ctx?.FinalConfidence ?? meta?.Confidence ?? 0.0,
+                Confidence = ctx?.FinalConfidence ?? meta?.EntryScore ?? 0.0,
                 EntryTime = ctx?.EntryTime ?? pos.EntryTime,
                 ExitTime = _bot.Server.Time
             };

--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -120,13 +120,24 @@ namespace GeminiV26.Instruments.AUDNZD
             // =========================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (AUDNZD)
             // =========================================================
-            int logicConfidence = entryContext.LogicBiasConfidence;
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
             if (logicConfidence <= 0)
             {
-                _entryLogic.Evaluate();
-                logicConfidence = _entryLogic.LastLogicConfidence;
-                GlobalLogger.Log(_bot, $"[AUDNZD EXEC] logicConfidence fallback={logicConfidence}");
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
             }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
 
             var ctx = new PositionContext
             {
@@ -140,6 +151,8 @@ namespace GeminiV26.Instruments.AUDNZD
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -147,9 +160,9 @@ namespace GeminiV26.Instruments.AUDNZD
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
             {
@@ -157,7 +170,7 @@ namespace GeminiV26.Instruments.AUDNZD
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -166,13 +179,13 @@ namespace GeminiV26.Instruments.AUDNZD
             }
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             if (volumeUnits <= 0)
             {
@@ -246,10 +259,10 @@ namespace GeminiV26.Instruments.AUDNZD
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján (nem változtatunk működésen)
+                // ⚠️ Trailing marad adjustedRiskConfidence alapján (nem változtatunk működésen)
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/AUDNZD/AudNzdInstrumentRiskSizer.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentRiskSizer.cs
@@ -42,9 +42,9 @@ namespace GeminiV26.Instruments.AUDNZD
         // =========================
         // SL (ATR multiplier)
         // =========================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // Jobb score → feszesebb SL
             // 3.2 → 2.7
@@ -55,7 +55,7 @@ namespace GeminiV26.Instruments.AUDNZD
         // TP struktúra (R + arány)
         // =========================
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
@@ -68,7 +68,7 @@ namespace GeminiV26.Instruments.AUDNZD
             // TP1 RATIO – DINAMIKUS
             // Jó score → több runner
             // =====================================================
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // TP1 mindig biztos, de jobb score → több runner
             tp1Ratio = 0.70 - n * 0.25; // 0.70 → 0.45
@@ -95,10 +95,10 @@ namespace GeminiV26.Instruments.AUDNZD
                 riskPercent);
         }
 
-        private static double NormalizeScore(int score)
+        private static double NormalizeScore(int finalConfidence)
         {
             // FX új valós tartomány: ~55–90
-            return Math.Clamp((score - 55) / 35.0, 0.0, 1.0);
+            return Math.Clamp((finalConfidence - 55) / 35.0, 0.0, 1.0);
         }
     }
 }

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -120,8 +120,24 @@ namespace GeminiV26.Instruments.AUDUSD
             // =========================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (EURUSD)
             // =========================================================
-            _entryLogic.Evaluate();
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
@@ -134,6 +150,8 @@ namespace GeminiV26.Instruments.AUDUSD
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -141,9 +159,9 @@ namespace GeminiV26.Instruments.AUDUSD
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
             {
@@ -151,7 +169,7 @@ namespace GeminiV26.Instruments.AUDUSD
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -160,13 +178,13 @@ namespace GeminiV26.Instruments.AUDUSD
             }
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             if (volumeUnits <= 0)
             {
@@ -243,10 +261,10 @@ namespace GeminiV26.Instruments.AUDUSD
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
+                // ⚠️ Trailing marad adjustedRiskConfidence alapján
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/AUDUSD/AudUsdInstrumentRiskSizer.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentRiskSizer.cs
@@ -42,9 +42,9 @@ namespace GeminiV26.Instruments.AUDUSD
         // =========================
         // SL (ATR multiplier)
         // =========================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // Jobb score → feszesebb SL
             // 3.2 → 2.7
@@ -55,7 +55,7 @@ namespace GeminiV26.Instruments.AUDUSD
         // TP struktúra (R + arány)
         // =========================
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
@@ -68,7 +68,7 @@ namespace GeminiV26.Instruments.AUDUSD
             // TP1 RATIO – DINAMIKUS
             // Jó score → több runner
             // =====================================================
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // TP1 mindig biztos, de jobb score → több runner
             tp1Ratio = 0.70 - n * 0.25; // 0.70 → 0.45
@@ -95,10 +95,10 @@ namespace GeminiV26.Instruments.AUDUSD
                 riskPercent);
         }
 
-        private static double NormalizeScore(int score)
+        private static double NormalizeScore(int finalConfidence)
         {
             // FX új valós tartomány: ~55–90
-            return Math.Clamp((score - 55) / 35.0, 0.0, 1.0);
+            return Math.Clamp((finalConfidence - 55) / 35.0, 0.0, 1.0);
         }
     }
 }

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -86,7 +86,24 @@ namespace GeminiV26.Instruments.BTCUSD
             // =========================================================
             // 🔑 ENTRY LOGIC – PRE-EXEC CONFIDENCE
             // =========================================================
-            _entryLogic.Evaluate(out _, out int logicConfidence);
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
             int statePenalty = 0;
 
             var ctx = new PositionContext
@@ -101,6 +118,8 @@ namespace GeminiV26.Instruments.BTCUSD
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -108,13 +127,13 @@ namespace GeminiV26.Instruments.BTCUSD
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
             // =========================================================
             // SL DISTANCE (ATR)
             // =========================================================
             double slPriceDist =
-                CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence), entry.Type);
+                CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
                 return;
@@ -126,12 +145,12 @@ namespace GeminiV26.Instruments.BTCUSD
             // =========================================================
             // RISK-BASED VOLUME (CRYPTO POSITION SIZER)
             // =========================================================
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
             long volumeUnits = CryptoPositionSizer.Calculate(
                 _bot,
                 riskPercent,
                 slPriceDist,
-                _riskSizer.GetLotCap(PositionContext.ClampRiskConfidence(ctx.FinalConfidence)));
+                _riskSizer.GetLotCap(adjustedRiskConfidence));
 
             if (volumeUnits < _bot.Symbol.VolumeInUnitsMin)
             {
@@ -146,7 +165,7 @@ namespace GeminiV26.Instruments.BTCUSD
             // TP POLICY
             // =========================================================
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
@@ -169,7 +188,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 return;
 
             GlobalLogger.Log(_bot, 
-                $"[BTC RISK] score={entry.Score} logicConf={logicConfidence} RC={PositionContext.ClampRiskConfidence(ctx.FinalConfidence)} FC={ctx.FinalConfidence} " +
+                $"[BTC RISK] score={entry.Score} logicConf={logicConfidence} RC={adjustedRiskConfidence} FC={ctx.FinalConfidence} " +
                 $"risk%={riskPercent:F2} slDist={slPriceDist:F2} slPips={slPips:F1} " +
                 $"volUnits={volumeUnits}"
             );

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -86,7 +86,24 @@ namespace GeminiV26.Instruments.ETHUSD
             // =========================================================
             // 🔑 ENTRY LOGIC – PRE-EXEC CONFIDENCE
             // =========================================================
-            _entryLogic.Evaluate(out _, out int logicConfidence);
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
             int statePenalty = 0;
 
             var ctx = new PositionContext
@@ -101,6 +118,8 @@ namespace GeminiV26.Instruments.ETHUSD
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -108,13 +127,13 @@ namespace GeminiV26.Instruments.ETHUSD
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
             // =========================================================
             // SL DISTANCE (ATR)
             // =========================================================
             double slPriceDist =
-                CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence), entry.Type);
+                CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
                 return;
@@ -126,12 +145,12 @@ namespace GeminiV26.Instruments.ETHUSD
             // =========================================================
             // RISK-BASED VOLUME (CRYPTO POSITION SIZER)
             // =========================================================
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
             long volumeUnits = CryptoPositionSizer.Calculate(
                 _bot,
                 riskPercent,
                 slPriceDist,
-                _riskSizer.GetLotCap(PositionContext.ClampRiskConfidence(ctx.FinalConfidence)));
+                _riskSizer.GetLotCap(adjustedRiskConfidence));
 
             if (volumeUnits < _bot.Symbol.VolumeInUnitsMin)
             {
@@ -146,7 +165,7 @@ namespace GeminiV26.Instruments.ETHUSD
             // TP POLICY
             // =========================================================
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
@@ -169,7 +188,7 @@ namespace GeminiV26.Instruments.ETHUSD
                 return;
 
             GlobalLogger.Log(_bot, 
-                $"[ETH RISK] score={entry.Score} logicConf={logicConfidence} RC={PositionContext.ClampRiskConfidence(ctx.FinalConfidence)} FC={ctx.FinalConfidence} " +
+                $"[ETH RISK] score={entry.Score} logicConf={logicConfidence} RC={adjustedRiskConfidence} FC={ctx.FinalConfidence} " +
                 $"risk%={riskPercent:F2} slDist={slPriceDist:F2} slPips={slPips:F1} " +
                 $"volUnits={volumeUnits}"
             );

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -120,8 +120,24 @@ namespace GeminiV26.Instruments.EURJPY
             // =========================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (AUDNZD)
             // =========================================================
-            _entryLogic.Evaluate();
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
@@ -134,6 +150,8 @@ namespace GeminiV26.Instruments.EURJPY
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -141,9 +159,9 @@ namespace GeminiV26.Instruments.EURJPY
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
             {
@@ -151,7 +169,7 @@ namespace GeminiV26.Instruments.EURJPY
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -160,13 +178,13 @@ namespace GeminiV26.Instruments.EURJPY
             }
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             if (volumeUnits <= 0)
             {
@@ -243,10 +261,10 @@ namespace GeminiV26.Instruments.EURJPY
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
+                // ⚠️ Trailing marad adjustedRiskConfidence alapján
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/EURJPY/EurJpyInstrumentRiskSizer.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentRiskSizer.cs
@@ -42,9 +42,9 @@ namespace GeminiV26.Instruments.EURJPY
         // =========================
         // SL (ATR multiplier)
         // =========================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // JPY: szélesebb alap, kisebb szűkülés
             // 3.3 → 2.9
@@ -55,13 +55,13 @@ namespace GeminiV26.Instruments.EURJPY
         // TP struktúra (R + arány)
         // =========================
         public void GetTakeProfit(
-    int score,
+    int finalConfidence,
     out double tp1R,
     out double tp1Ratio,
     out double tp2R,
     out double tp2Ratio)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // gyenge / bizonytalan
             if (n < 0.45)
@@ -102,10 +102,10 @@ namespace GeminiV26.Instruments.EURJPY
                 riskPercent);
         }
 
-        private static double NormalizeScore(int score)
+        private static double NormalizeScore(int finalConfidence)
         {
             // JPY FX: score-tartomány ugyanaz, de óvatosabban használjuk
-            return Math.Clamp((score - 55) / 35.0, 0.0, 1.0);
+            return Math.Clamp((finalConfidence - 55) / 35.0, 0.0, 1.0);
         }
     }
 }

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -99,8 +99,24 @@ namespace GeminiV26.Instruments.EURUSD
             // =========================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (EURUSD)
             // =========================================================
-            _entryLogic.Evaluate();
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
@@ -113,6 +129,8 @@ namespace GeminiV26.Instruments.EURUSD
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -120,13 +138,13 @@ namespace GeminiV26.Instruments.EURUSD
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
             GlobalLogger.Log(_bot, 
-                $"[EUR EXEC] CONF entryScore={entry.Score} logic={logicConfidence} final={ctx.FinalConfidence} statePenalty={statePenalty} riskConf={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}"
+                $"[EUR EXEC] CONF entryScore={entry.Score} logic={logicConfidence} final={ctx.FinalConfidence} statePenalty={statePenalty} riskConf={adjustedRiskConfidence}"
             );
 
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
             {
@@ -134,7 +152,7 @@ namespace GeminiV26.Instruments.EURUSD
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -143,13 +161,13 @@ namespace GeminiV26.Instruments.EURUSD
             }
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             GlobalLogger.Log(_bot, 
                 $"[EUR EXEC] RISK risk%={riskPercent:F3} slDist={slPriceDist:F5} volume={volumeUnits}"
@@ -234,8 +252,8 @@ namespace GeminiV26.Instruments.EURUSD
 
                 // maradhat így, hogy ne változzon a működés
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/EURUSD/EurUsdInstrumentRiskSizer.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentRiskSizer.cs
@@ -43,9 +43,9 @@ namespace GeminiV26.Instruments.EURUSD
         // =========================
         // SL (ATR multiplier)
         // =========================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // változatlan struktúra
             return 1.9 - n * 0.4;
@@ -55,13 +55,13 @@ namespace GeminiV26.Instruments.EURUSD
         // TP struktúra
         // =========================
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
             out double tp2Ratio)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // FX: gyors biztosítás
             tp1R = 0.50;
@@ -94,10 +94,10 @@ namespace GeminiV26.Instruments.EURUSD
         // =========================
         // SCORE NORMALIZATION – változatlan
         // =========================
-        private static double NormalizeScore(int score)
+        private static double NormalizeScore(int finalConfidence)
         {
             // FX reális tartomány: 55–90
-            return Math.Clamp((score - 55) / 35.0, 0.0, 1.0);
+            return Math.Clamp((finalConfidence - 55) / 35.0, 0.0, 1.0);
         }
     }
 }

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -120,8 +120,24 @@ namespace GeminiV26.Instruments.GBPJPY
             // =========================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (AUDNZD)
             // =========================================================
-            _entryLogic.Evaluate();
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
@@ -134,6 +150,8 @@ namespace GeminiV26.Instruments.GBPJPY
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -141,9 +159,9 @@ namespace GeminiV26.Instruments.GBPJPY
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
             {
@@ -151,7 +169,7 @@ namespace GeminiV26.Instruments.GBPJPY
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -160,13 +178,13 @@ namespace GeminiV26.Instruments.GBPJPY
             }
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             if (volumeUnits <= 0)
             {
@@ -243,10 +261,10 @@ namespace GeminiV26.Instruments.GBPJPY
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
+                // ⚠️ Trailing marad adjustedRiskConfidence alapján
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/GBPJPY/GbpJpyInstrumentRiskSizer.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentRiskSizer.cs
@@ -42,9 +42,9 @@ namespace GeminiV26.Instruments.GBPJPY
         // =========================
         // SL (ATR multiplier)
         // =========================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // GBPJPY: nagyon wickes
             // 3.5 → 3.0
@@ -55,13 +55,13 @@ namespace GeminiV26.Instruments.GBPJPY
         // TP struktúra (R + arány)
         // =========================
         public void GetTakeProfit(
-    int score,
+    int finalConfidence,
     out double tp1R,
     out double tp1Ratio,
     out double tp2R,
     out double tp2Ratio)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // gyenge / zajos
             if (n < 0.50)
@@ -102,10 +102,10 @@ namespace GeminiV26.Instruments.GBPJPY
                 riskPercent);
         }
 
-        private static double NormalizeScore(int score)
+        private static double NormalizeScore(int finalConfidence)
         {
             // GBPJPY: új FX score-tartomány, de óvatos használat
-            return Math.Clamp((score - 55) / 35.0, 0.0, 1.0);
+            return Math.Clamp((finalConfidence - 55) / 35.0, 0.0, 1.0);
         }
     }
 }

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -108,8 +108,24 @@ namespace GeminiV26.Instruments.GBPUSD
             // =====================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (GBPUSD)
             // =====================================================
-            _entryLogic.Evaluate();
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
 
             var ctx = new PositionContext
             {
@@ -123,6 +139,8 @@ namespace GeminiV26.Instruments.GBPUSD
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -130,7 +148,7 @@ namespace GeminiV26.Instruments.GBPUSD
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
             // =====================================================
             // HARD ATR GATE (GBPUSD) – NO MICRO VOL
@@ -157,11 +175,11 @@ namespace GeminiV26.Instruments.GBPUSD
                     ? TradeType.Buy
                     : TradeType.Sell;
 
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
             if (riskPercent <= 0)
                 return;
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
             if (slPriceDist <= 0)
                 return;
 
@@ -176,14 +194,14 @@ namespace GeminiV26.Instruments.GBPUSD
             }
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
             // sizing MUST use the same slPriceDist we will actually place
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
             if (volumeUnits <= 0)
                 return;
 
@@ -251,8 +269,8 @@ namespace GeminiV26.Instruments.GBPUSD
                 BeMode = BeMode.AfterTp1,
 
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight
             };
 

--- a/Instruments/GBPUSD/GbpUsdInstrumentRiskSizer.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentRiskSizer.cs
@@ -29,11 +29,11 @@ namespace GeminiV26.Instruments.GBPUSD
             return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
-        public double GetStopLossAtrMultiplier(int score, EntryType _ /* FX ignores entry type */)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType _ /* FX ignores entry type */)
         {
             double baseMult = SlBase;
 
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             if (n >= 0.75) baseMult -= 0.05;
             if (n >= 0.90) baseMult -= 0.05;
@@ -45,13 +45,13 @@ namespace GeminiV26.Instruments.GBPUSD
         // TP struktúra (R + arány)
         // =========================
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
             out double tp2Ratio)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // FX: gyors biztosítás
             tp1R = 0.40;
@@ -78,10 +78,10 @@ namespace GeminiV26.Instruments.GBPUSD
                 riskPercent);
         }
 
-        private static double NormalizeScore(int score)
+        private static double NormalizeScore(int finalConfidence)
         {
             // FX új score-tartomány: ~55–90
-            return Math.Clamp((score - 55) / 35.0, 0.0, 1.0);
+            return Math.Clamp((finalConfidence - 55) / 35.0, 0.0, 1.0);
         }
     }
 }

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -67,7 +67,25 @@ namespace GeminiV26.Instruments.GER40
             // =========================
             _entryLogic.Evaluate();
             _entryLogic.ApplyToEntryEvaluation(entry);
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
 
             // =========================
             // MARKET STATE – SOFT
@@ -99,6 +117,8 @@ namespace GeminiV26.Instruments.GER40
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -106,7 +126,7 @@ namespace GeminiV26.Instruments.GER40
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
             var tradeType =
                 entryContext.FinalDirection == TradeDirection.Long
@@ -116,28 +136,28 @@ namespace GeminiV26.Instruments.GER40
             // =========================
             // RISK POLICY
             // =========================
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
                 return;
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
                 return;
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            double slAtrMult = _riskSizer.GetStopLossAtrMultiplier(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slAtrMult = _riskSizer.GetStopLossAtrMultiplier(adjustedRiskConfidence, entry.Type);
 
-            double lotCap = _riskSizer.GetLotCap(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double lotCap = _riskSizer.GetLotCap(adjustedRiskConfidence);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
             if (volumeUnits <= 0)
                 return;
 
@@ -227,8 +247,8 @@ namespace GeminiV26.Instruments.GER40
                 Tp1CloseFraction = tp1Ratio,
 
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = volumeUnits,

--- a/Instruments/GER40/Ger40InstrumentRiskSizer.cs
+++ b/Instruments/GER40/Ger40InstrumentRiskSizer.cs
@@ -37,10 +37,10 @@ namespace GeminiV26.Instruments.GER40
         // STOP LOSS – ATR multiplier
         // EntryType NEM játszik szerepet
         // =====================================================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
-            if (score >= 85) return 2.3;
-            if (score >= 75) return 2.6;
+            if (finalConfidence >= 85) return 2.3;
+            if (finalConfidence >= 75) return 2.6;
             return 3.0;
         }
 
@@ -48,19 +48,19 @@ namespace GeminiV26.Instruments.GER40
         // TAKE PROFIT – R struktúra
         // =====================================================
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
             out double tp2Ratio)
         {
-            if (score >= 85)
+            if (finalConfidence >= 85)
             {
                 tp1R = 0.5;
                 tp1Ratio = 0.30; // 70% runner
                 tp2R = 3.0;
             }
-            else if (score >= 75)
+            else if (finalConfidence >= 75)
             {
                 tp1R = 0.45;
                 tp1Ratio = 0.40;

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -80,7 +80,25 @@ namespace GeminiV26.Instruments.NAS100
             // =========================
             _entryLogic.Evaluate();
             _entryLogic.ApplyToEntryEvaluation(entry);
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
 
             int statePenalty = 0;
 
@@ -109,6 +127,8 @@ namespace GeminiV26.Instruments.NAS100
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -116,7 +136,7 @@ namespace GeminiV26.Instruments.NAS100
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
             // === ORIGINAL LOGIC CONTINUES ===
             var tradeType =
@@ -127,26 +147,26 @@ namespace GeminiV26.Instruments.NAS100
             // =========================
             // RISK POLICY
             // =========================
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
                 return;
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
             if (slPriceDist <= 0)
                 return;
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            double slAtrMult = _riskSizer.GetStopLossAtrMultiplier(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
-            double lotCap = _riskSizer.GetLotCap(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double slAtrMult = _riskSizer.GetStopLossAtrMultiplier(adjustedRiskConfidence, entry.Type);
+            double lotCap = _riskSizer.GetLotCap(adjustedRiskConfidence);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             if (volumeUnits <= 0)
                 return;
@@ -236,8 +256,8 @@ namespace GeminiV26.Instruments.NAS100
                 Tp1CloseFraction = tp1Ratio,
 
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = volumeUnits,

--- a/Instruments/NAS100/NasInstrumentRiskSizer.cs
+++ b/Instruments/NAS100/NasInstrumentRiskSizer.cs
@@ -37,11 +37,11 @@ namespace GeminiV26.Instruments.NAS100
         // STOP LOSS – ATR multiplier
         // EntryType NEM játszik szerepet
         // =====================================================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
             // NAS100 continuation model – adjunk levegőt a jó setupnak
-            if (score >= 85) return 2.2;
-            if (score >= 75) return 2.4;
+            if (finalConfidence >= 85) return 2.2;
+            if (finalConfidence >= 75) return 2.4;
             return 2.6;
         }
 
@@ -49,7 +49,7 @@ namespace GeminiV26.Instruments.NAS100
         // TAKE PROFIT – R struktúra
         // =====================================================
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
@@ -58,13 +58,13 @@ namespace GeminiV26.Instruments.NAS100
             // NAS100 – continuation-first model
             // Gyors biztosítás, de runner marad
 
-            if (score >= 85)
+            if (finalConfidence >= 85)
             {
                 tp1R = 0.55;
                 tp1Ratio = 0.50;
                 tp2R = 2.2;
             }
-            else if (score >= 75)
+            else if (finalConfidence >= 75)
             {
                 tp1R = 0.50;
                 tp1Ratio = 0.55;

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -120,8 +120,24 @@ namespace GeminiV26.Instruments.NZDUSD
             // =========================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (NZDUSD)
             // =========================================================
-            _entryLogic.Evaluate();
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
@@ -134,6 +150,8 @@ namespace GeminiV26.Instruments.NZDUSD
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -141,9 +159,9 @@ namespace GeminiV26.Instruments.NZDUSD
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
             {
@@ -151,7 +169,7 @@ namespace GeminiV26.Instruments.NZDUSD
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -160,13 +178,13 @@ namespace GeminiV26.Instruments.NZDUSD
             }
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             if (volumeUnits <= 0)
             {
@@ -243,10 +261,10 @@ namespace GeminiV26.Instruments.NZDUSD
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
+                // ⚠️ Trailing marad adjustedRiskConfidence alapján
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/NZDUSD/NzdUsdInstrumentRiskSizer.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentRiskSizer.cs
@@ -42,9 +42,9 @@ namespace GeminiV26.Instruments.NZDUSD
         // =========================
         // SL (ATR multiplier)
         // =========================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // Jobb score → feszesebb SL
             // 3.2 → 2.7
@@ -55,7 +55,7 @@ namespace GeminiV26.Instruments.NZDUSD
         // TP struktúra (R + arány)
         // =========================
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
@@ -68,7 +68,7 @@ namespace GeminiV26.Instruments.NZDUSD
             // TP1 RATIO – DINAMIKUS
             // Jó score → több runner
             // =====================================================
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // TP1 mindig biztos, de jobb score → több runner
             tp1Ratio = 0.70 - n * 0.25; // 0.70 → 0.45
@@ -95,10 +95,10 @@ namespace GeminiV26.Instruments.NZDUSD
                 riskPercent);
         }
 
-        private static double NormalizeScore(int score)
+        private static double NormalizeScore(int finalConfidence)
         {
             // FX új valós tartomány: ~55–90
-            return Math.Clamp((score - 55) / 35.0, 0.0, 1.0);
+            return Math.Clamp((finalConfidence - 55) / 35.0, 0.0, 1.0);
         }
     }
 }

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -74,7 +74,25 @@ namespace GeminiV26.Instruments.US30
             // =========================
             _entryLogic.Evaluate();
             _entryLogic.ApplyToEntryEvaluation(entry);
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
 
             // =========================
             // MARKET STATE � SOFT
@@ -105,6 +123,8 @@ namespace GeminiV26.Instruments.US30
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -112,31 +132,31 @@ namespace GeminiV26.Instruments.US30
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
             var tradeType =
                 entryContext.FinalDirection == TradeDirection.Long
                     ? TradeType.Buy
                     : TradeType.Sell;
 
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
                 return;
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
                 return;
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             if (volumeUnits <= 0)
                 return;
@@ -215,8 +235,8 @@ namespace GeminiV26.Instruments.US30
                 Adx_M5 = entryContext.Adx_M5,
 
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = volumeUnits,

--- a/Instruments/US30/Us30InstrumentRiskSizer.cs
+++ b/Instruments/US30/Us30InstrumentRiskSizer.cs
@@ -41,7 +41,7 @@ namespace GeminiV26.Instruments.US30
         // =========================
         // SL (ATR multiplier)
         // =========================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
             double baseMult = SlBase;
 
@@ -68,8 +68,8 @@ namespace GeminiV26.Instruments.US30
                     break;
             }
 
-            if (score >= 85) baseMult -= 0.1;
-            if (score >= 92) baseMult -= 0.1;
+            if (finalConfidence >= 85) baseMult -= 0.1;
+            if (finalConfidence >= 92) baseMult -= 0.1;
 
             if (baseMult < 1.6) baseMult = 1.6;
 
@@ -80,7 +80,7 @@ namespace GeminiV26.Instruments.US30
         // TP struktúra (R + arány)
         // =========================
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
@@ -93,11 +93,11 @@ namespace GeminiV26.Instruments.US30
             // TP1 RATIO – DINAMIKUS
             // jobb score = több runner
             // =========================
-            if (score < 70)
+            if (finalConfidence < 70)
                 tp1Ratio = 0.65;   // védekező
-            else if (score < 80)
+            else if (finalConfidence < 80)
                 tp1Ratio = 0.55;
-            else if (score < 90)
+            else if (finalConfidence < 90)
                 tp1Ratio = 0.45;
             else
                 tp1Ratio = 0.35;   // prémium setup → futtatjuk
@@ -105,11 +105,11 @@ namespace GeminiV26.Instruments.US30
             // =========================
             // TP2 R – MONOTON GÖRBE
             // =========================
-            if (score < 70)
+            if (finalConfidence < 70)
                 tp2R = 1.0;
-            else if (score < 80)
+            else if (finalConfidence < 80)
                 tp2R = 1.4;
-            else if (score < 90)
+            else if (finalConfidence < 90)
                 tp2R = 2.0;
             else
                 tp2R = 3.0;

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -120,8 +120,24 @@ namespace GeminiV26.Instruments.USDCAD
             // =========================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (USDCAD)
             // =========================================================
-            _entryLogic.Evaluate();
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
@@ -134,6 +150,8 @@ namespace GeminiV26.Instruments.USDCAD
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -141,9 +159,9 @@ namespace GeminiV26.Instruments.USDCAD
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
             {
@@ -151,7 +169,7 @@ namespace GeminiV26.Instruments.USDCAD
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -160,13 +178,13 @@ namespace GeminiV26.Instruments.USDCAD
             }
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             if (volumeUnits <= 0)
             {
@@ -243,10 +261,10 @@ namespace GeminiV26.Instruments.USDCAD
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
+                // ⚠️ Trailing marad adjustedRiskConfidence alapján
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/USDCAD/UsdCadInstrumentRiskSizer.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentRiskSizer.cs
@@ -42,9 +42,9 @@ namespace GeminiV26.Instruments.USDCAD
         // =========================
         // SL (ATR multiplier)
         // =========================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // USDCAD – grind FX, nem spike instrument
             // 2.1 → 1.6 ATR
@@ -55,7 +55,7 @@ namespace GeminiV26.Instruments.USDCAD
         // TP struktúra (R + arány)
         // =========================
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
@@ -68,7 +68,7 @@ namespace GeminiV26.Instruments.USDCAD
             // TP1 RATIO – DINAMIKUS
             // Jó score → több runner
             // =====================================================
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // TP1 mindig biztos, de jobb score → több runner
             tp1Ratio = 0.70 - n * 0.25; // 0.70 → 0.45
@@ -95,10 +95,10 @@ namespace GeminiV26.Instruments.USDCAD
                 riskPercent);
         }
 
-        private static double NormalizeScore(int score)
+        private static double NormalizeScore(int finalConfidence)
         {
             // FX új valós tartomány: ~55–90
-            return Math.Clamp((score - 55) / 35.0, 0.0, 1.0);
+            return Math.Clamp((finalConfidence - 55) / 35.0, 0.0, 1.0);
         }
     }
 }

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -120,8 +120,24 @@ namespace GeminiV26.Instruments.USDCHF
             // =========================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (USDCHF)
             // =========================================================
-            _entryLogic.Evaluate();
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
             var ctx = new PositionContext
             {
                 Symbol = _bot.SymbolName,
@@ -134,6 +150,8 @@ namespace GeminiV26.Instruments.USDCHF
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -141,9 +159,9 @@ namespace GeminiV26.Instruments.USDCHF
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
             {
@@ -151,7 +169,7 @@ namespace GeminiV26.Instruments.USDCHF
                 return;
             }
 
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
             {
@@ -160,13 +178,13 @@ namespace GeminiV26.Instruments.USDCHF
             }
 
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             if (volumeUnits <= 0)
             {
@@ -243,10 +261,10 @@ namespace GeminiV26.Instruments.USDCHF
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
+                // ⚠️ Trailing marad adjustedRiskConfidence alapján
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/USDCHF/UsdChfInstrumentRiskSizer.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentRiskSizer.cs
@@ -42,9 +42,9 @@ namespace GeminiV26.Instruments.USDCHF
         // =========================
         // SL (ATR multiplier)
         // =========================
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // Jobb score → feszesebb SL
             // 3.2 → 2.7
@@ -55,7 +55,7 @@ namespace GeminiV26.Instruments.USDCHF
         // TP struktúra (R + arány)
         // =========================
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
@@ -68,7 +68,7 @@ namespace GeminiV26.Instruments.USDCHF
             // TP1 RATIO – DINAMIKUS
             // Jó score → több runner
             // =====================================================
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             // TP1 mindig biztos, de jobb score → több runner
             tp1Ratio = 0.70 - n * 0.25; // 0.70 → 0.45
@@ -95,10 +95,10 @@ namespace GeminiV26.Instruments.USDCHF
                 riskPercent);
         }
 
-        private static double NormalizeScore(int score)
+        private static double NormalizeScore(int finalConfidence)
         {
             // FX új valós tartomány: ~55–90
-            return Math.Clamp((score - 55) / 35.0, 0.0, 1.0);
+            return Math.Clamp((finalConfidence - 55) / 35.0, 0.0, 1.0);
         }
     }
 }

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -102,8 +102,24 @@ namespace GeminiV26.Instruments.USDJPY
             // =====================================================
             // ENTRY LOGIC – PRE-EXEC CONFIDENCE (USDJPY)
             // =====================================================
-            _entryLogic.Evaluate();
-            int logicConfidence = _entryLogic.LastLogicConfidence;
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
 
             // =========================================================
             // FINAL CONFIDENCE (entry + logic + market state)
@@ -120,6 +136,8 @@ namespace GeminiV26.Instruments.USDJPY
                 LogicConfidence = logicConfidence
             };
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
 
@@ -127,7 +145,7 @@ namespace GeminiV26.Instruments.USDJPY
 
             if (statePenalty != 0)
 
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
             var tradeType =
                 entryContext.FinalDirection == TradeDirection.Long
@@ -135,26 +153,26 @@ namespace GeminiV26.Instruments.USDJPY
                     : TradeType.Sell;
 
             // === STOP LOSS DISTANCE ===
-            double slPriceDist = CalculateStopLossPriceDistance(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty), entry.Type);
+            double slPriceDist = CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
                 return;
 
             // === TP CONFIG ===
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
                 out double tp2Ratio);
 
             // === RISK ===
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
 
             if (riskPercent <= 0)
                 return;
 
-            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            long volumeUnits = CalculateVolumeInUnits(riskPercent, slPriceDist, adjustedRiskConfidence);
 
             if (volumeUnits <= 0)
                 return;
@@ -233,10 +251,10 @@ namespace GeminiV26.Instruments.USDJPY
                 Tp1CloseFraction = tp1Ratio,
                 BeMode = BeMode.AfterTp1,
 
-                // ⚠️ Trailing marad PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján
+                // ⚠️ Trailing marad adjustedRiskConfidence alapján
                 TrailingMode =
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                    PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                    adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                    adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                                 TrailingMode.Tight,
 
                 EntryVolumeInUnits = result.Position.VolumeInUnits,

--- a/Instruments/USDJPY/UsdJpyInstrumentRiskSizer.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentRiskSizer.cs
@@ -30,9 +30,9 @@ namespace GeminiV26.Instruments.USDJPY
             return RiskProfileEngine.GetRiskPercent(finalConfidence);
         }
 
-        public double GetStopLossAtrMultiplier(int score, EntryType entryType)
+        public double GetStopLossAtrMultiplier(int finalConfidence, EntryType entryType)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             double baseMult = SlBase; // FX-only: egységes baseline
 
@@ -43,13 +43,13 @@ namespace GeminiV26.Instruments.USDJPY
         }
 
         public void GetTakeProfit(
-            int score,
+            int finalConfidence,
             out double tp1R,
             out double tp1Ratio,
             out double tp2R,
             out double tp2Ratio)
         {
-            double n = NormalizeScore(score);
+            double n = NormalizeScore(finalConfidence);
 
             if (n < 0.40)
             {
@@ -88,10 +88,10 @@ namespace GeminiV26.Instruments.USDJPY
                 riskPercent);
         }
 
-        private static double NormalizeScore(int score)
+        private static double NormalizeScore(int finalConfidence)
         {
             // USDJPY – új FX score-tartomány
-            return Math.Clamp((score - 55) / 35.0, 0.0, 1.0);
+            return Math.Clamp((finalConfidence - 55) / 35.0, 0.0, 1.0);
         }
 
     }

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -655,6 +655,10 @@ namespace GeminiV26.Instruments.XAUUSD
                     RemainingVolumeInUnits = pos.VolumeInUnits,
                     InitialVolumeInUnits = pos.VolumeInUnits,
 
+                    // Neutral confidence placeholders (same rehydrate convention as RehydrateService).
+                    EntryScore = 50,
+                    LogicConfidence = 50,
+
                     // SSOT snapshot
                     RiskPriceDistance = rDist,
                     PipSize = bot.Symbol.PipSize,

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -127,6 +127,25 @@ namespace GeminiV26.Instruments.XAUUSD
                     ? TradeType.Buy
                     : TradeType.Sell;
 
+            int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
+            string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
+
+            if (logicConfidence <= 0 && entry.LogicConfidence > 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.LogicConfidence);
+                logicConfidenceSource = "EntryEvaluation.LogicConfidence";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            if (logicConfidence <= 0)
+            {
+                logicConfidence = PositionContext.ClampRiskConfidence(entry.Score);
+                logicConfidenceSource = "EntryScoreFallback";
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
+            }
+
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_INPUT] entryScore={entry.Score} routedLogic={logicConfidence} source={logicConfidenceSource}", entryContext));
+
             // =====================================================
             // 3️⃣ POSITION CONTEXT – SSOT
             // -----------------------------------------------------
@@ -144,9 +163,7 @@ namespace GeminiV26.Instruments.XAUUSD
 
                 EntryScore = entry.Score,
 
-                LogicConfidence = entry.LogicConfidence > 0
-                    ? entry.LogicConfidence
-                    : entry.Score,
+                LogicConfidence = logicConfidence,
 
                 EntryTime = _bot.Server.Time,
 
@@ -172,24 +189,26 @@ namespace GeminiV26.Instruments.XAUUSD
             // FinalConfidence összeállítása (Rulebook 1.0)
             // -----------------------------------------------------
             ctx.ComputeFinalConfidence();
+            int adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty);
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][FINAL] final={ctx.FinalConfidence} adjustedRisk={adjustedRiskConfidence} statePenalty={statePenalty}", entryContext));
 
                         GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildEntrySnapshot(_bot, entryContext, entry), entryContext));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(TradeAuditLog.BuildDirectionSnapshot(entryContext, entry), entryContext));
             if (statePenalty != 0)
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)}", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
-            // Trailing mód PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) alapján (FinalConfidence + statePenalty)
+            // Trailing mód adjustedRiskConfidence alapján (FinalConfidence + statePenalty)
             ctx.TrailingMode =
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 85 ? TrailingMode.Loose :
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty) >= 75 ? TrailingMode.Normal :
+                adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                              TrailingMode.Tight;
 
             // =====================================================
-            // 4️⃣ SL / TP POLICY (PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty))
+            // 4️⃣ SL / TP POLICY (adjustedRiskConfidence)
             // =====================================================
             double slPriceDist = _riskSizer.CalculateStopLossPriceDistance(
                 _bot,
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 entry.Type);
 
             if (slPriceDist <= 0)
@@ -201,7 +220,7 @@ namespace GeminiV26.Instruments.XAUUSD
             double tp2Price = _riskSizer.CalculateTp2PriceFromSlDistance(
                 _bot,
                 tradeType,
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 slPriceDist);
 
             if (tp2Price <= 0)
@@ -214,7 +233,7 @@ namespace GeminiV26.Instruments.XAUUSD
             // 5️⃣ TP / R VALUES (EURUSD MINTA SZERINT)
             // =====================================================
             _riskSizer.GetTakeProfit(
-                PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty),
+                adjustedRiskConfidence,
                 out double tp1R,
                 out double tp1Ratio,
                 out double tp2R,
@@ -230,12 +249,12 @@ namespace GeminiV26.Instruments.XAUUSD
             // =====================================================
             // 6️⃣ VOLUME POLICY – METAL POSITION SIZER (XAU)
             // =====================================================
-            double riskPercent = _riskSizer.GetRiskPercent(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty));
+            double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
             long volumeUnits = MetalPositionSizer.Calculate(
                 _bot,
                 riskPercent,
                 slPriceDist,
-                _riskSizer.GetLotCap(PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty))
+                _riskSizer.GetLotCap(adjustedRiskConfidence)
             );
 
             if (volumeUnits <= 0)


### PR DESCRIPTION
### Motivation

- Fix inconsistent authority and naming around confidence where `EntryContext` snapshots, executor recomputations and legacy fields caused drift and ambiguity. 
- Prevent executors from re-running entry logic as the primary source of `LogicConfidence` to reduce divergence between routing and execution. 
- Make the penalty-shaped value used for risk sizing explicit and consistently named so downstream sizing/TP/SL code does not mislabel derived values as canonical `FinalConfidence`. 

### Description

- Add `AUDIT_CONFIDENCE_ARCH_2026-03-29.md` documenting canonical confidence pipeline, runtime flow, violations and a minimal fix plan. 
- Replace `PendingEntryMeta.Confidence` with `PendingEntryMeta.EntryScore` and keep `Confidence` as an `[Obsolete]` alias that maps to `EntryScore`. Update `TradeCore` to register and consume `EntryScore` where metadata/snapshots were previously using `Confidence`. 
- Change executors to consume routed logic confidence instead of re-running entry logic: they now prefer `entryContext.LogicBiasConfidence`, fall back to `entry.LogicConfidence` if present, then to neutral defaults, and always `ClampRiskConfidence(...)`; added logging of the chosen `logicConfidence` source. 
- Introduce a local `adjustedRiskConfidence = PositionContext.ClampRiskConfidence(ctx.FinalConfidence + statePenalty)` in executors and use it consistently for sizing, SL distance, TP selection and trailing mode (replacing many inline `ClampRiskConfidence(ctx.FinalConfidence + statePenalty)` usages). 
- Update multiple instrument `RiskSizer` implementations to rename method parameters from `score` to `finalConfidence` and to use `NormalizeScore(finalConfidence)` (no behavioural change). 
- Fix XAU rehydrate and executor paths to set neutral `EntryScore = 50` / `LogicConfidence = 50` placeholders before calling `ComputeFinalConfidence()` to avoid rehydrate defaulting to 0. 

### Testing

- Performed a solution build with `dotnet build` which completed successfully. 
- No automated unit/integration test suite was executed as part of this change; behavior relies on preserved existing algorithms and targeted refactors to naming and data flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98353de948328ade548702949f547)