### PR TITLE
Use FinalConfidence for adjustedRiskConfidence in entry snapshot log

### DIFF
--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -65,7 +65,7 @@ namespace GeminiV26.Core.Logging
                    $"logicConfidence={ctx.LogicBiasConfidence}\n" +
                    $"finalConfidence={ctx.FinalConfidence}\n" +
                    "statePenalty=0\n" +
-                   $"adjustedRiskConfidence={ctx.AdjustedRiskConfidence}\n" +
+                   $"adjustedRiskConfidence={ctx.FinalConfidence}\n" +
                    $"riskFinal={ctx.RiskConfidence}\n" +
                    $"atr={ctx?.AtrM5 ?? 0:0.#####}\n" +
                    $"adx={ctx?.Adx_M5 ?? 0:0.##}\n" +


### PR DESCRIPTION
### Motivation
- Fix logging mismatch where `adjustedRiskConfidence` was reporting `ctx.AdjustedRiskConfidence` instead of the intended `ctx.FinalConfidence`, causing inaccurate audit snapshots.

### Description
- In `Core/Logging/TradeAuditLog.cs` `BuildEntrySnapshot` now writes `adjustedRiskConfidence={ctx.FinalConfidence}` instead of `ctx.AdjustedRiskConfidence`.

### Testing
- Ran automated unit tests with `dotnet test` including logging-related tests, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9931b8acc832890d930fa1e8672d3)