### PR TITLE
Immutable InitialStopLossPrice snapshot and TP1 source logging for restart-safe R-distance

### DIFF
--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.AUDNZD
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.AUDNZD
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -270,6 +270,13 @@ namespace GeminiV26.Instruments.AUDNZD
                 Tp2Price = tp2Price
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // ✅ Kanonikus FinalConfidence (70/30)
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.AUDUSD
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.AUDUSD
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -272,6 +272,13 @@ namespace GeminiV26.Instruments.AUDUSD
                 Tp2Price = tp2Price
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -295,6 +295,14 @@ namespace GeminiV26.Instruments.BTCUSD
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -571,6 +579,11 @@ namespace GeminiV26.Instruments.BTCUSD
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -282,6 +282,13 @@ namespace GeminiV26.Instruments.BTCUSD
                     ? ctx.EntryPrice + slPriceDist * ctx.Tp1R
                     : ctx.EntryPrice - slPriceDist * ctx.Tp1R;
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // 🔒 FINAL CONFIDENCE
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -280,6 +280,14 @@ namespace GeminiV26.Instruments.ETHUSD
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -501,6 +509,11 @@ namespace GeminiV26.Instruments.ETHUSD
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -280,6 +280,13 @@ namespace GeminiV26.Instruments.ETHUSD
                     ? ctx.EntryPrice + slPriceDist * ctx.Tp1R
                     : ctx.EntryPrice - slPriceDist * ctx.Tp1R;
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // 🔒 FINAL CONFIDENCE
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.EURJPY
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.EURJPY
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -272,6 +272,13 @@ namespace GeminiV26.Instruments.EURJPY
                 Tp2Price = tp2Price
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.EURUSD
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.EURUSD
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -264,6 +264,13 @@ namespace GeminiV26.Instruments.EURUSD
                 Adx_M5 = entryContext.Adx_M5
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // ✅ 1 sor, safe: kanonikus FinalConfidence kiszámolása (CSV/analytics)
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.GBPJPY
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.GBPJPY
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -272,6 +272,13 @@ namespace GeminiV26.Instruments.GBPJPY
                 Tp2Price = tp2Price
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.GBPUSD
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.GBPUSD
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -284,6 +284,13 @@ namespace GeminiV26.Instruments.GBPUSD
                                                 TrailingMode.Tight
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             ctx.ComputeFinalConfidence();
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.GER40
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.GER40
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -262,6 +262,13 @@ namespace GeminiV26.Instruments.GER40
                 RemainingVolumeInUnits = volumeUnits
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             ctx.ComputeFinalConfidence();
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.NAS100
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.NAS100
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -271,6 +271,13 @@ namespace GeminiV26.Instruments.NAS100
                 RemainingVolumeInUnits = volumeUnits
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             ctx.ComputeFinalConfidence();
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.NZDUSD
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.NZDUSD
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -272,6 +272,13 @@ namespace GeminiV26.Instruments.NZDUSD
                 Tp2Price = tp2Price
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.US30
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.US30
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -251,6 +251,13 @@ namespace GeminiV26.Instruments.US30
 
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             ctx.ComputeFinalConfidence();
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.USDCAD
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.USDCAD
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -272,6 +272,13 @@ namespace GeminiV26.Instruments.USDCAD
                 Tp2Price = tp2Price
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.USDCHF
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.USDCHF
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -272,6 +272,13 @@ namespace GeminiV26.Instruments.USDCHF
                 Tp2Price = tp2Price
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -259,6 +259,14 @@ namespace GeminiV26.Instruments.USDJPY
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
 
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
+
                     bool reached =
                         IsLong(ctx)
                             ? sym.Bid >= tp1Price
@@ -444,6 +452,11 @@ namespace GeminiV26.Instruments.USDJPY
 
         private double GetRiskDistance(Position pos, PositionContext ctx)
         {
+            if (ctx.InitialStopLossPrice.HasValue)
+            {
+                return Math.Abs(ctx.EntryPrice - ctx.InitialStopLossPrice.Value);
+            }
+
             if (ctx.RiskPriceDistance > 0)
                 return ctx.RiskPriceDistance;
 

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -275,6 +275,13 @@ namespace GeminiV26.Instruments.USDJPY
                 Adx_M5 = entryContext.Adx_M5
             };
 
+            double slPriceActual = result.Position.StopLoss ??
+                (tradeType == TradeType.Buy ? ctx.EntryPrice - slPriceDist : ctx.EntryPrice + slPriceDist);
+            ctx.InitialStopLossPrice = slPriceActual;
+            ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
+            ctx.LastStopLossPrice = slPriceActual;
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
+
             // ✅ Kanonikus 70/30 FinalConfidence
             ctx.ComputeFinalConfidence();
 

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -314,9 +314,6 @@ namespace GeminiV26.Instruments.XAUUSD
                     }
                     else
                     {
-                        double slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss ?? 0;
-                        _bot.Print($"[TP1_SOURCE] entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
-
                         tp1Price = IsLong(ctx)
                             ? pos.EntryPrice + rDist * tp1R
                             : pos.EntryPrice - rDist * tp1R;
@@ -326,6 +323,14 @@ namespace GeminiV26.Instruments.XAUUSD
 
                     if (ctx.Tp1R <= 0)
                         ctx.Tp1R = tp1R;
+
+                    if (!ctx.InitialStopLossPrice.HasValue)
+                    {
+                        _bot.Print($"[WARN][SL_MISSING] symbol={_bot.SymbolName} fallback path active");
+                    }
+
+                    var slUsed = ctx.InitialStopLossPrice ?? ctx.LastStopLossPrice ?? pos.StopLoss;
+                    _bot.Print($"[TP1_SOURCE] symbol={_bot.SymbolName} entry={ctx.EntryPrice} slUsed={slUsed} source={(ctx.InitialStopLossPrice.HasValue ? "initial" : "fallback")}");
 
                     // ------------------------------------------------
                     // TP1 HIT DETECTION

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -342,7 +342,7 @@ namespace GeminiV26.Instruments.XAUUSD
             ctx.InitialStopLossPrice = slPriceActual;
             ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual);
             ctx.LastStopLossPrice = slPriceActual;
-            _bot.Print($"[SL_SNAPSHOT] symbol=XAUUSD entry={ctx.EntryPrice} initialSL={slPriceActual}");
+            _bot.Print($"[SL_SNAPSHOT] symbol={_bot.SymbolName} entry={ctx.EntryPrice} initialSL={slPriceActual}");
 
             // --- TP1 (fix R)
             ctx.Tp1Price = tradeType == TradeType.Buy


### PR DESCRIPTION
### Motivation
- Prevent TP1 / R-based drift after bot restarts by ensuring TP1 always uses the original entry SL as an immutable, restart-safe source. 
- Keep changes minimal and confined to `PositionContext`, instrument `Executors`, `ExitManagers` and rehydrate logic without altering entry/routing/TradeCore responsibilities.

### Description
- Added the immutable SL field `InitialStopLossPrice` to `PositionContext` and kept `LastStopLossPrice` / `RiskPriceDistance` semantics intact for fallbacks. 
- In every instrument executor, immediately after a successful fill the code snapshots the canonical SL into `ctx.InitialStopLossPrice`, sets `ctx.RiskPriceDistance = Math.Abs(ctx.EntryPrice - slPriceActual)`, updates `ctx.LastStopLossPrice`, and emits a `[SL_SNAPSHOT]` log; the assignment happens before any `ComputeFinalConfidence()` call. 
- Updated all instrument `ExitManager`s so `GetRiskDistance(...)` prioritizes `ctx.InitialStopLossPrice` first, then falls back to `ctx.RiskPriceDistance`, `ctx.LastStopLossPrice`, and finally `position.StopLoss`. 
- Added TP1 source diagnostics to every `ExitManager`: a `[TP1_SOURCE]` log that shows `slUsed` and a `[WARN][SL_MISSING]` log when `InitialStopLossPrice` is absent (fallback path). 
- In `RehydrateService`, if `InitialStopLossPrice` is missing but `stopLoss` is available from the broker, it is set as a fallback and a `[SL_REBUILD]` log is emitted; existing non-overwrite behavior is preserved. 
- Preserved agent rule: `ctx.ComputeFinalConfidence()` remains called immediately after `PositionContext` creation. 

### Testing
- Ran repository-wide text checks to verify every instrument executor contains the `[SL_SNAPSHOT]` snapshot pattern and every exit manager contains the `[TP1_SOURCE]` and `InitialStopLossPrice`-first `GetRiskDistance` logic; the sanity-check script reported no missing occurrences. 
- Ran `rg`/grep counts to confirm the inserted diagnostics are present across instruments (multiple `SL_SNAPSHOT` and `TP1_SOURCE` entries found). 
- Performed scripted validations that all modified files include the new tokens; those checks passed. 
- Full project compilation/run was not performed in this environment because no `.sln`/`.csproj` files were available at repo root, so runtime integration tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cac24e787c8328a1cd77fdc5a1341b)