### PR TITLE
Restore PositionContext.Log delegate to fix build errors

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -46,6 +46,7 @@ namespace GeminiV26.Core
 
         public string Symbol { get; set; } = string.Empty;
         public Robot Bot { get; set; }
+        public Action<string> Log { get; set; }
 
         public string TempId { get; set; } = string.Empty;
 


### PR DESCRIPTION
### Motivation
- A recent edit removed the logging delegate from `PositionContext`, which caused multiple instruments and exit managers to call `ctx.Log?.Invoke(...)` and produced ~18 compiler errors; the intent is to restore compatibility without changing runtime logic.

### Description
- Reintroduced the `Log` delegate property as `public Action<string> Log { get; set; }` in `Core/PositionContext.cs` to restore the nullable logging callback used across core and instrument code paths.

### Testing
- Verified the change by searching for the property with `rg -n "public Action<string> Log" Core/PositionContext.cs` and inspecting the file snippet with `nl -ba Core/PositionContext.cs | sed -n '42,56p'`, both of which showed the new property present and the file updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c990ab4cc88328a25d8c114a6831e2)