### PR TITLE
Anchor XAU TP1 distance to immutable initial SL (prevent TP1 drift)

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -416,6 +416,8 @@ namespace GeminiV26.Core
         /// </summary>
         public double? LastStopLossPrice { get; set; }
 
+        public double? InitialStopLossPrice { get; set; }
+
 
         // =========================
         // Post-TP1 management state

--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -420,6 +420,12 @@ namespace GeminiV26.Core.Runtime
                 RuntimeSymbolAvailable = true
             };
 
+            if (!ctx.InitialStopLossPrice.HasValue && stopLoss != null)
+            {
+                ctx.InitialStopLossPrice = stopLoss;
+                _bot.Print($"[SL_REBUILD] symbol={position.SymbolName} source=broker sl={stopLoss}");
+            }
+
             // AGENTS rule: PositionContext létrehozás után azonnal számoljuk a FinalConfidence-t.
             ctx.ComputeFinalConfidence();
             if (ctx.RuntimeSymbolAvailable)

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -314,6 +314,9 @@ namespace GeminiV26.Instruments.XAUUSD
                     }
                     else
                     {
+                        double slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss ?? 0;
+                        _bot.Print($"[TP1_SOURCE] entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                         tp1Price = IsLong(ctx)
                             ? pos.EntryPrice + rDist * tp1R
                             : pos.EntryPrice - rDist * tp1R;
@@ -657,18 +660,24 @@ namespace GeminiV26.Instruments.XAUUSD
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
-            // 1) Legjobb: ctx.RiskPriceDistance (belépéskori SSOT)
+            // 1) Legjobb: immutable entrykori SL snapshot
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
+            // 2) ctx.RiskPriceDistance (belépéskori SSOT)
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 
-            // 2) Ha nincs: próbáljuk a “kanonikus” SL snapshotot (rehydrate / executor töltheti)
+            // 3) Ha nincs: próbáljuk a “kanonikus” SL snapshotot (rehydrate / executor töltheti)
             if (ctx.LastStopLossPrice.HasValue && ctx.LastStopLossPrice.Value > 0 && ctx.EntryPrice > 0)
             {
                 double d = Math.Abs(ctx.EntryPrice - ctx.LastStopLossPrice.Value);
                 if (d > 0) return d;   // <-- marad double!
             }
 
-            // 3) Végső fallback (nem ideális): entryPrice vs aktuális SL
+            // 4) Végső fallback (nem ideális): entryPrice vs aktuális SL
             // TP1 előtt még oké, TP1 után torzulhat, de TP1 után már Tp1Hit=true
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -339,6 +339,10 @@ namespace GeminiV26.Instruments.XAUUSD
                     : ctx.EntryPrice + slPriceDist);
 
             double rDist = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol=XAUUSD entry={ctx.EntryPrice} initialSL={slPriceActual}");
 
             // --- TP1 (fix R)
             ctx.Tp1Price = tradeType == TradeType.Buy


### PR DESCRIPTION
### Motivation
- TP1 distance could shrink after restart because it was being derived from mutable SL/broker state instead of the original entry SL snapshot.
- The goal is to make TP1 calculation restart-safe by ensuring TP1 distance is anchored to an immutable initial SL captured at entry, with only minimal surgical edits restricted to XAU code paths.

### Description
- Added a new nullable field `InitialStopLossPrice` to `PositionContext` to hold an immutable entry-time SL snapshot.
- In `Instruments/XAUUSD/XauInstrumentExecutor.cs` captured the actual SL at fill and set `ctx.InitialStopLossPrice`, `ctx.RiskPriceDistance`, and `ctx.LastStopLossPrice`, and added a `[SL_SNAPSHOT]` print for visibility.
- In `Instruments/XAUUSD/XauExitManager.cs` changed `GetRiskDistance(...)` priority to prefer `ctx.InitialStopLossPrice` first, then `ctx.RiskPriceDistance`, `ctx.LastStopLossPrice`, and finally live `position.StopLoss`; added a `[TP1_SOURCE]` print when TP1 price is computed to record which SL source was used.
- In `Core/Runtime/RehydrateService.cs` backfilled `ctx.InitialStopLossPrice` from broker `stopLoss` when rebuilding contexts (only when missing) and added a `[SL_REBUILD]` print for auditability.

### Testing
- Attempted a `dotnet build` (`cd /workspace/GeminiV26 && dotnet build`) to validate compilation, but the environment lacks the `dotnet` tool and the build failed with `/bin/bash: line 1: dotnet: command not found`.
- No other automated test suite was available in this environment; textual/grep inspection verified the intended diffs were applied to `Core/PositionContext.cs`, `Instruments/XAUUSD/XauInstrumentExecutor.cs`, `Instruments/XAUUSD/XauExitManager.cs`, and `Core/Runtime/RehydrateService.cs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cac04918448328ba57cb2e54062556)