### PR TITLE
Add runtime file sink fan-out and unify log directories

### DIFF
--- a/Core/Analytics/TradeStatsTracker.cs
+++ b/Core/Analytics/TradeStatsTracker.cs
@@ -193,7 +193,7 @@ namespace GeminiV26.Core.Analytics
 
         private void ExportInstrumentStatsToFile(string symbol, InstrumentStats stats)
         {
-            const string basePath = @"C:\Users\Administrator\Documents\GeminiV26\Data\Trades";
+            var basePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "GeminiV26", "Logs", "Trades");
             var instrumentPath = Path.Combine(basePath, symbol);
             Directory.CreateDirectory(instrumentPath);
 
@@ -266,7 +266,7 @@ namespace GeminiV26.Core.Analytics
 
             try
             {
-                const string basePath = @"C:\Users\Administrator\Documents\GeminiV26\Data\Trades";
+                var basePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "GeminiV26", "Logs", "Trades");
                 Directory.CreateDirectory(basePath);
 
                 var safeSymbol = snapshot.Symbol.Trim();

--- a/Core/Logging/GlobalLogger.cs
+++ b/Core/Logging/GlobalLogger.cs
@@ -7,24 +7,32 @@ namespace GeminiV26.Core.Logging
     {
         public static void Log(Robot bot, string msg)
         {
-            if (msg == null)
-                return;
-
-            if (bot != null)
-            {
-                bot.Print(msg);
-                return;
-            }
-
-            Debug.WriteLine(msg);
+            Log(msg, bot);
         }
 
-        public static void Log(string msg)
+        public static void Log(string msg, Robot bot = null)
         {
             if (msg == null)
                 return;
 
-            Debug.WriteLine(msg);
+            if (bot != null)
+                bot.Print(msg);
+            else
+                Debug.WriteLine(msg);
+
+            try
+            {
+                RuntimeFileLogger.Write(msg);
+            }
+            catch
+            {
+                // never break trading
+            }
+        }
+
+        public static void Log(string msg)
+        {
+            Log(msg, null);
         }
 
         public static void Log(object source, string msg)
@@ -33,7 +41,7 @@ namespace GeminiV26.Core.Logging
                 return;
 
             string prefix = source == null ? "[LOG]" : $"[{source.GetType().Name}]";
-            Debug.WriteLine($"{prefix} {msg}");
+            Log($"{prefix} {msg}");
         }
     }
 }

--- a/Core/Logging/RuntimeFileLogger.cs
+++ b/Core/Logging/RuntimeFileLogger.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace GeminiV26.Core.Logging
+{
+    public static class RuntimeFileLogger
+    {
+        private static readonly object Sync = new object();
+
+        public static void Write(string message)
+        {
+            if (message == null)
+                return;
+
+            var utcNow = DateTime.UtcNow;
+            var runtimeDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                "GeminiV26",
+                "Logs",
+                "Runtime");
+
+            Directory.CreateDirectory(runtimeDir);
+
+            var path = Path.Combine(runtimeDir, $"runtime_{utcNow:yyyyMMdd}.log");
+            var line = new StringBuilder()
+                .Append('[')
+                .Append(utcNow.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture))
+                .Append("] ")
+                .Append(message)
+                .AppendLine()
+                .ToString();
+
+            lock (Sync)
+            {
+                File.AppendAllText(path, line);
+            }
+        }
+    }
+}

--- a/Data/BarLogger.cs
+++ b/Data/BarLogger.cs
@@ -45,7 +45,7 @@ namespace GeminiV26.Data
             _baseDir = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
                 "GeminiV26",
-                "Data",
+                "Logs",
                 "Bars",
                 _symbol
             );


### PR DESCRIPTION
### Motivation
- Ensure every runtime log is written both to the existing cTrader/debug sink and to a daily runtime file, while enforcing a unified `Documents/GeminiV26/Logs/` directory structure and keeping all existing logging calls and formats unchanged.

### Description
- Added `Core/Logging/RuntimeFileLogger.cs` implementing a static `RuntimeFileLogger.Write(string message)` that prefixes each line with UTC `[yyyy-MM-dd HH:mm:ss.fff]`, creates `Documents/GeminiV26/Logs/Runtime/`, and appends to `runtime_YYYYMMDD.log` in a thread-safe (`lock`) manner.
- Modified `Core/Logging/GlobalLogger.cs` to route through a new `Log(string msg, Robot bot = null)` overload that preserves `bot.Print(...)` / `Debug.WriteLine(...)` behavior and then calls `RuntimeFileLogger.Write(msg)` wrapped in `try/catch` so file I/O cannot break trading.
- Standardized existing file paths by changing `Data/BarLogger.cs` base dir from `.../Data/Bars/...` to `.../Logs/Bars/...` without touching log content or formats.
- Standardized trade stats outputs in `Core/Analytics/TradeStatsTracker.cs` to write into `.../Logs/Trades/...`, again only changing paths and not file formats or trading logic.

### Testing
- Ran `git diff` to inspect changes to `Core/Logging/GlobalLogger.cs`, `Core/Logging/RuntimeFileLogger.cs`, `Data/BarLogger.cs`, and `Core/Analytics/TradeStatsTracker.cs` and confirmed the intended edits succeeded.
- Ran repository searches (`rg` / `nl`) to verify `RuntimeFileLogger.Write` is invoked and that CSV loggers reference the unified `Logs` paths, with results matching expectations.
- Committed the changes successfully with `git commit` (recorded in the branch commit message).
- Full project build/compile was not executed because no `.sln`/`.csproj` was available in the environment, so a compile-time test could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca441fed7c8328a79199b1b0fca93c)