### PR TITLE
Fix C# interpolation syntax in instrument executors

### DIFF
--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -294,13 +294,13 @@ namespace GeminiV26.Instruments.AUDNZD
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[AUDNZD EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
                 $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -296,13 +296,13 @@ namespace GeminiV26.Instruments.AUDUSD
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[AUDUSD EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
                 $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -311,13 +311,13 @@ namespace GeminiV26.Instruments.BTCUSD
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[BTCUSD][EXEC] OPEN {tradeType} " +
                 $"vol={ctx.EntryVolumeInUnits} FC={ctx.FinalConfidence}", ctx));

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -309,13 +309,13 @@ namespace GeminiV26.Instruments.ETHUSD
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[ETHUSD][EXEC] OPEN {tradeType} " +
                 $"vol={ctx.EntryVolumeInUnits} FC={ctx.FinalConfidence}", ctx));

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -296,13 +296,13 @@ namespace GeminiV26.Instruments.EURJPY
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[EURJPY EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
                 $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -288,13 +288,13 @@ namespace GeminiV26.Instruments.EURUSD
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[EUR EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
                 $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -296,13 +296,13 @@ namespace GeminiV26.Instruments.GBPJPY
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[GBPJPY EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
                 $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -303,10 +303,10 @@ namespace GeminiV26.Instruments.GBPUSD
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[POSITION][OPEN] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} entryPrice={ctx.EntryPrice}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -281,10 +281,10 @@ namespace GeminiV26.Instruments.GER40
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[POSITION][OPEN] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} entryPrice={ctx.EntryPrice}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int confidence, EntryType entryType)

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -290,10 +290,10 @@ namespace GeminiV26.Instruments.NAS100
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[POSITION][OPEN] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} entryPrice={ctx.EntryPrice}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -296,13 +296,13 @@ namespace GeminiV26.Instruments.NZDUSD
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[NZDUSD EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
                 $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -270,10 +270,10 @@ namespace GeminiV26.Instruments.US30
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[POSITION][OPEN] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} entryPrice={ctx.EntryPrice}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -296,13 +296,13 @@ namespace GeminiV26.Instruments.USDCAD
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[USDCAD EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
                 $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -296,13 +296,13 @@ namespace GeminiV26.Instruments.USDCHF
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[USDCHF EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
                 $"score={entry.Score} SLpips={slPips:F1} TP2={tp2Price:F5}", ctx));

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -295,10 +295,10 @@ namespace GeminiV26.Instruments.USDJPY
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[POSITION][OPEN] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={ctx.EntryType} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} entryPrice={ctx.EntryPrice}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
         }
 
         private double CalculateStopLossPriceDistance(int score, EntryType entryType)

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -374,13 +374,13 @@ namespace GeminiV26.Instruments.XAUUSD
 
                 $"[POSITION][CONTEXT] symbol={ctx.Symbol ?? _bot.SymbolName} positionId={ctx.PositionId} pipelineId={(ctx.PositionId > 0 ? ctx.PositionId.ToString() : ctx.TempId)} " +
 
-                $"entryType={ctx.EntryType ?? \"NA\"} side={(result?.Position != null ? result.Position.TradeType.ToString() : \"NA\")} entryPrice={ctx.EntryPrice:0.#####} " +
+                $"entryType={ctx.EntryType ?? "NA"} side={(result?.Position != null ? result.Position.TradeType.ToString() : "NA")} entryPrice={ctx.EntryPrice:0.#####} " +
 
                 $"sl={(result?.Position?.StopLoss ?? 0):0.#####} tp1={(ctx.Tp1Price ?? 0):0.#####} tp2={(ctx.Tp2Price ?? 0):0.#####} " +
 
                 $"riskPct={riskPercent:F2} confidence={ctx.FinalConfidence:F2} " +
 
-                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : \"NA\")}", ctx));
+                $"htfState={(entryContext != null ? entryContext.ActiveHtfDirection.ToString() : "NA")}", ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
                 $"[XAU EXEC] OPEN {tradeType} vol={ctx.EntryVolumeInUnits} " +
                 $"FC={ctx.FinalConfidence} fill={ctx.EntryPrice:F2} " +


### PR DESCRIPTION
### Motivation
- A recent change introduced invalid escaping inside C# interpolated strings in instrument executor logs, which breaks parsing/compilation (e.g. CS8967 and related syntax errors). 
- The goal is to restore valid interpolation so the codebase can compile and logging snapshots render correctly.

### Description
- Replaced escaped string literal sequences inside interpolated expressions (`\"NA\"`) with a valid C# literal (`"NA"`).
- Applied the correction consistently across 16 instrument executor files under `Instruments/*/*InstrumentExecutor.cs` to fix the logging context interpolations.
- Changes only touch logging string interpolations and do not alter runtime logic or trade behavior.

### Testing
- Ran `git diff --check` and it passed.
- Verified with `rg -n '\\"NA\\"' Instruments -g '*.cs'` that no invalid-escaped occurrences remain.
- Attempted `dotnet build -v minimal` but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab10bf4c08328824eeb442a7daffc)