### PR TITLE
Cast candidate Score to double to fix LINQ type mismatch in TradeCore

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1175,7 +1175,7 @@ namespace GeminiV26.Core
 
             double topCandidateScore = symbolSignals
                 .Where(x => x != null)
-                .Select(x => x.Score)
+                .Select(x => (double)x.Score)
                 .DefaultIfEmpty(double.MinValue)
                 .Max();
 


### PR DESCRIPTION
### Motivation
- Fix a compile-time type mismatch when computing `topCandidateScore` where `Score` is an `int` but the LINQ fallback used `double.MinValue`, causing generic inference issues and a CS1929-like failure.

### Description
- Cast projected `Score` values to `double` in `Core/TradeCore.cs` by changing `.Select(x => x.Score)` to `.Select(x => (double)x.Score)`, ensuring `DefaultIfEmpty(double.MinValue)` and `Max()` operate on `double`.

### Testing
- Ran `rg -n "DefaultIfEmpty\(double\.MinValue\)" -g '*.cs'` to locate usages and `nl -ba Core/TradeCore.cs | sed -n '1173,1182p'` to inspect the modified region, both commands succeeded; `git commit` succeeded but no `dotnet build` was executed because no `.sln`/`.csproj` entrypoint was present in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9037141883289572a161d8cae7f1)