### PR TITLE
Tune final timing gate and add timing decision overrides and logs

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2778,17 +2778,44 @@ namespace GeminiV26.Core
                 return false;
 
             int recommendedTimingPenalty = ctx.MemoryAssessment?.RecommendedTimingPenalty ?? ctx.MemoryTimingPenalty;
+            double triggerLateScore = ctx.MemoryTriggerLateScore;
+            bool overextended = ctx.MemoryAssessment?.IsOverextendedMove ?? false;
+            bool exhausted = ctx.MemoryAssessment?.IsExhaustedContinuation ?? false;
+            const int timingBlockThreshold = -20;
+
+            double timingMultiplier = 1.0 + (recommendedTimingPenalty / 100.0);
+            timingMultiplier = Math.Max(0.5, Math.Min(1.0, timingMultiplier));
+            double adjustedConfidence = ctx.LogicBiasConfidence * timingMultiplier;
+
             GlobalLogger.Log(_bot, $"[MEM] penalty={recommendedTimingPenalty} source={(ctx.MemoryAssessment != null ? "assessment" : "fallback")}");
-            if (recommendedTimingPenalty <= -10)
+
+            bool timingOverride = false;
+            string timingOverrideReason = "none";
+            bool timingBlocked = recommendedTimingPenalty <= timingBlockThreshold;
+
+            if (eval.Score >= 70 && recommendedTimingPenalty > timingBlockThreshold)
             {
-                double triggerLateScore = ctx.MemoryTriggerLateScore;
-                bool overextended = ctx.MemoryAssessment?.IsOverextendedMove ?? false;
-                bool exhausted = ctx.MemoryAssessment?.IsExhaustedContinuation ?? false;
+                timingOverride = true;
+                timingOverrideReason = "high_score_override";
+            }
+
+            if (timingBlocked && (overextended || exhausted) && eval.Score >= 75)
+            {
+                timingOverride = true;
+                timingOverrideReason = "strong_score_overext_exhaust_override";
+                timingBlocked = false;
+            }
+
+            string timingDecision = timingBlocked ? "block" : "allow";
+            GlobalLogger.Log(_bot, $"[TIMING DECISION] symbol={ctx.Symbol ?? _bot.SymbolName} score={eval.Score:0.##} penalty={recommendedTimingPenalty} threshold={timingBlockThreshold} override={timingOverride.ToString().ToLowerInvariant()} overextended={overextended.ToString().ToLowerInvariant()} exhausted={exhausted.ToString().ToLowerInvariant()} finalDecision={timingDecision} reason={timingOverrideReason} adjustedConfidence={adjustedConfidence:0.##}");
+
+            if (timingBlocked)
+            {
                 string timingFingerprint = $"timing_block:{ctx.Symbol}:{eval.Type}:{eval.Score}:{recommendedTimingPenalty}:{triggerLateScore:0.###}:{overextended}:{exhausted}";
                 if (!string.Equals(ctx.LastLoggedStateFingerprint, timingFingerprint, StringComparison.Ordinal))
                 {
                     ctx.LastLoggedStateFingerprint = timingFingerprint;
-                    GlobalLogger.Log(_bot, $"[TIMING BLOCK] stage=final_acceptance symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} score={eval.Score:0.##} confidence={ctx.LogicBiasConfidence:0.##} penalty={recommendedTimingPenalty} triggerLateScore={triggerLateScore:0.###} overextended={overextended.ToString().ToLowerInvariant()} exhausted={exhausted.ToString().ToLowerInvariant()}");
+                    GlobalLogger.Log(_bot, $"[TIMING BLOCK] stage=final_acceptance symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} score={eval.Score:0.##} confidence={ctx.LogicBiasConfidence:0.##} adjustedConfidence={adjustedConfidence:0.##} penalty={recommendedTimingPenalty} triggerLateScore={triggerLateScore:0.###} overextended={overextended.ToString().ToLowerInvariant()} exhausted={exhausted.ToString().ToLowerInvariant()} threshold={timingBlockThreshold}");
                 }
                 return false;
             }


### PR DESCRIPTION
### Motivation
- Reduce over‑aggressive timing blocking at final acceptance while preserving clear protection against very late entries. 
- Make a minimal, localized change limited to timing/final acceptance logic and add logs for before/after comparison. 

### Description
- Change hard timing block threshold in `PassFinalAcceptance(...)` from `recommendedTimingPenalty <= -10` to `recommendedTimingPenalty <= -20` via `timingBlockThreshold = -20`.
- Add a high‑quality setup override where `eval.Score >= 70 && recommendedTimingPenalty > timingBlockThreshold` is recorded as a `high_score_override` and logged (does not change other gates).
- Soften overextended/exhausted hard blocks by allowing entries when `timingBlocked && (overextended || exhausted) && eval.Score >= 75` and record reason `strong_score_overext_exhaust_override`.
- Compute a safe `adjustedConfidence = ctx.LogicBiasConfidence * timingMultiplier` with `timingMultiplier = 1 + penalty/100.0` clamped to `[0.5,1.0]` for observability only, and add a consolidated `[TIMING DECISION]` log and enriched `[TIMING BLOCK]` log including `adjustedConfidence` and `threshold`.
- Changes are intentionally confined to timing/final acceptance logic and do not alter the immutable final confidence pipeline or other code paths.

### Testing
- Attempted `dotnet build` in this environment but the `dotnet` CLI is not installed, so compile validation could not be executed here (build not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab21a12fc83288dfb397f889b41d6)