### PR TITLE
Reduce noisy trailing logs and add trail-state to PositionContext

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -450,6 +450,14 @@ namespace GeminiV26.Core
 
         public bool TrailNoStructureLogged { get; set; }
 
+        public bool TrailLowProgressLogged { get; set; }
+
+        public bool TrailAtrUnavailableLogged { get; set; }
+
+        public bool TrailResolverFailedLogged { get; set; }
+
+        public string LastTrailCheckFingerprint { get; set; } = string.Empty;
+
         public int TrailSteps { get; set; }
 
         public int LastStateTraceBarIndex { get; set; } = -1;

--- a/Core/TradeManagement/AdaptiveTrailingEngine.cs
+++ b/Core/TradeManagement/AdaptiveTrailingEngine.cs
@@ -29,9 +29,16 @@ namespace GeminiV26.Core.TradeManagement
             double atr = _atr.Result.LastValue;
             if (atr <= 0)
             {
-                GlobalLogger.Log(_bot, $"[TTM][TRAIL][SKIP] reason=atr_unavailable symbol={pos.SymbolName} positionId={pos.Id}");
+                if (ctx == null || !ctx.TrailAtrUnavailableLogged)
+                {
+                    GlobalLogger.Log(_bot, $"[TTM][TRAIL][SKIP] reason=atr_unavailable symbol={pos.SymbolName} positionId={pos.Id}");
+                    if (ctx != null)
+                        ctx.TrailAtrUnavailableLogged = true;
+                }
                 return;
             }
+            if (ctx != null)
+                ctx.TrailAtrUnavailableLogged = false;
 
             if (ctx?.FinalDirection == TradeDirection.None)
             {
@@ -43,7 +50,12 @@ namespace GeminiV26.Core.TradeManagement
             string direction = isLong ? "LONG" : "SHORT";
             double oldSl = pos.StopLoss.Value;
             double newSl = 0;
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TRAIL][CHECK]\ncurrentSl={FormatPrice(oldSl)}\ntp1Hit={ctx.Tp1Hit}\ntrailActive={ctx.TrailingActivated}", ctx, pos));
+            string trailCheckFingerprint = $"{FormatPrice(oldSl)}|{ctx.Tp1Hit}|{ctx.TrailingActivated}|{ctx.LastTrailingStopTarget}";
+            if (!string.Equals(ctx.LastTrailCheckFingerprint, trailCheckFingerprint, StringComparison.Ordinal))
+            {
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TRAIL][CHECK]\ncurrentSl={FormatPrice(oldSl)}\ntp1Hit={ctx.Tp1Hit}\ntrailActive={ctx.TrailingActivated}", ctx, pos));
+                ctx.LastTrailCheckFingerprint = trailCheckFingerprint;
+            }
             string trailMode = "FALLBACK";
             string reason = string.Empty;
             bool valid = false;
@@ -177,8 +189,6 @@ namespace GeminiV26.Core.TradeManagement
             if (!result.IsSuccessful)
             {
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[MODIFY][FAIL]\nsl={FormatPrice(newSl)}\ntp={FormatPrice(pos.TakeProfit)}\nerror={result.Error}", ctx, pos));
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TRAIL][FAIL]\nsl={FormatPrice(newSl)}\nerror={result.Error}", ctx, pos));
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TRAIL] modify FAILED pos={pos.Id} error={result.Error}", ctx, pos));
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slCandidate={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=modify_failed error={result.Error}", ctx, pos));
                 return;
             }
@@ -188,11 +198,7 @@ namespace GeminiV26.Core.TradeManagement
             ctx.TrailingActivated = true;
             ctx.TrailSteps++;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[MODIFY][SUCCESS]\nsl={FormatPrice(newSl)}\ntp={FormatPrice(pos.TakeProfit)}\nreason=trail_update", ctx, pos));
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TRAIL][STEP]\nstep={ctx.TrailSteps}\nslOld={FormatPrice(oldSl)}\nslNew={FormatPrice(newSl)}", ctx, pos));
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TRAIL] modified pos={pos.Id} oldSL={oldSl} newSL={newSl}", ctx, pos));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TTM][TRAIL] symbol={pos.SymbolName} direction={direction} mode={trailMode} slOld={FormatPrice(oldSl)} slNew={FormatPrice(newSl)} tp={FormatPrice(pos.TakeProfit)} reason=updated", ctx, pos));
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TTM][TRAIL][DYNAMIC] norm={decision.ScoreNormalized:0.00} slMult={decision.DynamicSlMultiplier:0.00}", ctx, pos));
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT] TRAILING ACTIVE symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(isLong ? _bot.Symbol.Bid : _bot.Symbol.Ask)} sl={newSl} tp={pos.TakeProfit}", ctx, pos));
         }
 
         private bool TryBuildStructureStop(bool isLong, StructureSnapshot structure, TrailingProfile profile, double atr, double slAtrMultiplier, out double newSl, out string reason, out int anchorBarsAgo)

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -435,7 +435,7 @@ namespace GeminiV26.Instruments.XAUUSD
             
             if (closeVolume < sym.VolumeInUnitsMin)
             {
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE skipped symbol={pos.SymbolName} positionId={pos.Id} reason=closeVolumeBelowMin rawUnits={rawUnitsD} flooredUnits={flooredUnits} closeVolume={closeVolume} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}", ctx, pos));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE skipped symbol={pos.SymbolName} positionId={pos.Id} reason=tp1_close_units_below_min rawUnits={rawUnitsD} flooredUnits={flooredUnits} closeVolume={closeVolume} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}", ctx, pos));
                 return;
             }
 
@@ -443,7 +443,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (!closeResult.IsSuccessful)
             {
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT] PARTIAL CLOSE failed symbol={pos.SymbolName} positionId={pos.Id} direction={pos.TradeType} currentPrice={(IsLong(ctx) ? sym.Bid : sym.Ask)} tp1={ctx.Tp1Price} rawUnits={rawUnitsD} flooredUnits={flooredUnits} closeVolume={closeVolume} min={sym.VolumeInUnitsMin} step={sym.VolumeInUnitsStep}", ctx, pos));
-                GlobalLogger.Log(_bot, "[TP1][FAIL] execution failed");
+                GlobalLogger.Log(_bot, $"[TP1][FAIL] symbol={pos.SymbolName} positionId={pos.Id} volume={closeVolume} error={closeResult.Error}");
                 return;
             }
 
@@ -542,17 +542,27 @@ namespace GeminiV26.Instruments.XAUUSD
 
             if (!TryResolveExitSymbol(pos, out var sym, ctx))
             {
-                GlobalLogger.Log(_bot, $"[EXIT][TRAIL][SKIP] reason=resolver_failed symbol={pos.SymbolName} positionId={pos.Id}");
+                if (!ctx.TrailResolverFailedLogged)
+                {
+                    GlobalLogger.Log(_bot, $"[EXIT][TRAIL][SKIP] reason=resolver_failed symbol={pos.SymbolName} positionId={pos.Id}");
+                    ctx.TrailResolverFailedLogged = true;
+                }
                 return;
             }
+            ctx.TrailResolverFailedLogged = false;
 
             // ===== ATR (előre inicializált indikátor!) =====
             double atrPrice = _atr.Result.LastValue;
             if (atrPrice <= 0)
             {
-                GlobalLogger.Log(_bot, $"[EXIT][TRAIL][SKIP] reason=atr_unavailable symbol={pos.SymbolName} positionId={pos.Id}");
+                if (!ctx.TrailAtrUnavailableLogged)
+                {
+                    GlobalLogger.Log(_bot, $"[EXIT][TRAIL][SKIP] reason=atr_unavailable symbol={pos.SymbolName} positionId={pos.Id}");
+                    ctx.TrailAtrUnavailableLogged = true;
+                }
                 return;
             }
+            ctx.TrailAtrUnavailableLogged = false;
 
             // ===== PROFIL SZERINTI ATR SZORZÓ =====
             double atrMult =
@@ -577,9 +587,14 @@ namespace GeminiV26.Instruments.XAUUSD
             // legalább 0.25 ATR előny kell
             if (progressDist < atrPrice * 0.25)
             {
-                GlobalLogger.Log(_bot, $"[EXIT][TRAIL][SKIP] reason=low_progress symbol={pos.SymbolName} positionId={pos.Id}");
+                if (!ctx.TrailLowProgressLogged)
+                {
+                    GlobalLogger.Log(_bot, $"[EXIT][TRAIL][SKIP] reason=low_progress symbol={pos.SymbolName} positionId={pos.Id}");
+                    ctx.TrailLowProgressLogged = true;
+                }
                 return;
             }
+            ctx.TrailLowProgressLogged = false;
 
             // ===== ÚJ SL =====
             double newSl =
@@ -595,9 +610,14 @@ namespace GeminiV26.Instruments.XAUUSD
 
             if (improvePips < _profile.MinTrailImprovePips)
             {
-                GlobalLogger.Log(_bot, $"[EXIT][TRAIL][SKIP] reason=no_improvement symbol={pos.SymbolName} positionId={pos.Id}");
+                if (!ctx.TrailNoImprovementLogged)
+                {
+                    GlobalLogger.Log(_bot, $"[EXIT][TRAIL][SKIP] reason=no_improvement symbol={pos.SymbolName} positionId={pos.Id}");
+                    ctx.TrailNoImprovementLogged = true;
+                }
                 return;
             }
+            ctx.TrailNoImprovementLogged = false;
 
             SafeModify(
                  pos,


### PR DESCRIPTION
### Motivation
- Prevent repeated identical log lines during trailing and TP execution caused by transient resolver/ATR/progress conditions.  
- Record trail-related state and fingerprints in `PositionContext` to make trailing behavior idempotent and easier to debug.  

### Description
- Added new `PositionContext` properties: `TrailLowProgressLogged`, `TrailAtrUnavailableLogged`, `TrailResolverFailedLogged`, and `LastTrailCheckFingerprint` to track trailing log state.  
- In `AdaptiveTrailingEngine`, suppress repeated `atr_unavailable` logs by toggling `TrailAtrUnavailableLogged`, and introduced a `LastTrailCheckFingerprint` to only emit `[TRAIL][CHECK]` when relevant inputs change.  
- In `XauExitManager`, suppress repeated logs for `resolver_failed`, `atr_unavailable`, `low_progress`, and `no_improvement` by setting/clearing the corresponding `Trail*Logged` flags, and updated some TP1 partial-close log messages for clearer reasons and error reporting.  
- Removed several duplicate/verbose log lines and consolidated successful/failed modify/step messages to reduce noise.  

### Testing
- Built the solution and ran the existing automated unit test suite, which completed successfully.  
- Ran the project's CI build checks (compile + unit tests) with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca40a02ed88328817a3f5e5f99003f)