### PR TITLE
Add confidence-system production audit report

### DIFF
--- a/AUDIT_CONFIDENCE_SYSTEM_2026-03-29.md
+++ b/AUDIT_CONFIDENCE_SYSTEM_2026-03-29.md
@@ -1,0 +1,25 @@
+# Confidence System Audit (Gemini V26)
+Date: 2026-03-29
+Auditor mode: production-risk review
+
+## Scope Reviewed
+- TradeCore confidence snapshot construction
+- All instrument executors confidence source, fallback, and risk shaping usage
+- ExitManager confidence usage
+- Rehydrate confidence initialization paths
+
+## High-Risk Findings
+1. **XAU executor violates specified neutral fallback policy**
+   - Uses `EntryScoreFallback` (entry score) instead of neutral `50` when both routed and entry logic confidence are unavailable.
+2. **Crypto executors use canonical final confidence for trailing, not adjusted risk confidence**
+   - BTCUSD/ETHUSD trailing mode is derived from `ctx.FinalConfidence` after order placement.
+3. **Executor-side logic recomputation present in index executors**
+   - US30/NAS100/GER40 call `_entryLogic.Evaluate()` and overwrite `entry` fields via `ApplyToEntryEvaluation(entry)` during execution flow.
+4. **TradeCore snapshot and executor risk confidence can diverge without explicit reconciliation log**
+   - TradeCore logs `FC/RC` from `_ctx`; executors recompute local `ctx.FinalConfidence` and `adjustedRiskConfidence`.
+5. **Exit behavior still keyed on FinalConfidence thresholds in ExitManagers**
+   - TP1 fallback bucket logic uses `ctx.FinalConfidence` across managers.
+
+## Notes
+- `PositionContext.FinalConfidence` appears immutable by API design (`private set`, idempotent compute guard).
+- Rehydrate paths (generic service and XAU custom) initialize neutral confidence values before calling `ComputeFinalConfidence()`.


### PR DESCRIPTION
### Motivation
- Add a short production-risk audit of the recently refactored confidence pipeline to surface hidden bugs, architectural violations, and logging/rehydrate inconsistencies before live deployment.

### Description
- Add `AUDIT_CONFIDENCE_SYSTEM_2026-03-29.md` documenting observed issues including primary source usage (`LogicBiasConfidence`), executor fallbacks to `EntryEvaluation.LogicConfidence` (and neutral `50`), the XAU executor using `EntryScoreFallback` instead of neutral `50`, executor-side re-evaluation (`_entryLogic.Evaluate()` → `ApplyToEntryEvaluation`), misuse of `FinalConfidence` vs `adjustedRiskConfidence` (notably BTC/ETH trailing), and deterministic rehydrate neutralization via `ComputeFinalConfidence()`.

### Testing
- Performed repository-wide code-path inspections with `rg` pattern sweeps for `LogicBiasConfidence`, `EntryScore`, `ComputeFinalConfidence()`, `adjustedRiskConfidence`, `_entryLogic.Evaluate`, and related logging tokens and verified the audit entries against the matching source lines; all scans completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98b24663c83289ded43db63e3c1d8)