### PR TITLE
Score-normalized dynamic multipliers for TrendTradeManager and AdaptiveTrailingEngine

### DIFF
--- a/Core/TradeManagement/AdaptiveTrailingEngine.cs
+++ b/Core/TradeManagement/AdaptiveTrailingEngine.cs
@@ -50,7 +50,7 @@ namespace GeminiV26.Core.TradeManagement
 
             if (!forceFallback)
             {
-                valid = TryBuildStructureStop(isLong, structure, profile, atr, decision.SlAtrMultiplier, out newSl, out string structureReason, out int anchorBarsAgo);
+                valid = TryBuildStructureStop(isLong, structure, profile, atr, decision.DynamicSlMultiplier, out newSl, out string structureReason, out int anchorBarsAgo);
                 if (valid)
                 {
                     trailMode = "STRUCTURE";
@@ -69,7 +69,7 @@ namespace GeminiV26.Core.TradeManagement
 
             if (!valid)
             {
-                BuildVolatilityStop(isLong, profile, atr, decision.SlAtrMultiplier, out newSl, out string regime, out double multiplier);
+                BuildVolatilityStop(isLong, profile, atr, decision.DynamicSlMultiplier, out newSl, out string regime, out double multiplier);
                 trailMode = "VOLATILITY_FALLBACK";
                 reason = string.IsNullOrWhiteSpace(reason) ? $"fallback regime={regime}" : $"{reason} regime={regime}";
                 fallbackVolatilityLog = $"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode=VOLATILITY_FALLBACK slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason={reason} multiplier={multiplier:0.00}";
@@ -90,6 +90,13 @@ namespace GeminiV26.Core.TradeManagement
                     : Math.Min(newSl, ctx.BePrice);
             }
 
+            if (decision.ScoreNormalized > 0.7)
+            {
+                newSl = isLong
+                    ? Math.Max(newSl, _bot.Symbol.Bid - atr * decision.DynamicSlMultiplier * 0.8)
+                    : Math.Min(newSl, _bot.Symbol.Ask + atr * decision.DynamicSlMultiplier * 0.8);
+            }
+
             newSl = Normalize(newSl);
 
             if (newSl <= 0)
@@ -97,7 +104,7 @@ namespace GeminiV26.Core.TradeManagement
 
             if (!ImprovesStop(isLong, newSl, oldSl) && trailMode == "STRUCTURE")
             {
-                BuildVolatilityStop(isLong, profile, atr, decision.SlAtrMultiplier, out double fallbackSl, out string fallbackRegime, out double fallbackMultiplier);
+                BuildVolatilityStop(isLong, profile, atr, decision.DynamicSlMultiplier, out double fallbackSl, out string fallbackRegime, out double fallbackMultiplier);
                 fallbackSl = isLong
                     ? Math.Max(fallbackSl, oldSl)
                     : Math.Min(fallbackSl, oldSl);
@@ -172,6 +179,7 @@ namespace GeminiV26.Core.TradeManagement
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TRAIL][STEP]\nstep={ctx.TrailSteps}\nslOld={FormatPrice(oldSl)}\nslNew={FormatPrice(newSl)}", ctx, pos));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TRAIL] modified pos={pos.Id} oldSL={oldSl} newSL={newSl}", ctx, pos));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slNew={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=updated", ctx, pos));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TTM][TRAIL][DYNAMIC] norm={decision.ScoreNormalized:0.00} slMult={decision.DynamicSlMultiplier:0.00}", ctx, pos));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(isLong ? _bot.Symbol.Bid : _bot.Symbol.Ask)} sl={newSl} tp={pos.TakeProfit}", ctx, pos));
         }
 

--- a/Core/TradeManagement/TrendTradeManager.cs
+++ b/Core/TradeManagement/TrendTradeManager.cs
@@ -31,6 +31,9 @@ namespace GeminiV26.Core.TradeManagement
         public bool IsRunner { get; init; }
         public double SlAtrMultiplier { get; init; }
         public double TpAtrMultiplier { get; init; }
+        public double ScoreNormalized { get; init; }
+        public double DynamicSlMultiplier { get; init; }
+        public double DynamicTpMultiplier { get; init; }
     }
 
     public sealed class TrendTradeManager
@@ -67,7 +70,10 @@ namespace GeminiV26.Core.TradeManagement
                     Tp2ExtensionMultiplier = 1.0,
                     IsRunner = false,
                     SlAtrMultiplier = profile?.LowConfidenceSlAtrMultiplier ?? 1.0,
-                    TpAtrMultiplier = profile?.LowConfidenceTpAtrMultiplier ?? 1.0
+                    TpAtrMultiplier = profile?.LowConfidenceTpAtrMultiplier ?? 1.0,
+                    ScoreNormalized = 0.0,
+                    DynamicSlMultiplier = profile?.LowConfidenceSlAtrMultiplier ?? 1.0,
+                    DynamicTpMultiplier = profile?.LowConfidenceTpAtrMultiplier ?? 1.0
                 };
             }
 
@@ -117,6 +123,8 @@ namespace GeminiV26.Core.TradeManagement
             if (shallowPullback)
                 score++;
 
+            double scoreNormalized = Math.Min(1.0, Math.Max(0.0, score / 5.0));
+
             TradeTrendState state = score switch
             {
                 <= 1 => TradeTrendState.Normal,
@@ -126,19 +134,13 @@ namespace GeminiV26.Core.TradeManagement
 
             AdaptiveTrailingMode mode = AdaptiveTrailingMode.Structure;
 
-            double slAtrMultiplier = state switch
-            {
-                TradeTrendState.StrongTrend => profile.StrongTrendSlAtrMultiplier,
-                TradeTrendState.Trend => profile.TrendSlAtrMultiplier,
-                _ => profile.LowConfidenceSlAtrMultiplier
-            };
+            double slAtrMultiplier =
+                profile.LowConfidenceSlAtrMultiplier +
+                (profile.StrongTrendSlAtrMultiplier - profile.LowConfidenceSlAtrMultiplier) * scoreNormalized;
 
-            double tpAtrMultiplier = state switch
-            {
-                TradeTrendState.StrongTrend => profile.StrongTrendTpAtrMultiplier,
-                TradeTrendState.Trend => profile.TrendTpAtrMultiplier,
-                _ => profile.LowConfidenceTpAtrMultiplier
-            };
+            double tpAtrMultiplier =
+                profile.LowConfidenceTpAtrMultiplier +
+                (profile.StrongTrendTpAtrMultiplier - profile.LowConfidenceTpAtrMultiplier) * scoreNormalized;
 
             string confidenceBucket = GetConfidenceBucket(score);
             bool profileStateChanged = !string.Equals(ctx.LastProfileState, state.ToString(), StringComparison.Ordinal);
@@ -149,6 +151,16 @@ namespace GeminiV26.Core.TradeManagement
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TTM][PROFILE] symbol={position.SymbolName} direction={(isLong ? "LONG" : "SHORT")} state={state} score={score} slMult={slAtrMultiplier:0.00} tpMult={tpAtrMultiplier:0.00} reason=confidence_profile", ctx, position));
                 ctx.LastProfileState = state.ToString();
                 ctx.LastProfileBucket = confidenceBucket;
+            }
+
+            bool dynamicMultiplierChanged =
+                ctx.PostTp1TrendScore != score ||
+                !ctx.LastTtmTp2Multiplier.HasValue ||
+                Math.Abs(ctx.LastTtmTp2Multiplier.Value - tpAtrMultiplier) >= 0.000001;
+
+            if (dynamicMultiplierChanged)
+            {
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TTM][DYNAMIC] score={score} norm={scoreNormalized:0.00} sl={slAtrMultiplier:0.00} tp={tpAtrMultiplier:0.00}", ctx, position));
             }
 
             bool allowTp2Extension = isRunner && profile.AllowTp2Extension;
@@ -175,11 +187,14 @@ namespace GeminiV26.Core.TradeManagement
                 State = state,
                 Score = score,
                 TrailingMode = mode,
-                AllowTp2Extension = false,
+                AllowTp2Extension = allowTp2Extension,
                 Tp2ExtensionMultiplier = tpAtrMultiplier,
                 IsRunner = isRunner,
                 SlAtrMultiplier = slAtrMultiplier,
-                TpAtrMultiplier = tpAtrMultiplier
+                TpAtrMultiplier = tpAtrMultiplier,
+                ScoreNormalized = scoreNormalized,
+                DynamicSlMultiplier = slAtrMultiplier,
+                DynamicTpMultiplier = tpAtrMultiplier
             };
         }
 


### PR DESCRIPTION
### Motivation
- Replace discrete confidence buckets with a continuous `score` (0–5) signal to produce smoother SL/TP multiplier behavior and reduce bucket-driven jumps.
- Surface the normalized score and dynamic multipliers in the decision object so trailing logic can respond continuously without changing external interfaces.
- Apply mild tightening of trailing stops for strong scores while preserving existing architecture, logging, and backward compatibility.

### Description
- Added `ScoreNormalized`, `DynamicSlMultiplier`, and `DynamicTpMultiplier` to `TrendDecision` and populated them in both the normal and early-exit return paths in `TrendTradeManager`.
- Compute `scoreNormalized = Math.Min(1.0, Math.Max(0.0, score / 5.0))` and replace bucket switch logic with smooth interpolation for SL/TP ATR multipliers using the profile bounds (low-confidence -> strong-trend).
- Kept `TradeTrendState`/profile bucket logic for logging only, and added a `[TTM][DYNAMIC]` log entry when dynamic values change.
- Fixed TP2 extension flag bug by returning `AllowTp2Extension = allowTp2Extension` in the main decision path.
- Updated `AdaptiveTrailingEngine` to use `decision.DynamicSlMultiplier` in place of `decision.SlAtrMultiplier`, added a tightening clause when `decision.ScoreNormalized > 0.7`, and added a `[TTM][TRAIL][DYNAMIC]` log on successful SL updates.
- Only the following files were modified: `Core/TradeManagement/TrendTradeManager.cs` and `Core/TradeManagement/AdaptiveTrailingEngine.cs`.

### Testing
- Attempted `dotnet build` in this environment with `dotnet build`, but it failed due to the SDK not being available (`/bin/bash: line 1: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca34260c68832887b6289d4c17eb0d)