### PR TITLE
Add single-line end-to-end observability logs for entry → exec → open funnel

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -268,6 +268,7 @@ namespace GeminiV26.Core.Entry
         public TradeDirection RoutedDirection { get; set; } = TradeDirection.None;
         public TradeDirection FinalDirection { get; set; } = TradeDirection.None;
         public bool DirectionDebugLogged { get; set; }
+        public string LastLoggedStateFingerprint { get; set; }
 
         // Finalized snapshot fields (read-only source for audit snapshot generation)
         public int EntryScore { get; set; }

--- a/Core/Risk/PositionSizing/CryptoPositionSizer.cs
+++ b/Core/Risk/PositionSizing/CryptoPositionSizer.cs
@@ -19,21 +19,21 @@ namespace GeminiV26.Core.Risk.PositionSizing
             double rawUnits = riskAmount / slPriceDistance;
             double capUnits = lotCap * bot.Symbol.LotSize;
             double finalUnits = Math.Min(rawUnits, capUnits);
+            string symbol = bot.SymbolName ?? "UNKNOWN";
 
             long normalized =
                 (long)bot.Symbol.NormalizeVolumeInUnits(
                     finalUnits,
                     RoundingMode.Down);
 
-            GlobalLogger.Log(bot, 
-                $"[POSITION SIZER] {bot.SymbolName} " +
-                $"balance={balance:F2} risk%={riskPercent:F3} " +
-                $"riskAmount={riskAmount:F2} slPips={(slPriceDistance / bot.Symbol.PipSize):F2} " +
-                $"rawLots=0.0000 rawUnits={rawUnits:F0} " +
-                $"capUnits={capUnits:F0} normalized={normalized}");
+            GlobalLogger.Log(bot, $"[CRYPTO SIZE RAW] symbol={symbol} balance={balance:0.##} riskPercent={riskPercent:0.###} riskAmount={riskAmount:0.###} slDistance={slPriceDistance:0.########} rawUnits={rawUnits:0.###} capUnits={capUnits:0.###} finalUnits={finalUnits:0.###}");
+            GlobalLogger.Log(bot, $"[CRYPTO SIZE NORMALIZED] symbol={symbol} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} lotSize={bot.Symbol.LotSize}");
 
             if (normalized < bot.Symbol.VolumeInUnitsMin)
+            {
+                GlobalLogger.Log(bot, $"[CRYPTO SIZE ZERO] symbol={symbol} reason=below_min_after_normalization finalUnits={finalUnits:0.###} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} riskPercent={riskPercent:0.###} slDistance={slPriceDistance:0.########}");
                 return 0;
+            }
 
             return normalized;
         }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -701,6 +701,8 @@ namespace GeminiV26.Core
                 }
 
                 _tradeMetaStore.TryGet(pos.Id, out var pendingMeta);
+                string openedEntryType = pctx?.EntryType ?? pendingMeta?.EntryType ?? "UNKNOWN";
+                GlobalLogger.Log(_bot, $"[POSITION][OPEN] symbol={pos.SymbolName ?? _bot.SymbolName} entryType={openedEntryType} positionId={pos.Id}");
                 _logger.OnTradeOpened(BuildLogContext(pos, pendingMeta, pctx: _positionContexts.TryGetValue(pos.Id, out var ctxValue) ? ctxValue : null));
             };
 
@@ -1175,6 +1177,10 @@ namespace GeminiV26.Core
             {
                 StampEntrySourceHtfTrace(_ctx, e);
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][ROUTER_CAND] sym={_bot.SymbolName} type={e?.Type} valid={e?.IsValid} score={e?.Score} dir={e?.Direction} reason={e?.Reason}", _ctx));
+                if (e != null)
+                {
+                    GlobalLogger.Log(_bot, $"[ENTRY][CANDIDATE] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} positionId=NA score={e.Score:0.##} confidence={e.LogicConfidence:0.##} trend={_ctx?.TrendDirection}");
+                }
                 LogHtfFlowStage(_ctx, e, "ENTRY_EVALUATION", "_entryRouter.Evaluate");
                 if (e != null)
                 {
@@ -1333,6 +1339,7 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[TC] ENTRY WINNER {selected.Type} dir={selected.Direction} score={selected.Score}", _ctx));
                 GlobalLogger.Log(_bot, $"[POS ?] [ENTRY] symbol={selected.Symbol ?? _bot.SymbolName} score={selected.Score} direction={selected.Direction}");
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][ROUTED] sym={_bot.SymbolName} type={selected.Type} routedDir={selected.Direction} score={selected.Score}", _ctx));
+                GlobalLogger.Log(_bot, $"[ENTRY][WINNER] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} positionId=NA score={selected.Score:0.##} confidence={selected.LogicConfidence:0.##}");
 
                 if (!PassFinalAcceptance(_ctx, selected))
                 {
@@ -1382,6 +1389,8 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[HTF][PASS] dir={_ctx.ActiveHtfDirection} conf={_ctx.ActiveHtfConfidence:F2}", _ctx));
                 if (_ctx.ActiveHtfDirection == TradeDirection.None)
                     GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[HTF][WARN] Missing HTF snapshot", _ctx));
+                double requestRiskPercent = ResolveExecutionRiskPercent(selected, _ctx);
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][REQUEST] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} positionId=NA score={selected.Score:0.##} riskPercent={requestRiskPercent:0.##}");
 
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][EXEC_PRE] sym={_bot.SymbolName} finalCtxDir={_ctx.FinalDirection}", _ctx));
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][EXEC_CONFIRMED] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}", _ctx));
@@ -2745,9 +2754,16 @@ namespace GeminiV26.Core
             GlobalLogger.Log(_bot, $"[MEM] penalty={recommendedTimingPenalty} source={(ctx.MemoryAssessment != null ? "assessment" : "fallback")}");
             if (recommendedTimingPenalty <= -10)
             {
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(
-                    $"[TIMING BLOCK] penalty={recommendedTimingPenalty}",
-                    ctx));
+                double triggerLateScore = ctx.MemoryAssessment?.TriggerLateScore ?? 0.0;
+                bool overextended = ctx.MemoryAssessment?.IsOverextended ?? false;
+                bool exhausted = ctx.MemoryAssessment?.IsExhaustedContinuation ?? false;
+                string timingFingerprint = $"timing_block:{ctx.Symbol}:{eval.Type}:{eval.Score}:{recommendedTimingPenalty}:{triggerLateScore:0.###}:{overextended}:{exhausted}";
+                if (!string.Equals(ctx.LastLoggedStateFingerprint, timingFingerprint, StringComparison.Ordinal))
+                {
+                    ctx.LastLoggedStateFingerprint = timingFingerprint;
+                    GlobalLogger.Log(_bot, $"[TIMING BLOCK] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} positionId=NA score={eval.Score:0.##} penalty={recommendedTimingPenalty} triggerLateScore={triggerLateScore:0.###} overextended={overextended.ToString().ToLowerInvariant()} exhausted={exhausted.ToString().ToLowerInvariant()}");
+                    GlobalLogger.Log(_bot, $"[ENTRY][FINAL][BLOCK] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} positionId=NA score={eval.Score:0.##} reason=timing_block penalty={recommendedTimingPenalty}");
+                }
                 return false;
             }
 
@@ -2813,7 +2829,27 @@ namespace GeminiV26.Core
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(
                 $"[FINAL][PASS] {symbol} {eval.Type} {eval.Direction} score={eval.Score} trend={ctx.TrendDirection} conf={ctx.LogicBiasConfidence}",
                 ctx));
+            GlobalLogger.Log(_bot, $"[ENTRY][FINAL][PASS] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} positionId=NA score={eval.Score:0.##} penalty={recommendedTimingPenalty}");
             return true;
+        }
+
+        private double ResolveExecutionRiskPercent(EntryEvaluation selected, EntryContext ctx)
+        {
+            if (selected == null || ctx == null)
+                return 0;
+
+            int logic = PositionContext.ClampRiskConfidence(Math.Max(0, ctx.LogicBiasConfidence));
+            int entryScore = PositionContext.ClampRiskConfidence(selected.Score);
+            int final = PositionContext.ComputeFinalConfidenceValue(entryScore, logic);
+            int adjusted = PositionContext.ClampRiskConfidence(final);
+            string symbol = (ctx.Symbol ?? _bot.SymbolName ?? string.Empty).ToUpperInvariant();
+
+            if (symbol == "BTCUSD")
+                return _btcUsdRiskSizer?.GetRiskPercent(adjusted) ?? 0;
+            if (symbol == "ETHUSD")
+                return _ethUsdRiskSizer?.GetRiskPercent(adjusted) ?? 0;
+
+            return 0;
         }
 
         private static bool HasStrongStructure(EntryContext ctx, TradeDirection direction)

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -51,12 +51,14 @@ namespace GeminiV26.Instruments.BTCUSD
             if (entry == null)
             {
                 GlobalLogger.Log(_bot, "[DIR][EXEC_ABORT] Missing entry");
+                GlobalLogger.Log(_bot, "[ENTRY][EXEC][ABORT] symbol=BTCUSD entryType=UNKNOWN positionId=NA reason=missing_entry");
                 return;
             }
 
             if (entryContext == null || entryContext.FinalDirection == TradeDirection.None)
             {
                 GlobalLogger.Log(_bot, "[DIR][EXEC_ABORT] Missing FinalDirection");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=missing_final_direction");
                 return;
             }
 
@@ -136,11 +138,17 @@ namespace GeminiV26.Instruments.BTCUSD
                 CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
+            {
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_sl_distance");
                 return;
+            }
 
             double slPips = slPriceDist / _bot.Symbol.PipSize;
             if (slPips <= 0)
+            {
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_sl_pips");
                 return;
+            }
 
             // =========================================================
             // RISK-BASED VOLUME (CRYPTO POSITION SIZER)
@@ -154,10 +162,8 @@ namespace GeminiV26.Instruments.BTCUSD
 
             if (volumeUnits < _bot.Symbol.VolumeInUnitsMin)
             {
-                GlobalLogger.Log(_bot, 
-                    $"[BTCUSD][EXEC] abort: volume < min " +
-                    $"(vol={volumeUnits}, min={_bot.Symbol.VolumeInUnitsMin})"
-                );
+                GlobalLogger.Log(_bot, $"[BTCUSD][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=volume_below_min volume={volumeUnits} minVolume={_bot.Symbol.VolumeInUnitsMin} riskPercent={riskPercent:0.##} slDistance={slPriceDist:0.########}");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=volume_below_min");
                 return;
             }
 
@@ -185,7 +191,10 @@ namespace GeminiV26.Instruments.BTCUSD
                 Math.Abs(tp2Price - entryPrice) / _bot.Symbol.PipSize;
 
             if (tp2Pips <= 0)
+            {
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_tp_pips");
                 return;
+            }
 
             GlobalLogger.Log(_bot, 
                 $"[BTC RISK] score={entry.Score} logicConf={logicConfidence} RC={adjustedRiskConfidence} FC={ctx.FinalConfidence} " +
@@ -211,11 +220,14 @@ namespace GeminiV26.Instruments.BTCUSD
             {
                 GlobalLogger.Log(_bot, "[BTCUSD][EXEC] ORDER FAILED (TradeResult unsuccessful or Position null)");
                 GlobalLogger.Log(_bot, $"[BTCUSD][EXEC] ORDER FAILED isSuccessful={result.IsSuccessful}");
+                string error = result?.Error.ToString() ?? "unknown";
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][FAIL] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason={error}");
                 return;
             }
 
 
             long posId = result.Position.Id;
+            GlobalLogger.Log(_bot, $"[ENTRY][EXEC][SUCCESS] symbol={result.Position.SymbolName ?? _bot.SymbolName} entryType={entry.Type} positionId={posId}");
             GlobalLogger.Log(_bot, $"[TRADE LINK] tempId={entryContext.TempId} posId={posId} symbol={result.Position.SymbolName}");
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -51,12 +51,14 @@ namespace GeminiV26.Instruments.ETHUSD
             if (entry == null)
             {
                 GlobalLogger.Log(_bot, "[DIR][EXEC_ABORT] Missing entry");
+                GlobalLogger.Log(_bot, "[ENTRY][EXEC][ABORT] symbol=ETHUSD entryType=UNKNOWN positionId=NA reason=missing_entry");
                 return;
             }
 
             if (entryContext == null || entryContext.FinalDirection == TradeDirection.None)
             {
                 GlobalLogger.Log(_bot, "[DIR][EXEC_ABORT] Missing FinalDirection");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=missing_final_direction");
                 return;
             }
 
@@ -136,11 +138,17 @@ namespace GeminiV26.Instruments.ETHUSD
                 CalculateStopLossPriceDistance(adjustedRiskConfidence, entry.Type);
 
             if (slPriceDist <= 0)
+            {
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_sl_distance");
                 return;
+            }
 
             double slPips = slPriceDist / _bot.Symbol.PipSize;
             if (slPips <= 0)
+            {
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_sl_pips");
                 return;
+            }
 
             // =========================================================
             // RISK-BASED VOLUME (CRYPTO POSITION SIZER)
@@ -154,10 +162,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
             if (volumeUnits < _bot.Symbol.VolumeInUnitsMin)
             {
-                GlobalLogger.Log(_bot, 
-                    $"[ETHUSD][EXEC] abort: volume < min " +
-                    $"(vol={volumeUnits}, min={_bot.Symbol.VolumeInUnitsMin})"
-                );
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=volume_below_min");
                 return;
             }
 
@@ -185,7 +190,10 @@ namespace GeminiV26.Instruments.ETHUSD
                 Math.Abs(tp2Price - entryPrice) / _bot.Symbol.PipSize;
 
             if (tp2Pips <= 0)
+            {
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_tp_pips");
                 return;
+            }
 
             GlobalLogger.Log(_bot, 
                 $"[ETH RISK] score={entry.Score} logicConf={logicConfidence} RC={adjustedRiskConfidence} FC={ctx.FinalConfidence} " +
@@ -211,11 +219,14 @@ namespace GeminiV26.Instruments.ETHUSD
             {
                 GlobalLogger.Log(_bot, "[ETHUSD][EXEC] ORDER FAILED (TradeResult unsuccessful or Position null)");
                 GlobalLogger.Log(_bot, $"[ETHUSD][EXEC] ORDER FAILED isSuccessful={result.IsSuccessful}");
+                string error = result?.Error.ToString() ?? "unknown";
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][FAIL] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason={error}");
                 return;
             }
 
 
             long posId = result.Position.Id;
+            GlobalLogger.Log(_bot, $"[ENTRY][EXEC][SUCCESS] symbol={result.Position.SymbolName ?? _bot.SymbolName} entryType={entry.Type} positionId={posId}");
             GlobalLogger.Log(_bot, $"[TRADE LINK] tempId={entryContext.TempId} posId={posId} symbol={result.Position.SymbolName}");
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXEC] order placed volume={volumeUnits}", result.Position.Id, entryContext.TempId));
 


### PR DESCRIPTION
### Motivation
- Provide full end-to-end observability for the entry → execution → open funnel so a trade can be reconstructed from Candidate → Winner → Final → Execution → Open with single-line key=value logs. 
- Keep strictly to logging-only changes, null-safe behavior, and anti-spam/dedupe rules so production behaviour and thresholds are unchanged. 

### Description
- Added `LastLoggedStateFingerprint` to `EntryContext` and dedupe timing-block logs so timing-block messages are emitted once per state fingerprint. 
- Instrumented candidate/winner/final logging in `Core/TradeCore.cs` with single-line `[ENTRY][CANDIDATE]`, `[ENTRY][WINNER]`, `[ENTRY][FINAL][PASS]`, and `[ENTRY][FINAL][BLOCK]` messages and added an `[ENTRY][EXEC][REQUEST]` log (includes resolved riskPercent for BTC/ETH). 
- Enriched `PassFinalAcceptance` timing-block output with `triggerLateScore`, `overextended`, and `exhausted` sourced from `ctx.MemoryAssessment` and protected by the fingerprint dedupe check. 
- Added crypto sizing diagnostics in `Core/Risk/PositionSizing/CryptoPositionSizer.cs` with `[CRYPTO SIZE RAW]`, `[CRYPTO SIZE NORMALIZED]`, and `[CRYPTO SIZE ZERO]` single-line logs. 
- Added execution outcome logs in BTC/ETH executors (`Instruments/BTCUSD/*`, `Instruments/ETHUSD/*`) including `[ENTRY][EXEC][REQUEST]` abort enrichments, `[ENTRY][EXEC][ABORT]`, `[ENTRY][EXEC][FAIL]` (with reason), and `[ENTRY][EXEC][SUCCESS]` (with positionId), plus BTC-specific abort enrichment for volume_below_min. 
- Added `[POSITION][OPEN]` single-line confirmation when broker confirms an open including `symbol`, resolved `entryType`, and `positionId`; preserved null-safety and avoided changing any trading thresholds or control flow. 

### Testing
- Attempted automated build with `dotnet build` but it could not be executed in this environment because `dotnet` is not installed, so a full compile/test run was not possible (build attempt failed). 
- Performed automated static/file verification commands (`rg`, `sed`, `git status`, `git show`) to confirm modified files and inserted log lines, and verified the changes were committed successfully. 
- No runtime behavioral tests were run due to environment limitations; changes are logging-only and were implemented to be null-safe and non-invasive to trading logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca8a7a3910832880493af44d7f5273)