### PR TITLE
Fix TradeCore final entry pass logging for EntryContext

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2852,7 +2852,7 @@ namespace GeminiV26.Core
                 return false;
             }
 
-            GlobalLogger.Log(_bot, $"[ENTRY][FINAL][PASS] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} positionId={ctx.PositionId} pipelineId={ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId} score={eval.Score:0.##} penalty={recommendedTimingPenalty}");
+            GlobalLogger.Log(_bot, $"[ENTRY][FINAL][PASS] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} positionId=0 pipelineId={(ctx?.TempId ?? "NA")} score={eval.Score:0.##} penalty={recommendedTimingPenalty}");
             return true;
         }
 


### PR DESCRIPTION
### Motivation
- Prevent a runtime/compile issue and incorrect log output caused by referencing a non-existent `EntryContext.PositionId` in the final entry pass log.

### Description
- Replace the problematic interpolated log in `Core/TradeCore.cs` to log `positionId=0` and use a null-safe pipeline id expression `(ctx?.TempId ?? "NA")`, with proper parenthesization to keep the interpolation valid.

### Testing
- Applied the targeted patch and verified the updated line with `nl -ba Core/TradeCore.cs | sed -n '2848,2862p'` and `rg` checks which confirmed the change succeeded; project discovery with `rg --files -g '*.sln' -g '*.csproj'` found no `.sln`/`.csproj` files so no `dotnet build` was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caae2772808328a19f3a275fdc3aed)