### PR TITLE
Finalize confidence safeguards with visible fallbacks

### DIFF
--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -65,7 +65,7 @@ namespace GeminiV26.Core.Logging
                    $"logicConfidence={ctx.LogicBiasConfidence}\n" +
                    $"finalConfidence={ctx.FinalConfidence}\n" +
                    "statePenalty=0\n" +
-                   $"adjustedRiskConfidence={ctx.RiskConfidence}\n" +
+                   $"adjustedRiskConfidence={ctx.AdjustedRiskConfidence}\n" +
                    $"riskFinal={ctx.RiskConfidence}\n" +
                    $"atr={ctx?.AtrM5 ?? 0:0.#####}\n" +
                    $"adx={ctx?.Adx_M5 ?? 0:0.##}\n" +

--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -329,7 +329,12 @@ namespace GeminiV26.Core
 
             FinalConfidence = ComputeFinalConfidenceValue(EntryScore, LogicConfidence);
             if (AdjustedRiskConfidence <= 0)
+            {
+                // Failsafe fallback – MUST be visible
                 AdjustedRiskConfidence = FinalConfidence;
+
+                Log?.Invoke("[CONF][ADJUSTED_FALLBACK] using FinalConfidence");
+            }
             _isFinalConfidenceComputed = true;
         }
 

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.AUDNZD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.AUDUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -545,10 +545,18 @@ namespace GeminiV26.Instruments.BTCUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -470,10 +470,18 @@ namespace GeminiV26.Instruments.ETHUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.EURJPY
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.EURUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.GBPJPY
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.GBPUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.GER40
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.NAS100
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.NZDUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.US30
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.USDCAD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.USDCHF
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -413,10 +413,18 @@ namespace GeminiV26.Instruments.USDJPY
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            if (ctx.AdjustedRiskConfidence >= 85)
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
+            if (confidence >= 85)
                 return 0.40;
 
-            if (ctx.AdjustedRiskConfidence >= 70)
+            if (confidence >= 70)
                 return 0.50;
 
             return 0.60;

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -594,9 +594,17 @@ namespace GeminiV26.Instruments.XAUUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
+            int confidence = ctx.AdjustedRiskConfidence;
+
+            if (confidence <= 0)
+            {
+                confidence = ctx.FinalConfidence;
+                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+            }
+
             // Profil bucket
-            if (ctx.AdjustedRiskConfidence >= 85) return _profile.Tp1R_High;
-            if (ctx.AdjustedRiskConfidence >= 70) return _profile.Tp1R_Normal;
+            if (confidence >= 85) return _profile.Tp1R_High;
+            if (confidence >= 70) return _profile.Tp1R_Normal;
             return _profile.Tp1R_Low;
         }
 


### PR DESCRIPTION
### Motivation
- Make the adjusted-risk fallback visible in runtime logs so silent fallbacks to `FinalConfidence` are observable.
- Ensure audit snapshots record the actual `AdjustedRiskConfidence` value instead of the wrong field.
- Protect exit logic from invalid `AdjustedRiskConfidence` by using a guarded local value with a visible fallback.

### Description
- Added explicit log in `ComputeFinalConfidence()` in `PositionContext.cs` when `AdjustedRiskConfidence` is set from `FinalConfidence` (`[CONF][ADJUSTED_FALLBACK]`).
- Fixed snapshot field in `Core/Logging/TradeAuditLog.cs` to use `ctx.AdjustedRiskConfidence` for `adjustedRiskConfidence`.
- In every instrument `ExitManager` implementation replaced direct `ctx.AdjustedRiskConfidence` usage with a guarded local `int confidence = ctx.AdjustedRiskConfidence;` and added fallback to `ctx.FinalConfidence` with `ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");`, then used `confidence` for threshold checks.

### Testing
- Ran `git diff --check` to validate no whitespace or simple diff errors and it passed.
- Searched for markers with `rg -n "\[CONF\]\[ADJUSTED_FALLBACK\]|adjustedRiskConfidence=\{ctx\.AdjustedRiskConfidence\}|\[CONF\]\[EXIT_FALLBACK\]"` to confirm changes are present and the search passed.
- Verified modified files compile-sanity by inspecting diffs for consistent replacements (no automated build executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98f2cedf08328a761b941c04892bb)