### PR TITLE
Add XAUUSD TP1 distance and restart-state audit reports (2026-03-30)

### DIFF
--- a/Documentation/xau_tp1_audit_2026-03-30.md
+++ b/Documentation/xau_tp1_audit_2026-03-30.md
@@ -1,0 +1,72 @@
+# XAUUSD TP1 Distance Audit (2026-03-30)
+
+## Scope
+Audited only XAUUSD path: entry -> SL distance -> TP1 price.
+
+## Full calculation path
+
+1. **Executor asks RiskSizer for SL distance**
+   - `slPriceDist = CalculateStopLossPriceDistance(...)`.
+2. **RiskSizer computes SL distance**
+   - Loads M5 bars only for count check (`GetBars(TimeFrame.Minute5)`), but ATR is read from `bot.Indicators.AverageTrueRange(14, Exponential)` (no bars/timeframe argument).
+   - Formula: `slDistance = atr * atrMult + 0.25`.
+3. **Executor converts distance to SL pips and sends market order**
+   - `slPips = slPriceDist / Symbol.PipSize` and passes it to `ExecuteMarketOrder`.
+4. **Executor finalizes TP1 from fill price and realized SL distance**
+   - `rDist = abs(entryPrice - slPriceActual)`.
+   - `tp1Price = entry ± (rDist * tp1R)`.
+5. **TP1R source**
+   - `GetTakeProfit(...)` hard-sets `tp1R = 0.45` for XAUUSD.
+
+## Numeric reconstruction (example)
+Given:
+- `entry = 4516.73`
+- `tp1   = 4515.07`
+
+Derived:
+- `tp1Distance = |4516.73 - 4515.07| = 1.66`
+- If `tp1R = 0.45`, then `slDistance ~= 1.66 / 0.45 = 3.6889`
+
+Back-solving ATR by multiplier branch:
+- If `atrMult = 2.2` -> `atr ~= (3.6889 - 0.25) / 2.2 = 1.5631`
+- If `atrMult = 2.6` -> `atr ~= 1.3227`
+- If `atrMult = 3.0` -> `atr ~= 1.1463`
+
+This is consistent with **small ATR input driving small SL, then small TP1 (0.45R)**.
+
+## Root cause classification
+**A) ATR too small** (primary), driven by ATR source ambiguity/timeframe mismatch.
+
+Why:
+- Code comment says "XAU M5", and M5 bars are fetched, but ATR is not tied to those M5 bars.
+- ATR call omits bars/timeframe, so effective ATR source follows robot/chart context rather than explicit M5.
+- On lower/noisier chart context, ATR can be materially smaller -> SL shrinks -> TP1 shrinks proportionally.
+
+## Additional findings
+
+- **Multiplier branch is not abnormally low**: returns 2.2 / 2.6 / 3.0 only.
+- **TP1 formula itself is correct** (`entry ± rDist*tp1R`).
+- **No obvious XAU pip/tick shrink in TP1 path**: TP1 is computed directly in price space from realized `rDist`, not rounded to pip/tick before check.
+- **Missing safeguards (critical operational gap)**:
+  - No XAU-specific minimum SL distance floor (price units).
+  - No minimum TP1 distance floor.
+  - No ATR sanity floor for XAU before using ATR in SL formula.
+- **Logging gap**:
+  - There is no single mandatory `[SL_CALC]` log containing ATR, timeframe, multiplier, and slDistance together.
+  - There is no single mandatory `[TP_CALC]` log containing tp1R and tp1Distance at entry.
+
+## Repeatability
+Yes, repeatable.
+- Any run where ATR resolves from too-small context can reproduce tight SL/TP1.
+- Because TP1 is fixed at `0.45R`, any SL compression linearly compresses TP1.
+
+## Minimal fix recommendation (no refactor)
+1. Bind ATR calculation explicitly to M5 bars in XAU risk sizing.
+2. Add lightweight guards:
+   - minimum `slDistance` (XAU price units),
+   - minimum `tp1Distance` (derived from `slDistance * tp1R`),
+   - ATR sanity floor for XAU.
+3. Add entry-time audit logs:
+   - `[SL_CALC] symbol, atr, atr_tf, multiplier, slDistance, source`
+   - `[TP_CALC] symbol, tp1R, tp1Price, tp1Distance`
+

--- a/Documentation/xau_tp1_restart_state_audit_2026-03-30.md
+++ b/Documentation/xau_tp1_restart_state_audit_2026-03-30.md
@@ -1,0 +1,104 @@
+# XAUUSD TP1 Restart/State-Loss Audit (2026-03-30)
+
+## 1) Where original SL is set
+
+### Entry-time SL creation
+- XAU executor computes SL distance pre-order, sends SL in pips to broker, then reads actual SL from the filled position:
+  - `slPriceActual = result.Position.StopLoss ?? (entry ± slPriceDist)`
+  - `rDist = abs(entry - slPriceActual)`
+  - `tp1Price = entry ± (rDist * tp1R)`
+
+### What is persisted in `PositionContext`
+- `PositionContext` has `RiskPriceDistance` and `LastStopLossPrice`, but **no immutable `InitialStopLossPrice` field**.
+- In XAU executor finalize block, `ctx.Tp1Price` is stored, but there is no explicit assignment of `ctx.RiskPriceDistance = rDist` and no `ctx.LastStopLossPrice = slPriceActual`.
+
+### Critical status
+- **CRITICAL:** there is no immutable original-SL snapshot field (`InitialStopLossPrice`) in `PositionContext`.
+
+## 2) Where TP1 SL comes from
+
+TP1 path in XAU exit manager:
+- Gets `rDist = GetRiskDistance(pos, ctx)`.
+- `GetRiskDistance` source priority:
+  1. `ctx.RiskPriceDistance`
+  2. `abs(ctx.EntryPrice - ctx.LastStopLossPrice)`
+  3. `abs(pos.EntryPrice - pos.StopLoss)` (live broker position)
+- If `ctx.Tp1Price` already exists, that stored price is used directly.
+- If missing, TP1 is recomputed as `entry ± rDist * tp1R`.
+
+So TP1 SL source is context/broker stop-based distance, **not ATR recomputation** in exit path.
+
+## 3) Restart path behavior
+
+Startup flow:
+- `GeminiV26Bot.OnStart()` calls `_core.RehydrateOpenPositions()`.
+- `TradeCore.RehydrateOpenPositions()` runs `RehydrateService.Run()`.
+- `RehydrateService.TryRebuild(...)` rebuilds context for open positions.
+
+SL restoration on rehydrate:
+- Reads `stopLoss = position.StopLoss` from broker position.
+- Computes `riskDistance = abs(entryPrice - stopLoss)`.
+- Stores both:
+  - `ctx.RiskPriceDistance = riskDistance`
+  - `ctx.LastStopLossPrice = stopLoss`
+
+No ATR-based SL recomputation is done in rehydrate.
+
+## 4) Mismatch evidence (A vs B)
+
+### Definitions
+- A = original SL at entry execution time.
+- B = SL basis used for TP1 distance after restart/missing context.
+
+### Code-level evidence
+- A is available transiently as `slPriceActual` in executor at entry.
+- A is not persisted immutably as `InitialStopLossPrice` in context.
+- After restart, B is rebuilt from **current broker stop** (`position.StopLoss`) via rehydrate.
+
+Therefore, if current broker stop differs from the original entry SL, then `A != B` and TP1 distance can shift.
+
+Important nuance:
+- For normal lifecycle, BE/trailing are TP1-gated, so pre-TP1 SL usually remains original.
+- But code does not enforce immutable original-SL usage for TP1 reconstruction; it relies on mutable stop snapshots.
+
+## 5) Root cause classification
+
+**E) Combination of above**
+- A) Missing initial SL snapshot (immutable field absent).
+- B) Context loss/restart rebuild path exists and repopulates from live position state.
+- D) TP1 reconstruction can use non-original SL source (`position.StopLoss` fallback chain).
+
+Not confirmed:
+- C) No evidence that SL is recomputed from ATR during restart.
+
+## 6) Minimal fix location (no refactor)
+
+1. Add immutable entry SL snapshot field to `PositionContext`:
+- File: `Core/PositionContext.cs`
+- Add `InitialStopLossPrice` (double?) near other SL/risk fields.
+
+2. Set immutable snapshot at entry fill:
+- File: `Instruments/XAUUSD/XauInstrumentExecutor.cs`
+- Where `slPriceActual` and `rDist` are computed, persist:
+  - `ctx.InitialStopLossPrice = slPriceActual`
+  - `ctx.RiskPriceDistance = rDist`
+
+3. TP1 source hardening:
+- File: `Instruments/XAUUSD/XauExitManager.cs`
+- In `GetRiskDistance`, prioritize `InitialStopLossPrice` before mutable fields.
+
+4. Restart-safe restoration:
+- File: `Core/Runtime/RehydrateService.cs`
+- If no stored immutable snapshot exists, restore from broker position SL (already done), and mark source in log.
+
+## 7) Required logging to add (currently missing)
+
+At entry fill:
+- `[SL_SNAPSHOT] symbol=XAUUSD entry=... initialSL=...`
+
+At rehydrate rebuild:
+- `[SL_REBUILD] symbol=XAUUSD source=broker|context|recomputed sl=...`
+
+At TP1 computation:
+- `[TP1_SOURCE] symbol=XAUUSD slUsed=... source=initial_snapshot|risk_distance|last_sl|position_sl`
+


### PR DESCRIPTION
### Motivation
- Add forensic audits documenting why XAUUSD TP1 distances became unexpectedly small and why TP1 can shift after restarts, including root-cause analysis and minimal remediation recommendations.
- Capture reproducible numeric reconstruction and evidence for ATR timeframe ambiguity, missing immutable SL snapshot, and logging gaps to guide low-risk fixes.
- Provide concrete, localized fix recommendations that can be applied without large refactors to harden SL/TP1 behavior for XAUUSD.

### Description
- Add `Documentation/xau_tp1_audit_2026-03-30.md` which traces the full TP1 calculation path, demonstrates numeric reconstruction, identifies ATR timeframe ambiguity as the primary root cause, and recommends binding ATR to M5 plus SL/TP/ATR floors and additional audit logs.
- Add `Documentation/xau_tp1_restart_state_audit_2026-03-30.md` which analyzes restart/rehydration behavior, shows the absence of an immutable `InitialStopLossPrice` in `PositionContext` as a root cause, and recommends adding a snapshot field, persisting it at entry, prioritizing it in `GetRiskDistance`, and improving rehydrate logging.
- Include explicit minimal fix locations and suggested log statements to make remediation actionable without broad refactors.

### Testing
- No automated tests were run because this is a documentation-only change and contains audit reports and remediation recommendations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cabc681a308328b67e06dc1577665e)