### PR TITLE
Fix broken multiline interpolated log strings in instrument executors

### DIFF
--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -273,11 +273,12 @@ namespace GeminiV26.Instruments.AUDNZD
             // ✅ Kanonikus FinalConfidence (70/30)
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -275,11 +275,12 @@ namespace GeminiV26.Instruments.AUDUSD
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -281,11 +281,12 @@ namespace GeminiV26.Instruments.BTCUSD
                 adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                              TrailingMode.Tight;
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -279,11 +279,12 @@ namespace GeminiV26.Instruments.ETHUSD
                 adjustedRiskConfidence >= 75 ? TrailingMode.Normal :
                                              TrailingMode.Tight;
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -275,11 +275,12 @@ namespace GeminiV26.Instruments.EURJPY
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -267,11 +267,12 @@ namespace GeminiV26.Instruments.EURUSD
             // ✅ 1 sor, safe: kanonikus FinalConfidence kiszámolása (CSV/analytics)
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -275,11 +275,12 @@ namespace GeminiV26.Instruments.GBPJPY
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -276,11 +276,12 @@ namespace GeminiV26.Instruments.GBPUSD
 
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -254,11 +254,12 @@ namespace GeminiV26.Instruments.GER40
 
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -263,11 +263,12 @@ namespace GeminiV26.Instruments.NAS100
 
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -275,11 +275,12 @@ namespace GeminiV26.Instruments.NZDUSD
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -243,11 +243,12 @@ namespace GeminiV26.Instruments.US30
 
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -275,11 +275,12 @@ namespace GeminiV26.Instruments.USDCAD
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -275,11 +275,12 @@ namespace GeminiV26.Instruments.USDCHF
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -268,11 +268,12 @@ namespace GeminiV26.Instruments.USDJPY
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -343,11 +343,12 @@ namespace GeminiV26.Instruments.XAUUSD
             // =====================================================
             // 10 REGISTER CONTEXT
             // =====================================================
-            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}
-volumeUnits={ctx.EntryVolumeInUnits:0.##}
-entryPrice={ctx.EntryPrice:0.#####}
-sl={result.Position.StopLoss}
-tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
+                $"[ENTRY][EXEC][SUCCESS] symbol={ctx.Symbol ?? result.Position.SymbolName ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={result.Position.Id} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : (ctx.TempId ?? entryContext.TempId)}\n" +
+                $"volumeUnits={ctx.EntryVolumeInUnits:0.##}\n" +
+                $"entryPrice={ctx.EntryPrice:0.#####}\n" +
+                $"sl={result.Position.StopLoss}\n" +
+                $"tp={result.Position.TakeProfit ?? ctx.Tp2Price}", ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildContextCreate(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildDirectionSnapshot(ctx), ctx, result.Position));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildOpenSnapshot(ctx, result.Position.StopLoss, result.Position.TakeProfit ?? ctx.Tp2Price, ctx.EntryVolumeInUnits), ctx, result.Position));


### PR DESCRIPTION
### Motivation
- Recent changes introduced multiline interpolated log strings that produced C# syntax errors in several instrument executor classes, breaking compilation and logs.
- The intent is to restore valid C# syntax for the `[ENTRY][EXEC][SUCCESS]` logging while keeping log content unchanged.

### Description
- Replaced raw multiline interpolated string literals in the `[ENTRY][EXEC][SUCCESS]` log call with concatenated interpolated string segments that use explicit `\n` escapes across affected files.
- The fix was applied consistently to all instrument executor files under `Instruments/*/*InstrumentExecutor.cs` that contained the broken multiline interpolation (16 files total).
- No runtime logic was changed; only the string construction for the log messages was adjusted to be valid C#.

### Testing
- Attempted `dotnet build -v minimal`, but the environment does not have the .NET SDK installed so the build could not be executed (`dotnet: command not found`).
- Verified the replacements with a code search using `rg` to confirm the `[ENTRY][EXEC][SUCCESS]` log messages now use concatenated interpolated strings with `\n` escapes, and that the expected files were updated (16 files found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caabf9f068832894d471b4476a7d28)