### PR TITLE
Add XAU counter-HTF entry protection filter

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2831,6 +2831,41 @@ namespace GeminiV26.Core
             string symbol = ctx.Symbol ?? _bot.SymbolName;
             bool isLong = eval.Direction == TradeDirection.Long;
             bool isShort = eval.Direction == TradeDirection.Short;
+            string canonicalSymbol = SymbolRouting.NormalizeSymbol(symbol);
+            TradeDirection htfDirection = ResolveHtfAllowedDirection(ctx);
+            TradeDirection candidateDirection = eval.Direction;
+            bool structureAligned = eval.HasStrongStructure;
+            int scoreBeforeXauCounterFilter = eval.Score;
+            int scoreAfterXauCounterFilter = eval.Score;
+
+            bool isCounterHTF =
+                (htfDirection == TradeDirection.Long && candidateDirection == TradeDirection.Short) ||
+                (htfDirection == TradeDirection.Short && candidateDirection == TradeDirection.Long);
+
+            if (canonicalSymbol == "XAUUSD" && isCounterHTF)
+            {
+                if (!structureAligned)
+                {
+                    string reason = "xau_counter_htf_structure_fail";
+                    GlobalLogger.Log(_bot,
+                        $"[XAU FILTER] symbol=XAUUSD entryType={eval.Type} scoreBefore={scoreBeforeXauCounterFilter} scoreAfter={scoreAfterXauCounterFilter} " +
+                        $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} decision=block reason={reason}");
+                    return false;
+                }
+
+                if (scoreAfterXauCounterFilter < 65)
+                {
+                    string reason = "xau_counter_htf_block";
+                    GlobalLogger.Log(_bot,
+                        $"[XAU FILTER] symbol=XAUUSD entryType={eval.Type} scoreBefore={scoreBeforeXauCounterFilter} scoreAfter={scoreAfterXauCounterFilter} " +
+                        $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} decision=block reason={reason}");
+                    return false;
+                }
+
+                GlobalLogger.Log(_bot,
+                    $"[XAU FILTER] symbol=XAUUSD entryType={eval.Type} scoreBefore={scoreBeforeXauCounterFilter} scoreAfter={scoreAfterXauCounterFilter} " +
+                    $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} decision=allow reason=pass");
+            }
 
             if ((isLong && ctx.IsOverextendedLong) ||
                 (isShort && ctx.IsOverextendedShort))


### PR DESCRIPTION
### Motivation

- Prevent weak counter-HTF entries on XAUUSD by applying stricter entry filtering when a candidate direction conflicts with the HTF bias, while keeping the change strictly scoped to entry filtering and XAU only.

### Description

- Added counter-HTF detection in `PassFinalAcceptance` by computing `htfDirection` vs `candidateDirection` and `isCounterHTF` for the candidate. 
- Inserted an `XAUUSD`-only protection block that hard-rejects counter-HTF candidates when `structureAligned == false` with reason `xau_counter_htf_structure_fail`. 
- Hard-rejects counter-HTF candidates for XAUUSD when score < 65 with reason `xau_counter_htf_block`, otherwise allows and continues. 
- Added dedicated `[XAU FILTER]` logging including `symbol`, `entryType`, `scoreBefore`, `scoreAfter`, `htfDirection`, `candidateDirection`, `structureAligned`, `decision`, and `reason`, and kept all logic local to `Core/TradeCore.cs`.

### Testing

- Ran a whitespace/diff sanity check with `git diff --check` which succeeded. 
- Verified repository status with `git status --short` and committed the change via `git commit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab5e3699c832892ecfc5a02296352)