### PR TITLE
Extend structured logging with position prefixing and per-instance runtime files

### DIFF
--- a/Core/Logging/GlobalLogger.cs
+++ b/Core/Logging/GlobalLogger.cs
@@ -12,17 +12,25 @@ namespace GeminiV26.Core.Logging
 
         public static void Log(string msg, Robot bot = null)
         {
+            Log(msg, bot, null);
+        }
+
+        public static void Log(string msg, Robot bot, string positionId)
+        {
             if (msg == null)
                 return;
 
+            var finalMessage = WithPosition(msg, positionId);
+
             if (bot != null)
-                bot.Print(msg);
+                bot.Print(finalMessage);
             else
-                Debug.WriteLine(msg);
+                Debug.WriteLine(finalMessage);
 
             try
             {
-                RuntimeFileLogger.Write(msg);
+                var instanceName = bot != null ? bot.SymbolName : "GLOBAL";
+                RuntimeFileLogger.Write(finalMessage, instanceName);
             }
             catch
             {
@@ -32,7 +40,7 @@ namespace GeminiV26.Core.Logging
 
         public static void Log(string msg)
         {
-            Log(msg, null);
+            Log(msg, null, null);
         }
 
         public static void Log(object source, string msg)
@@ -42,6 +50,14 @@ namespace GeminiV26.Core.Logging
 
             string prefix = source == null ? "[LOG]" : $"[{source.GetType().Name}]";
             Log($"{prefix} {msg}");
+        }
+
+        public static string WithPosition(string msg, string positionId)
+        {
+            if (msg == null || positionId == null)
+                return msg;
+
+            return $"[POS:{positionId}] {msg}";
         }
     }
 }

--- a/Core/Logging/RuntimeFileLogger.cs
+++ b/Core/Logging/RuntimeFileLogger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -7,19 +8,26 @@ namespace GeminiV26.Core.Logging
 {
     public static class RuntimeFileLogger
     {
-        private static readonly object Sync = new object();
+        private static readonly ConcurrentDictionary<string, object> _fileLocks = new ConcurrentDictionary<string, object>();
 
         public static void Write(string message)
+        {
+            Write(message, null);
+        }
+
+        public static void Write(string message, string instanceName = null)
         {
             if (message == null)
                 return;
 
             var utcNow = DateTime.UtcNow;
+            var normalizedInstanceName = NormalizeInstanceName(instanceName);
             var runtimeDir = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
                 "GeminiV26",
                 "Logs",
-                "Runtime");
+                "Runtime",
+                normalizedInstanceName);
 
             Directory.CreateDirectory(runtimeDir);
 
@@ -32,10 +40,29 @@ namespace GeminiV26.Core.Logging
                 .AppendLine()
                 .ToString();
 
-            lock (Sync)
+            var fileLock = _fileLocks.GetOrAdd(path, _ => new object());
+
+            // TODO Phase 4+: introduce async buffered writer (channel/queue based)
+            // to reduce IO pressure under high-frequency logging (16+ instances)
+            lock (fileLock)
             {
                 File.AppendAllText(path, line);
             }
+        }
+
+        private static string NormalizeInstanceName(string instanceName)
+        {
+            if (string.IsNullOrWhiteSpace(instanceName))
+                return "GLOBAL";
+
+            var cleaned = instanceName.Trim();
+            foreach (var invalidChar in Path.GetInvalidFileNameChars())
+                cleaned = cleaned.Replace(invalidChar.ToString(), string.Empty);
+
+            if (string.IsNullOrWhiteSpace(cleaned))
+                return "GLOBAL";
+
+            return cleaned.ToUpperInvariant();
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Enforce optional position-level tracing by prefixing log messages with a `PositionId` when available to improve trade-level traceability.
- Prevent cross-instrument log collisions by routing runtime logs into per-instance files instead of a single shared runtime file.
- Prepare the codebase for future async/buffered IO optimizations while keeping current synchronous behavior to avoid regressions.

### Description
- Added a new overload `Log(string msg, Robot bot, string positionId)` and routed existing `Log(...)` overloads through it to enforce optional position prefixing centrally while preserving existing call patterns.
- Implemented `WithPosition(string msg, string positionId)` which prefixes messages as `[POS:<id>] ` only when `positionId` is provided and otherwise returns the original message.
- Updated runtime routing to call `RuntimeFileLogger.Write(finalMessage, instanceName)` with `instanceName` derived from `bot.SymbolName` or falling back to `"GLOBAL"` so logs go into `Logs/Runtime/{INSTANCE}/runtime_YYYYMMDD.log`.
- Reworked `RuntimeFileLogger` to provide `Write(string message, string instanceName = null)`, normalize instance names (strip invalid filename chars, uppercase, fallback `GLOBAL`), and use a `ConcurrentDictionary<string, object>` to hold per-file lock objects; also added the requested TODO for future async/buffered writers.

### Testing
- Ran `git diff --check` to validate patch formatting and it passed with no issues.
- Verified repository status with `git status --short` to confirm only intended files were modified before committing and the commit succeeded.
- Created PR metadata via the repository tooling and the make_pr helper completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca464f634c83288e24115b166af6a8)