### PR TITLE
Use GlobalLogger for confidence-fallback logs across PositionContext and exit managers

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -333,7 +333,7 @@ namespace GeminiV26.Core
                 // Failsafe fallback – MUST be visible
                 AdjustedRiskConfidence = FinalConfidence;
 
-                Log?.Invoke("[CONF][ADJUSTED_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(Bot, "[CONF][ADJUSTED_FALLBACK] using FinalConfidence");
             }
             _isFinalConfidenceComputed = true;
         }

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.AUDNZD
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.AUDUSD
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -550,7 +550,7 @@ namespace GeminiV26.Instruments.BTCUSD
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -475,7 +475,7 @@ namespace GeminiV26.Instruments.ETHUSD
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.EURJPY
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.EURUSD
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.GBPJPY
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.GBPUSD
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.GER40
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.NAS100
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.NZDUSD
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.US30
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.USDCAD
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.USDCHF
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -418,7 +418,7 @@ namespace GeminiV26.Instruments.USDJPY
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             if (confidence >= 85)

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -599,7 +599,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (confidence <= 0)
             {
                 confidence = ctx.FinalConfidence;
-                ctx.Log?.Invoke("[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
             }
 
             // Profil bucket


### PR DESCRIPTION
### Motivation

- Centralize and standardize logging for confidence fallback messages by removing ad-hoc delegate invocations and using the global logger.
- Ensure fallback messages are always emitted in a consistent way when `AdjustedRiskConfidence` is missing or zero.

### Description

- Replaced `Log?.Invoke` / `ctx.Log?.Invoke` usages with `GlobalLogger.Log(...)` in `PositionContext` and multiple instrument exit managers to emit the `[CONF][ADJUSTED_FALLBACK]` / `[CONF][EXIT_FALLBACK]` messages.
- Updated `ComputeFinalConfidence` to call `GlobalLogger.Log(Bot, ...)` when `AdjustedRiskConfidence` is set from `FinalConfidence` as a failsafe.
- Updated `ResolveTp1R` implementations across many `*ExitManager.cs` files to call `GlobalLogger.Log(_bot, ...)` when falling back from `AdjustedRiskConfidence` to `FinalConfidence`.
- No algorithmic or behavioral logic changes to confidence calculation or TP/SL resolution; changes are limited to logging calls.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c990ab4cc88328a25d8c114a6831e2)