### PR TITLE
Restore volatility in trailing, smooth strong-score tightening, and apply non-linear score scaling

### DIFF
--- a/Core/TradeManagement/AdaptiveTrailingEngine.cs
+++ b/Core/TradeManagement/AdaptiveTrailingEngine.cs
@@ -93,8 +93,8 @@ namespace GeminiV26.Core.TradeManagement
             if (decision.ScoreNormalized > 0.7)
             {
                 newSl = isLong
-                    ? Math.Max(newSl, _bot.Symbol.Bid - atr * decision.DynamicSlMultiplier * 0.8)
-                    : Math.Min(newSl, _bot.Symbol.Ask + atr * decision.DynamicSlMultiplier * 0.8);
+                    ? Math.Max(newSl, _bot.Symbol.Bid - atr * decision.DynamicSlMultiplier * (0.9 + 0.1 * decision.ScoreNormalized))
+                    : Math.Min(newSl, _bot.Symbol.Ask + atr * decision.DynamicSlMultiplier * (0.9 + 0.1 * decision.ScoreNormalized));
             }
 
             newSl = Normalize(newSl);
@@ -255,7 +255,8 @@ namespace GeminiV26.Core.TradeManagement
                 multiplier = profile.AtrMultiplierNormal;
             }
 
-            multiplier = slAtrMultiplier;
+            double volMultiplier = multiplier;
+            multiplier = slAtrMultiplier * volMultiplier;
             double price = isLong ? s.Bid : s.Ask;
 
             newSl = isLong

--- a/Core/TradeManagement/TrendTradeManager.cs
+++ b/Core/TradeManagement/TrendTradeManager.cs
@@ -123,7 +123,8 @@ namespace GeminiV26.Core.TradeManagement
             if (shallowPullback)
                 score++;
 
-            double scoreNormalized = Math.Min(1.0, Math.Max(0.0, score / 5.0));
+            double scoreRaw = Math.Min(1.0, Math.Max(0.0, score / 5.0));
+            double scoreNormalized = Math.Pow(scoreRaw, 1.3);
 
             TradeTrendState state = score switch
             {
@@ -141,6 +142,7 @@ namespace GeminiV26.Core.TradeManagement
             double tpAtrMultiplier =
                 profile.LowConfidenceTpAtrMultiplier +
                 (profile.StrongTrendTpAtrMultiplier - profile.LowConfidenceTpAtrMultiplier) * scoreNormalized;
+            tpAtrMultiplier = Math.Min(tpAtrMultiplier, profile.StrongTrendTpAtrMultiplier);
 
             string confidenceBucket = GetConfidenceBucket(score);
             bool profileStateChanged = !string.Equals(ctx.LastProfileState, state.ToString(), StringComparison.Ordinal);
@@ -160,7 +162,7 @@ namespace GeminiV26.Core.TradeManagement
 
             if (dynamicMultiplierChanged)
             {
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TTM][DYNAMIC] score={score} norm={scoreNormalized:0.00} sl={slAtrMultiplier:0.00} tp={tpAtrMultiplier:0.00}", ctx, position));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TTM][DYNAMIC] score={score} norm={scoreNormalized:0.00} sl={slAtrMultiplier:0.00} tp={tpAtrMultiplier:0.00} atr={atr:0.#####}", ctx, position));
             }
 
             bool allowTp2Extension = isRunner && profile.AllowTp2Extension;


### PR DESCRIPTION
### Motivation

- Volatility contribution to stop distance was accidentally overwritten causing dynamic trailing to ignore market environment. 
- Strong-score tightening used a fixed aggressive factor which led to premature stop-outs in high-confidence trades. 
- Linear score normalization underweights very strong signals and overweights middling ones, reducing strategy edge clarity.

### Description

- In `AdaptiveTrailingEngine.cs` updated `BuildVolatilityStop(...)` to preserve the regime-based volatility multiplier (`volMultiplier`) and combine it with the score/SL multiplier by setting `multiplier = slAtrMultiplier * volMultiplier` instead of overwriting it. 
- In `AdaptiveTrailingEngine.cs` softened the strong-score trailing clamp by replacing the fixed `* 0.8` factor with `* (0.9 + 0.1 * decision.ScoreNormalized)` for both long and short branches to smooth tightening. 
- In `TrendTradeManager.cs` changed score normalization to be non-linear by adding `scoreRaw = Math.Min(1.0, Math.Max(0.0, score / 5.0));` and `scoreNormalized = Math.Pow(scoreRaw, 1.3);` so high scores gain more weight. 
- In `TrendTradeManager.cs` capped `tpAtrMultiplier` after calculation with `tpAtrMultiplier = Math.Min(tpAtrMultiplier, profile.StrongTrendTpAtrMultiplier);` and extended the `[TTM][DYNAMIC]` log line to include `atr={atr:0.#####}` for easier SL/TP vs ATR validation.

### Testing

- Ran `git diff --check` and it reported no whitespace or diff-check issues. 
- Verified file-level changes via repository search and content inspection showing the intended edits to `AdaptiveTrailingEngine.cs` and `TrendTradeManager.cs`. 
- A full compile was not executed because no `.sln`/`.csproj` files were present in the environment, so compilation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca35c66be48328a8c5c0eb970818fd)