### PR TITLE
Introduce `AdjustedRiskConfidence` and switch executors/exits to use it (plus logging and audit)

### DIFF
--- a/AUDIT_CONFIDENCE_SYSTEM_2026-03-29.md
+++ b/AUDIT_CONFIDENCE_SYSTEM_2026-03-29.md
@@ -1,0 +1,25 @@
+# Confidence System Audit (Gemini V26)
+Date: 2026-03-29
+Auditor mode: production-risk review
+
+## Scope Reviewed
+- TradeCore confidence snapshot construction
+- All instrument executors confidence source, fallback, and risk shaping usage
+- ExitManager confidence usage
+- Rehydrate confidence initialization paths
+
+## High-Risk Findings
+1. **XAU executor violates specified neutral fallback policy**
+   - Uses `EntryScoreFallback` (entry score) instead of neutral `50` when both routed and entry logic confidence are unavailable.
+2. **Crypto executors use canonical final confidence for trailing, not adjusted risk confidence**
+   - BTCUSD/ETHUSD trailing mode is derived from `ctx.FinalConfidence` after order placement.
+3. **Executor-side logic recomputation present in index executors**
+   - US30/NAS100/GER40 call `_entryLogic.Evaluate()` and overwrite `entry` fields via `ApplyToEntryEvaluation(entry)` during execution flow.
+4. **TradeCore snapshot and executor risk confidence can diverge without explicit reconciliation log**
+   - TradeCore logs `FC/RC` from `_ctx`; executors recompute local `ctx.FinalConfidence` and `adjustedRiskConfidence`.
+5. **Exit behavior still keyed on FinalConfidence thresholds in ExitManagers**
+   - TP1 fallback bucket logic uses `ctx.FinalConfidence` across managers.
+
+## Notes
+- `PositionContext.FinalConfidence` appears immutable by API design (`private set`, idempotent compute guard).
+- Rehydrate paths (generic service and XAU custom) initialize neutral confidence values before calling `ComputeFinalConfidence()`.

--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -65,6 +65,7 @@ namespace GeminiV26.Core.Logging
                    $"logicConfidence={ctx.LogicBiasConfidence}\n" +
                    $"finalConfidence={ctx.FinalConfidence}\n" +
                    "statePenalty=0\n" +
+                   $"adjustedRiskConfidence={ctx.RiskConfidence}\n" +
                    $"riskFinal={ctx.RiskConfidence}\n" +
                    $"atr={ctx?.AtrM5 ?? 0:0.#####}\n" +
                    $"adx={ctx?.Adx_M5 ?? 0:0.##}\n" +

--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -89,6 +89,8 @@ namespace GeminiV26.Core
         /// </summary>
         public int FinalConfidence { get; private set; }
 
+        public int AdjustedRiskConfidence { get; set; }
+
         private bool _isFinalConfidenceComputed;
 
         public DateTime EntryTime { get; set; }
@@ -326,6 +328,8 @@ namespace GeminiV26.Core
                 return;
 
             FinalConfidence = ComputeFinalConfidenceValue(EntryScore, LogicConfidence);
+            if (AdjustedRiskConfidence <= 0)
+                AdjustedRiskConfidence = FinalConfidence;
             _isFinalConfidenceComputed = true;
         }
 

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.AUDNZD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -279,6 +279,7 @@ namespace GeminiV26.Instruments.AUDNZD
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[ctx.PositionId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.AUDUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -281,6 +281,7 @@ namespace GeminiV26.Instruments.AUDUSD
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[ctx.PositionId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -545,10 +545,10 @@ namespace GeminiV26.Instruments.BTCUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -265,8 +265,8 @@ namespace GeminiV26.Instruments.BTCUSD
             ctx.ComputeFinalConfidence();
 
             ctx.TrailingMode =
-                ctx.FinalConfidence >= 85 ? TrailingMode.Loose :
-                ctx.FinalConfidence >= 75 ? TrailingMode.Normal :
+                adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                              TrailingMode.Tight;
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXEC][SUCCESS]\nvolumeUnits={ctx.EntryVolumeInUnits:0.##}\nentryPrice={ctx.EntryPrice:0.#####}\nsl={result.Position.StopLoss}\ntp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
@@ -275,6 +275,7 @@ namespace GeminiV26.Instruments.BTCUSD
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[posId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -470,10 +470,10 @@ namespace GeminiV26.Instruments.ETHUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -264,8 +264,8 @@ namespace GeminiV26.Instruments.ETHUSD
             ctx.ComputeFinalConfidence();
 
             ctx.TrailingMode =
-                ctx.FinalConfidence >= 85 ? TrailingMode.Loose :
-                ctx.FinalConfidence >= 75 ? TrailingMode.Normal :
+                adjustedRiskConfidence >= 85 ? TrailingMode.Loose :
+                adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                              TrailingMode.Tight;
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXEC][SUCCESS]\nvolumeUnits={ctx.EntryVolumeInUnits:0.##}\nentryPrice={ctx.EntryPrice:0.#####}\nsl={result.Position.StopLoss}\ntp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
@@ -274,6 +274,7 @@ namespace GeminiV26.Instruments.ETHUSD
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[posId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.EURJPY
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -281,6 +281,7 @@ namespace GeminiV26.Instruments.EURJPY
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[ctx.PositionId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.EURUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -273,6 +273,7 @@ namespace GeminiV26.Instruments.EURUSD
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[ctx.PositionId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.GBPJPY
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -281,6 +281,7 @@ namespace GeminiV26.Instruments.GBPJPY
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[ctx.PositionId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.GBPUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -282,6 +282,7 @@ namespace GeminiV26.Instruments.GBPUSD
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[positionKey] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[OPEN] entryPrice={ctx.EntryPrice}", ctx));

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.GER40
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -65,9 +65,6 @@ namespace GeminiV26.Instruments.GER40
             // =========================
             // ENTRY LOGIC – GER40
             // =========================
-            _entryLogic.Evaluate();
-            _entryLogic.ApplyToEntryEvaluation(entry);
-
             int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
             string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
 
@@ -263,6 +260,7 @@ namespace GeminiV26.Instruments.GER40
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[positionKey] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[OPEN] entryPrice={ctx.EntryPrice}", ctx));

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.NAS100
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -78,9 +78,6 @@ namespace GeminiV26.Instruments.NAS100
             // =========================
             // ENTRY LOGIC – NAS
             // =========================
-            _entryLogic.Evaluate();
-            _entryLogic.ApplyToEntryEvaluation(entry);
-
             int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
             string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
 
@@ -272,6 +269,7 @@ namespace GeminiV26.Instruments.NAS100
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[positionKey] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[OPEN] entryPrice={ctx.EntryPrice}", ctx));

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.NZDUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -281,6 +281,7 @@ namespace GeminiV26.Instruments.NZDUSD
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[ctx.PositionId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.US30
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -72,9 +72,6 @@ namespace GeminiV26.Instruments.US30
             // =========================
             // ENTRY LOGIC � US30
             // =========================
-            _entryLogic.Evaluate();
-            _entryLogic.ApplyToEntryEvaluation(entry);
-
             int logicConfidence = PositionContext.ClampRiskConfidence(entryContext.LogicBiasConfidence);
             string logicConfidenceSource = "EntryContext.LogicBiasConfidence";
 
@@ -252,6 +249,7 @@ namespace GeminiV26.Instruments.US30
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[positionKey] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[OPEN] entryPrice={ctx.EntryPrice}", ctx));

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.USDCAD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -281,6 +281,7 @@ namespace GeminiV26.Instruments.USDCAD
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[ctx.PositionId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.USDCHF
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -281,6 +281,7 @@ namespace GeminiV26.Instruments.USDCHF
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[ctx.PositionId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -413,10 +413,10 @@ namespace GeminiV26.Instruments.USDJPY
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.FinalConfidence >= 85)
+            if (ctx.AdjustedRiskConfidence >= 85)
                 return 0.40;
 
-            if (ctx.FinalConfidence >= 70)
+            if (ctx.AdjustedRiskConfidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -274,6 +274,7 @@ namespace GeminiV26.Instruments.USDJPY
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[ctx.PositionId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[OPEN] entryPrice={ctx.EntryPrice}", ctx));

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -595,8 +595,8 @@ namespace GeminiV26.Instruments.XAUUSD
                 return ctx.Tp1R;
 
             // Profil bucket
-            if (ctx.FinalConfidence >= 85) return _profile.Tp1R_High;
-            if (ctx.FinalConfidence >= 70) return _profile.Tp1R_Normal;
+            if (ctx.AdjustedRiskConfidence >= 85) return _profile.Tp1R_High;
+            if (ctx.AdjustedRiskConfidence >= 70) return _profile.Tp1R_Normal;
             return _profile.Tp1R_Low;
         }
 

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -139,8 +139,8 @@ namespace GeminiV26.Instruments.XAUUSD
 
             if (logicConfidence <= 0)
             {
-                logicConfidence = PositionContext.ClampRiskConfidence(entry.Score);
-                logicConfidenceSource = "EntryScoreFallback";
+                logicConfidence = 50;
+                logicConfidenceSource = "NeutralDefault";
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[CONF][EXEC_FALLBACK] source={logicConfidenceSource} value={logicConfidence}", entryContext));
             }
 
@@ -349,6 +349,7 @@ namespace GeminiV26.Instruments.XAUUSD
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));
 
             _positionContexts[ctx.PositionId] = ctx;
+            ctx.AdjustedRiskConfidence = adjustedRiskConfidence;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[DIR][SET] posId={ctx.PositionId} finalDir={ctx.FinalDirection}", ctx));
             _exitManager.RegisterContext(ctx);
 


### PR DESCRIPTION
### Motivation
- Introduce a distinct risk-adjusted confidence value so exit and trailing behavior can be driven by an executor-provided `adjustedRiskConfidence` without changing the canonical `FinalConfidence` calculation.
- Ensure the position context, exit managers and instrument executors consistently store and consume the risk-adjusted value to avoid divergence between TradeCore snapshots and executor-side runtime decisions.
- Improve auditability by logging the risk-adjusted value and add an audit note file describing the confidence system review.

### Description
- Added `AdjustedRiskConfidence` property to `PositionContext`, and updated `ComputeFinalConfidence()` to initialize `AdjustedRiskConfidence` to `FinalConfidence` when unset.
- Updated instrument executors to assign `ctx.AdjustedRiskConfidence = adjustedRiskConfidence` after opening positions and to keep `ctx.ComputeFinalConfidence()` as the canonical FinalConfidence computation for analytics.
- Modified many ExitManagers to use `ctx.AdjustedRiskConfidence` instead of `ctx.FinalConfidence` for TP1 bucket resolution and other risk-shaping logic, and updated trailing mode decisions in executors to use the `adjustedRiskConfidence` snapshot value.
- Added `adjustedRiskConfidence` to the entry snapshot printed by `TradeAuditLog.BuildEntrySnapshot` and added `AUDIT_CONFIDENCE_SYSTEM_2026-03-29.md` documenting the audit findings and scope.
- Removed some executor-side recomputation of entry logic in index executors to avoid overwriting routed entry evaluation (e.g. removed calls to `_entryLogic.Evaluate()` / `ApplyToEntryEvaluation(entry)` in several index executors) and changed the XAU executor neutral fallback to `50` instead of using an `EntryScoreFallback`.

### Testing
- Built the solution using `dotnet build` to verify compilation after the widespread changes and the build completed successfully.
- Ran the automated unit/integration test suite with `dotnet test` and observed tests pass locally (no regressions reported by the test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98b24663c83289ded43db63e3c1d8)