### PR TITLE
Harden execution-context logging and add candidate fallback logging

### DIFF
--- a/Core/Risk/PositionSizing/CryptoPositionSizer.cs
+++ b/Core/Risk/PositionSizing/CryptoPositionSizer.cs
@@ -10,8 +10,10 @@ namespace GeminiV26.Core.Risk.PositionSizing
             double riskPercent,
             double slPriceDistance,
             double lotCap,
-            bool isExecutionContext = false)
+            bool? isExecutionContext = null)
         {
+            bool execCtx = isExecutionContext ?? false;
+
             if (riskPercent <= 0 || slPriceDistance <= 0 || lotCap <= 0)
                 return 0;
 
@@ -27,7 +29,7 @@ namespace GeminiV26.Core.Risk.PositionSizing
                     finalUnits,
                     RoundingMode.Down);
 
-            if (isExecutionContext)
+            if (execCtx)
             {
                 GlobalLogger.Log(bot, $"[CRYPTO SIZE RAW] symbol={symbol} balance={balance:0.##} riskPercent={riskPercent:0.###} riskAmount={riskAmount:0.###} slDistance={slPriceDistance:0.########} rawUnits={rawUnits:0.###} capUnits={capUnits:0.###} finalUnits={finalUnits:0.###}");
                 GlobalLogger.Log(bot, $"[CRYPTO SIZE NORMALIZED] symbol={symbol} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} lotSize={bot.Symbol.LotSize}");
@@ -35,7 +37,7 @@ namespace GeminiV26.Core.Risk.PositionSizing
 
             if (normalized < bot.Symbol.VolumeInUnitsMin)
             {
-                if (isExecutionContext)
+                if (execCtx)
                 {
                     GlobalLogger.Log(bot, $"[CRYPTO SIZE ZERO] symbol={symbol} reason=below_min_after_normalization finalUnits={finalUnits:0.###} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} riskPercent={riskPercent:0.###} slDistance={slPriceDistance:0.########}");
                 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1173,20 +1173,10 @@ namespace GeminiV26.Core
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DBG ENTRY] total candidates={symbolSignals.Count}", _ctx));
 
-            double topCandidateScore = symbolSignals
-                .Where(x => x != null)
-                .Select(x => (double)x.Score)
-                .DefaultIfEmpty(double.MinValue)
-                .Max();
-
             foreach (var e in symbolSignals)
             {
                 StampEntrySourceHtfTrace(_ctx, e);
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][ROUTER_CAND] sym={_bot.SymbolName} type={e?.Type} valid={e?.IsValid} score={e?.Score} dir={e?.Direction} reason={e?.Reason}", _ctx));
-                if (e != null && (e.Score >= 50 || e.Score >= topCandidateScore))
-                {
-                    GlobalLogger.Log(_bot, $"[ENTRY][CANDIDATE] symbol={e.Symbol ?? _bot.SymbolName} entryType={e.Type} score={e.Score:0.##} confidence={e.LogicConfidence:0.##} trend={_ctx?.TrendDirection}");
-                }
                 LogHtfFlowStage(_ctx, e, "ENTRY_EVALUATION", "_entryRouter.Evaluate");
                 if (e != null)
                 {
@@ -1273,6 +1263,37 @@ namespace GeminiV26.Core
                 // ROUTER
                 // =====================================================
                 var selected = _router.SelectEntry(symbolSignals, _ctx);
+                bool hasWinner = selected != null;
+                double topCandidateScore = symbolSignals
+                    .Where(x => x != null)
+                    .Select(x => (double)x.Score)
+                    .DefaultIfEmpty(double.MinValue)
+                    .Max();
+                var bestCandidate = symbolSignals
+                    .Where(x => x != null)
+                    .OrderByDescending(x => x.Score)
+                    .FirstOrDefault();
+                bool fallbackLogged = false;
+
+                foreach (var candidate in symbolSignals.Where(x => x != null))
+                {
+                    bool isTopRanked = candidate.Score >= topCandidateScore;
+                    bool shouldLogCandidate = isTopRanked || candidate.Score >= 50 || !hasWinner;
+                    if (!shouldLogCandidate)
+                        continue;
+
+                    if (!hasWinner)
+                    {
+                        if (fallbackLogged || !ReferenceEquals(candidate, bestCandidate))
+                            continue;
+
+                        GlobalLogger.Log(_bot, $"[ENTRY][CANDIDATE] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} score={candidate.Score:0.##} confidence={candidate.LogicConfidence:0.##} trend={_ctx?.TrendDirection} fallback=true");
+                        fallbackLogged = true;
+                        continue;
+                    }
+
+                    GlobalLogger.Log(_bot, $"[ENTRY][CANDIDATE] symbol={candidate.Symbol ?? _bot.SymbolName} entryType={candidate.Type} score={candidate.Score:0.##} confidence={candidate.LogicConfidence:0.##} trend={_ctx?.TrendDirection}");
+                }
 
                 GlobalLogger.Log(_bot, $"[TRACE] selected is null = {selected == null}");
                 if (selected != null)


### PR DESCRIPTION
### Motivation
- Prevent logging leakage from CryptoPositionSizer when `isExecutionContext` is missing or misused to avoid logs running outside execution flow.
- Ensure candidate evaluation never produces a silent cycle by emitting at least one candidate log when no winner is selected.
- Preserve all trading logic, thresholds, and routing while tightening logging visibility and safety.

### Description
- Changed `CryptoPositionSizer.Calculate(...)` signature to accept `bool? isExecutionContext = null` and introduced a local `bool execCtx = isExecutionContext ?? false` so the method defaults safely to non-execution context. 
- Gated all crypto sizing logs behind `execCtx`, protecting `[CRYPTO SIZE RAW]`, `[CRYPTO SIZE NORMALIZED]`, and `[CRYPTO SIZE ZERO]` so they only run when explicitly in execution context. 
- Left BTC/ETH call sites intact and verified they explicitly pass `isExecutionContext: true` when invoking `CryptoPositionSizer.Calculate(...)`. 
- Reworked candidate logging in `TradeCore` to compute `hasWinner` and `topCandidateScore`, then log candidates when `isTopRanked || score >= 50 || !hasWinner`, with a `fallback=true` tag and `fallbackLogged` guard to emit only a single fallback log (the best candidate) when no winner exists. 
- Kept all selection, scoring, and execution behavior unchanged; only logging conditions and tags were modified.

### Testing
- Searched and inspected occurrences with `rg`/`sed` to verify changes and call sites, including `rg -n "CryptoPositionSizer|isExecutionContext|\[CRYPTO SIZE RAW\]|\[ENTRY\]\[CANDIDATE\]"`, and confirmed BTC/ETH executor calls pass `isExecutionContext: true`; these checks succeeded. 
- Verified modified files with `git status --short` and committed the changes (`861fff5`), confirming a clean working tree; the commit succeeded. 
- No unit test suite was present or executed; verification was limited to automated repository searches and file inspections which all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca90fb3ce083289be45326aa964d18)