### PR TITLE
Refine XAU counter-HTF final acceptance gating

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2849,22 +2849,31 @@ namespace GeminiV26.Core
                     string reason = "xau_counter_htf_structure_fail";
                     GlobalLogger.Log(_bot,
                         $"[XAU FILTER] symbol=XAUUSD entryType={eval.Type} scoreBefore={scoreBeforeXauCounterFilter} scoreAfter={scoreAfterXauCounterFilter} " +
-                        $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} decision=block reason={reason}");
+                        $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} timingPenalty={recommendedTimingPenalty} isCounterHTF={isCounterHTF.ToString().ToLowerInvariant()} decision=block reason={reason}");
                     return false;
                 }
 
-                if (scoreAfterXauCounterFilter < 65)
+                if (recommendedTimingPenalty <= -10)
                 {
-                    string reason = "xau_counter_htf_block";
+                    string reason = "xau_counter_htf_timing_conflict";
                     GlobalLogger.Log(_bot,
                         $"[XAU FILTER] symbol=XAUUSD entryType={eval.Type} scoreBefore={scoreBeforeXauCounterFilter} scoreAfter={scoreAfterXauCounterFilter} " +
-                        $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} decision=block reason={reason}");
+                        $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} timingPenalty={recommendedTimingPenalty} isCounterHTF={isCounterHTF.ToString().ToLowerInvariant()} decision=block reason={reason}");
+                    return false;
+                }
+
+                if (scoreAfterXauCounterFilter < 80)
+                {
+                    string reason = "xau_counter_htf_low_score";
+                    GlobalLogger.Log(_bot,
+                        $"[XAU FILTER] symbol=XAUUSD entryType={eval.Type} scoreBefore={scoreBeforeXauCounterFilter} scoreAfter={scoreAfterXauCounterFilter} " +
+                        $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} timingPenalty={recommendedTimingPenalty} isCounterHTF={isCounterHTF.ToString().ToLowerInvariant()} decision=block reason={reason}");
                     return false;
                 }
 
                 GlobalLogger.Log(_bot,
                     $"[XAU FILTER] symbol=XAUUSD entryType={eval.Type} scoreBefore={scoreBeforeXauCounterFilter} scoreAfter={scoreAfterXauCounterFilter} " +
-                    $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} decision=allow reason=pass");
+                    $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} timingPenalty={recommendedTimingPenalty} isCounterHTF={isCounterHTF.ToString().ToLowerInvariant()} decision=allow reason=pass");
             }
 
             if ((isLong && ctx.IsOverextendedLong) ||


### PR DESCRIPTION
### Motivation

- Reduce risky counter-HTF XAUUSD entries by disallowing weak/medium setups and honoring timing conflicts. 
- Enforce a strict decision order for XAU counter-HTF checks so structure, timing, and score are validated in sequence. 
- Preserve global architecture, scoring, timing systems, and all non-XAU behavior while improving the XAU-specific final gate.

### Description

- Tightened the XAU counter-HTF score gate in `PassFinalAcceptance` from `score < 65` to `score < 80` and changed the block reason to `xau_counter_htf_low_score`.
- Added a timing conflict block `recommendedTimingPenalty <= -10` with reason `xau_counter_htf_timing_conflict`, placed after the structure check and before the score check.
- Enforced exact sequence for counter-HTF XAU checks: first block on `!structureAligned` (reason `xau_counter_htf_structure_fail`), then block on timing conflict, then block on low score, otherwise allow.
- Extended the `[XAU FILTER]` log lines in the XAU branch to include `timingPenalty=` and `isCounterHTF=` and kept all changes confined to `Core/TradeCore.cs` within the XAU-specific branch.

### Testing

- Ran repository searches with `rg` to locate the XAU gate and related symbols, which returned the expected `PassFinalAcceptance` locations and XAU log lines. (succeeded)
- Reviewed the changes with `git diff -- Core/TradeCore.cs` and confirmed only the intended XAU branch was modified. (succeeded)
- Verified working tree status with `git status --short` and committed the change with `git commit`, which completed successfully. (succeeded)
- No test-suite or unit/integration tests were available or executed in the repository during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab81e2aa083289360dd8bccfa03ba)