### PR TITLE
Improve logging consistency and reduce noisy duplicate events

### DIFF
--- a/Core/Risk/PositionSizing/CryptoPositionSizer.cs
+++ b/Core/Risk/PositionSizing/CryptoPositionSizer.cs
@@ -9,7 +9,8 @@ namespace GeminiV26.Core.Risk.PositionSizing
             Robot bot,
             double riskPercent,
             double slPriceDistance,
-            double lotCap)
+            double lotCap,
+            bool isExecutionContext = false)
         {
             if (riskPercent <= 0 || slPriceDistance <= 0 || lotCap <= 0)
                 return 0;
@@ -26,12 +27,19 @@ namespace GeminiV26.Core.Risk.PositionSizing
                     finalUnits,
                     RoundingMode.Down);
 
-            GlobalLogger.Log(bot, $"[CRYPTO SIZE RAW] symbol={symbol} balance={balance:0.##} riskPercent={riskPercent:0.###} riskAmount={riskAmount:0.###} slDistance={slPriceDistance:0.########} rawUnits={rawUnits:0.###} capUnits={capUnits:0.###} finalUnits={finalUnits:0.###}");
-            GlobalLogger.Log(bot, $"[CRYPTO SIZE NORMALIZED] symbol={symbol} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} lotSize={bot.Symbol.LotSize}");
+            if (isExecutionContext)
+            {
+                GlobalLogger.Log(bot, $"[CRYPTO SIZE RAW] symbol={symbol} balance={balance:0.##} riskPercent={riskPercent:0.###} riskAmount={riskAmount:0.###} slDistance={slPriceDistance:0.########} rawUnits={rawUnits:0.###} capUnits={capUnits:0.###} finalUnits={finalUnits:0.###}");
+                GlobalLogger.Log(bot, $"[CRYPTO SIZE NORMALIZED] symbol={symbol} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} lotSize={bot.Symbol.LotSize}");
+            }
 
             if (normalized < bot.Symbol.VolumeInUnitsMin)
             {
-                GlobalLogger.Log(bot, $"[CRYPTO SIZE ZERO] symbol={symbol} reason=below_min_after_normalization finalUnits={finalUnits:0.###} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} riskPercent={riskPercent:0.###} slDistance={slPriceDistance:0.########}");
+                if (isExecutionContext)
+                {
+                    GlobalLogger.Log(bot, $"[CRYPTO SIZE ZERO] symbol={symbol} reason=below_min_after_normalization finalUnits={finalUnits:0.###} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} riskPercent={riskPercent:0.###} slDistance={slPriceDistance:0.########}");
+                }
+
                 return 0;
             }
 

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1173,13 +1173,19 @@ namespace GeminiV26.Core
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DBG ENTRY] total candidates={symbolSignals.Count}", _ctx));
 
+            double topCandidateScore = symbolSignals
+                .Where(x => x != null)
+                .Select(x => x.Score)
+                .DefaultIfEmpty(double.MinValue)
+                .Max();
+
             foreach (var e in symbolSignals)
             {
                 StampEntrySourceHtfTrace(_ctx, e);
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][ROUTER_CAND] sym={_bot.SymbolName} type={e?.Type} valid={e?.IsValid} score={e?.Score} dir={e?.Direction} reason={e?.Reason}", _ctx));
-                if (e != null)
+                if (e != null && (e.Score >= 50 || e.Score >= topCandidateScore))
                 {
-                    GlobalLogger.Log(_bot, $"[ENTRY][CANDIDATE] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} positionId=NA score={e.Score:0.##} confidence={e.LogicConfidence:0.##} trend={_ctx?.TrendDirection}");
+                    GlobalLogger.Log(_bot, $"[ENTRY][CANDIDATE] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} score={e.Score:0.##} confidence={e.LogicConfidence:0.##} trend={_ctx?.TrendDirection}");
                 }
                 LogHtfFlowStage(_ctx, e, "ENTRY_EVALUATION", "_entryRouter.Evaluate");
                 if (e != null)
@@ -1339,7 +1345,7 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[TC] ENTRY WINNER {selected.Type} dir={selected.Direction} score={selected.Score}", _ctx));
                 GlobalLogger.Log(_bot, $"[POS ?] [ENTRY] symbol={selected.Symbol ?? _bot.SymbolName} score={selected.Score} direction={selected.Direction}");
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][ROUTED] sym={_bot.SymbolName} type={selected.Type} routedDir={selected.Direction} score={selected.Score}", _ctx));
-                GlobalLogger.Log(_bot, $"[ENTRY][WINNER] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} positionId=NA score={selected.Score:0.##} confidence={selected.LogicConfidence:0.##}");
+                GlobalLogger.Log(_bot, $"[ENTRY][WINNER] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} score={selected.Score:0.##} confidence={selected.LogicConfidence:0.##}");
 
                 if (!PassFinalAcceptance(_ctx, selected))
                 {
@@ -1390,7 +1396,7 @@ namespace GeminiV26.Core
                 if (_ctx.ActiveHtfDirection == TradeDirection.None)
                     GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[HTF][WARN] Missing HTF snapshot", _ctx));
                 double requestRiskPercent = ResolveExecutionRiskPercent(selected, _ctx);
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][REQUEST] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} positionId=NA score={selected.Score:0.##} riskPercent={requestRiskPercent:0.##}");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][REQUEST] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} score={selected.Score:0.##} riskPercent={requestRiskPercent:0.##}");
 
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][EXEC_PRE] sym={_bot.SymbolName} finalCtxDir={_ctx.FinalDirection}", _ctx));
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][EXEC_CONFIRMED] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}", _ctx));
@@ -2761,8 +2767,7 @@ namespace GeminiV26.Core
                 if (!string.Equals(ctx.LastLoggedStateFingerprint, timingFingerprint, StringComparison.Ordinal))
                 {
                     ctx.LastLoggedStateFingerprint = timingFingerprint;
-                    GlobalLogger.Log(_bot, $"[TIMING BLOCK] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} positionId=NA score={eval.Score:0.##} penalty={recommendedTimingPenalty} triggerLateScore={triggerLateScore:0.###} overextended={overextended.ToString().ToLowerInvariant()} exhausted={exhausted.ToString().ToLowerInvariant()}");
-                    GlobalLogger.Log(_bot, $"[ENTRY][FINAL][BLOCK] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} positionId=NA score={eval.Score:0.##} reason=timing_block penalty={recommendedTimingPenalty}");
+                    GlobalLogger.Log(_bot, $"[TIMING BLOCK] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} score={eval.Score:0.##} confidence={ctx.LogicBiasConfidence:0.##} penalty={recommendedTimingPenalty} triggerLateScore={triggerLateScore:0.###} overextended={overextended.ToString().ToLowerInvariant()} exhausted={exhausted.ToString().ToLowerInvariant()}");
                 }
                 return false;
             }
@@ -2829,7 +2834,7 @@ namespace GeminiV26.Core
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(
                 $"[FINAL][PASS] {symbol} {eval.Type} {eval.Direction} score={eval.Score} trend={ctx.TrendDirection} conf={ctx.LogicBiasConfidence}",
                 ctx));
-            GlobalLogger.Log(_bot, $"[ENTRY][FINAL][PASS] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} positionId=NA score={eval.Score:0.##} penalty={recommendedTimingPenalty}");
+            GlobalLogger.Log(_bot, $"[ENTRY][FINAL][PASS] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} score={eval.Score:0.##} penalty={recommendedTimingPenalty}");
             return true;
         }
 

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -51,14 +51,14 @@ namespace GeminiV26.Instruments.BTCUSD
             if (entry == null)
             {
                 GlobalLogger.Log(_bot, "[DIR][EXEC_ABORT] Missing entry");
-                GlobalLogger.Log(_bot, "[ENTRY][EXEC][ABORT] symbol=BTCUSD entryType=UNKNOWN positionId=NA reason=missing_entry");
+                GlobalLogger.Log(_bot, "[ENTRY][EXEC][ABORT] symbol=BTCUSD entryType=UNKNOWN reason=missing_entry");
                 return;
             }
 
             if (entryContext == null || entryContext.FinalDirection == TradeDirection.None)
             {
                 GlobalLogger.Log(_bot, "[DIR][EXEC_ABORT] Missing FinalDirection");
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=missing_final_direction");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=missing_final_direction");
                 return;
             }
 
@@ -139,14 +139,14 @@ namespace GeminiV26.Instruments.BTCUSD
 
             if (slPriceDist <= 0)
             {
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_sl_distance");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=invalid_sl_distance");
                 return;
             }
 
             double slPips = slPriceDist / _bot.Symbol.PipSize;
             if (slPips <= 0)
             {
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_sl_pips");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=invalid_sl_pips");
                 return;
             }
 
@@ -158,12 +158,13 @@ namespace GeminiV26.Instruments.BTCUSD
                 _bot,
                 riskPercent,
                 slPriceDist,
-                _riskSizer.GetLotCap(adjustedRiskConfidence));
+                _riskSizer.GetLotCap(adjustedRiskConfidence),
+                isExecutionContext: true);
 
             if (volumeUnits < _bot.Symbol.VolumeInUnitsMin)
             {
-                GlobalLogger.Log(_bot, $"[BTCUSD][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=volume_below_min volume={volumeUnits} minVolume={_bot.Symbol.VolumeInUnitsMin} riskPercent={riskPercent:0.##} slDistance={slPriceDist:0.########}");
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=volume_below_min");
+                GlobalLogger.Log(_bot, $"[BTCUSD][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=volume_below_min volume={volumeUnits} minVolume={_bot.Symbol.VolumeInUnitsMin} riskPercent={riskPercent:0.##} slDistance={slPriceDist:0.########}");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=volume_below_min");
                 return;
             }
 
@@ -192,7 +193,7 @@ namespace GeminiV26.Instruments.BTCUSD
 
             if (tp2Pips <= 0)
             {
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_tp_pips");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=invalid_tp_pips");
                 return;
             }
 
@@ -221,7 +222,7 @@ namespace GeminiV26.Instruments.BTCUSD
                 GlobalLogger.Log(_bot, "[BTCUSD][EXEC] ORDER FAILED (TradeResult unsuccessful or Position null)");
                 GlobalLogger.Log(_bot, $"[BTCUSD][EXEC] ORDER FAILED isSuccessful={result.IsSuccessful}");
                 string error = result?.Error.ToString() ?? "unknown";
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][FAIL] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason={error}");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][FAIL] symbol={_bot.SymbolName} entryType={entry.Type} reason={error}");
                 return;
             }
 

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -51,14 +51,14 @@ namespace GeminiV26.Instruments.ETHUSD
             if (entry == null)
             {
                 GlobalLogger.Log(_bot, "[DIR][EXEC_ABORT] Missing entry");
-                GlobalLogger.Log(_bot, "[ENTRY][EXEC][ABORT] symbol=ETHUSD entryType=UNKNOWN positionId=NA reason=missing_entry");
+                GlobalLogger.Log(_bot, "[ENTRY][EXEC][ABORT] symbol=ETHUSD entryType=UNKNOWN reason=missing_entry");
                 return;
             }
 
             if (entryContext == null || entryContext.FinalDirection == TradeDirection.None)
             {
                 GlobalLogger.Log(_bot, "[DIR][EXEC_ABORT] Missing FinalDirection");
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=missing_final_direction");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=missing_final_direction");
                 return;
             }
 
@@ -139,14 +139,14 @@ namespace GeminiV26.Instruments.ETHUSD
 
             if (slPriceDist <= 0)
             {
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_sl_distance");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=invalid_sl_distance");
                 return;
             }
 
             double slPips = slPriceDist / _bot.Symbol.PipSize;
             if (slPips <= 0)
             {
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_sl_pips");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=invalid_sl_pips");
                 return;
             }
 
@@ -158,11 +158,12 @@ namespace GeminiV26.Instruments.ETHUSD
                 _bot,
                 riskPercent,
                 slPriceDist,
-                _riskSizer.GetLotCap(adjustedRiskConfidence));
+                _riskSizer.GetLotCap(adjustedRiskConfidence),
+                isExecutionContext: true);
 
             if (volumeUnits < _bot.Symbol.VolumeInUnitsMin)
             {
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=volume_below_min");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=volume_below_min");
                 return;
             }
 
@@ -191,7 +192,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
             if (tp2Pips <= 0)
             {
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason=invalid_tp_pips");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=invalid_tp_pips");
                 return;
             }
 
@@ -220,7 +221,7 @@ namespace GeminiV26.Instruments.ETHUSD
                 GlobalLogger.Log(_bot, "[ETHUSD][EXEC] ORDER FAILED (TradeResult unsuccessful or Position null)");
                 GlobalLogger.Log(_bot, $"[ETHUSD][EXEC] ORDER FAILED isSuccessful={result.IsSuccessful}");
                 string error = result?.Error.ToString() ?? "unknown";
-                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][FAIL] symbol={_bot.SymbolName} entryType={entry.Type} positionId=NA reason={error}");
+                GlobalLogger.Log(_bot, $"[ENTRY][EXEC][FAIL] symbol={_bot.SymbolName} entryType={entry.Type} reason={error}");
                 return;
             }
 


### PR DESCRIPTION
### Motivation

- Remove placeholder `positionId=NA` from pre-position logs to avoid misleading entries and preserve real `positionId` only when available.  
- Stop duplicate timing messages by emitting a single fingerprinted `[TIMING BLOCK]` log and removing the redundant `[ENTRY][FINAL][BLOCK]`.  
- Limit noisy or high-frequency logs (candidate listings and crypto sizing) to execution-relevant contexts to reduce log volume and improve signal-to-noise.  
- Add existing `confidence` metadata to timing-block logs without computing new values so the log contains useful context.

### Description

- Files modified: `Core/TradeCore.cs`, `Core/Risk/PositionSizing/CryptoPositionSizer.cs`, `Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs`, and `Instruments/ETHUSD/EthUsdInstrumentExecutor.cs`.  
- Removed `positionId=NA` placeholders from entry-stage logs so pre-position messages no longer contain a fake `positionId` and real `positionId` remains in post-execution/position-open logs (e.g. `ENTRY][EXEC][ABORT]`, `ENTRY][EXEC][FAIL]`, `ENTRY][EXEC][REQUEST]`).  
- Deduplicated timing logs by keeping the fingerprinted `[TIMING BLOCK]` and removing the duplicate `[ENTRY][FINAL][BLOCK]`, and added `confidence={ctx.LogicBiasConfidence}` to the retained timing log using the existing in-scope value.  
- Reduced `[ENTRY][CANDIDATE]` spam by computing `topCandidateScore` and logging candidates only when `e.Score >= 50` or `e.Score >= topCandidateScore`.  
- Scoped crypto sizing logs to execution flows by adding an `isExecutionContext` parameter to `CryptoPositionSizer.Calculate(...)`, guarding the three crypto-size logs with `if (isExecutionContext)`, and passing `isExecutionContext: true` from BTC/ETH executors; the method signature remains backwards-compatible by defaulting the flag to `false`.

### Testing

- Confirmed search-based validations with `rg`/grep to ensure no remaining `positionId=NA` placeholders and that the duplicate `[ENTRY][FINAL][BLOCK]` line was removed.  
- Verified changed call-sites to `CryptoPositionSizer.Calculate(...)` now pass `isExecutionContext: true` from `BTCUSD` and `ETHUSD` executors and that crypto-size logs are guarded by the flag.  
- Attempted to build with `dotnet build` but the container does not have `dotnet` installed so a compile check could not be executed in this environment (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca8eb7de888328983c08b63871fd2d)