### PR TITLE
Disable XAU impulse entry and add strict XAU environment gating

### DIFF
--- a/Core/Entry/EntryRouter.cs
+++ b/Core/Entry/EntryRouter.cs
@@ -38,6 +38,12 @@ namespace GeminiV26.Core.Entry
 
                 foreach (var entryType in _entryTypes)
                 {
+                    if (entryType != null && entryType.Type == EntryType.XAU_Impulse)
+                    {
+                        ctx?.Log?.Invoke("[ENTRY BLOCK] XAU Impulse disabled");
+                        continue;
+                    }
+
                     TradeDirection htfAllowedDirection = ctx?.ResolveAssetHtfAllowedDirection() ?? TradeDirection.None;
                     var startClassification = HtfClassificationModel.ComputeHtfClassification(
                         TradeDirection.None,

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -21,6 +21,9 @@ namespace GeminiV26.EntryTypes.METAL
         private const double MinCloseBreakAtr = 0.05;
         private const double HtfAgainstMinBreakAtr = 0.08;
         private const double HtfAgainstMinBody = 0.60;
+        private const double MinRangeThreshold = 0.35;
+        private const double StrongImpulseThreshold = 0.90;
+        private const double StrongBreakoutThreshold = 0.60;
 
         private const int ScoreDeadband = 2;
 
@@ -156,6 +159,19 @@ namespace GeminiV26.EntryTypes.METAL
                     ? ctx.BarsSinceImpulseLong_M5
                     : ctx.BarsSinceImpulseShort_M5;
 
+            bool isAtrCompression = !ctx.IsAtrExpanding_M5;
+            bool isChop =
+                ctx.Adx_M5 < 18.0
+                || isAtrCompression
+                || rangeAtr < MinRangeThreshold
+                || barsSinceImpulse > 5;
+
+            if (isChop)
+            {
+                ctx.Log?.Invoke($"[XAU][CHOP] detected: ADX={ctx.Adx_M5:0.0} atrCompression={isAtrCompression} rangeWidth={rangeAtr:0.00} barsSinceImpulse={barsSinceImpulse}");
+                return InvalidDir(ctx, dir, "XAU chop environment", score);
+            }
+
             if (barsSinceImpulse > tuning.MaxBarsSinceImpulse)
             {
                 score -= 6;
@@ -252,6 +268,12 @@ namespace GeminiV26.EntryTypes.METAL
                 bodyRatio >= 0.45 &&
                 ctx.LastClosedBarInTrendDirection;
 
+            if (earlyBreakout)
+            {
+                ctx.Log?.Invoke("[XAU][EARLY_BREAK] blocked");
+                return InvalidDir(ctx, dir, "Early break", score);
+            }
+
             bool hasConfirmation =
                 breakoutConfirmed
                 || earlyBreakout;
@@ -287,9 +309,27 @@ namespace GeminiV26.EntryTypes.METAL
                 reasons.Add("NO_BREAKOUT");
             }
 
-            bool isAgainst =
-                ctx.ActiveHtfDirection != TradeDirection.None &&
-                ctx.ActiveHtfDirection != dir;
+            bool htfConflict =
+                ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None &&
+                dir != ctx.ResolveAssetHtfAllowedDirection();
+
+            double impulseStrength = ctx.AtrM5 > 0 ? Math.Abs(bar.Close - bar.Open) / ctx.AtrM5 : 0;
+            double breakoutStrength = breakAtr;
+            bool strongLtf =
+                ctx.Adx_M5 > 25.0 &&
+                impulseStrength > StrongImpulseThreshold &&
+                breakoutStrength > StrongBreakoutThreshold;
+
+            if (htfConflict && !strongLtf)
+            {
+                ctx.Log?.Invoke($"[XAU][HTF_CONFLICT] blocked - weak LTF adx={ctx.Adx_M5:0.0} impulse={impulseStrength:0.00} breakout={breakoutStrength:0.00}");
+                return InvalidDir(ctx, dir, "HTF conflict without strong LTF", score);
+            }
+
+            if (htfConflict && strongLtf)
+                ctx.Log?.Invoke($"[XAU][HTF_OVERRIDE] strong LTF allows trade adx={ctx.Adx_M5:0.0} impulse={impulseStrength:0.00} breakout={breakoutStrength:0.00}");
+
+            bool isAgainst = htfConflict;
 
             if (isAgainst)
             {
@@ -351,6 +391,19 @@ namespace GeminiV26.EntryTypes.METAL
 
             if (setupScore <= 0)
                 score = Math.Min(score, minScore - 10);
+
+            bool hasRecentImpulse = barsSinceImpulse <= 5;
+            bool validEnvironment =
+                ctx.Adx_M5 > 22.0 &&
+                hasRecentImpulse &&
+                !isAtrCompression &&
+                rangeAtr > MinRangeThreshold;
+
+            if (!validEnvironment)
+            {
+                ctx.Log?.Invoke($"[XAU][NO_MOVE] blocked adx={ctx.Adx_M5:0.0} hasRecentImpulse={hasRecentImpulse} atrCompression={isAtrCompression} rangeWidth={rangeAtr:0.00}");
+                return InvalidDir(ctx, dir, "No expansion environment", score);
+            }
 
             int effectiveMinScore = earlyBreakout ? minScore - 2 : minScore;
 

--- a/EntryTypes/METAL/XAU_ImpulseEntry.cs
+++ b/EntryTypes/METAL/XAU_ImpulseEntry.cs
@@ -26,45 +26,6 @@ namespace GeminiV26.EntryTypes.METAL
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
-            DirectionDebug.LogOnce(ctx);
-            var matrix = ctx?.SessionMatrixConfig ?? SessionMatrixDefaults.Neutral;
-            if (!matrix.AllowBreakout)
-                return Reject(ctx, "SESSION_MATRIX_BREAKOUT_DISABLED");
-
-            if (ctx == null || !ctx.IsReady || ctx.M5 == null)
-                return Reject(ctx, "CTX_NOT_READY");
-
-            if (ctx.LogicBias == TradeDirection.None)
-                return new EntryEvaluation
-                {
-                    Symbol = ctx?.Symbol,
-                    Type = Type,
-                    Direction = TradeDirection.None,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "NO_LOGIC_BIAS"
-                };
-
-            bool htfMismatch =
-                ctx.ResolveAssetHtfConfidence01() >= 0.6 &&
-                ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None &&
-                ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias;
-            if (htfMismatch)
-                ctx.Log?.Invoke($"[HTF][SOFT_MISMATCH] entryType={Type} dir={ctx.LogicBias} htf={ctx.ResolveAssetHtfAllowedDirection()} conf={ctx.ResolveAssetHtfConfidence01():0.00}");
-
-            if (ctx.LogicBias == TradeDirection.Long)
-            {
-                var eval = EvaluateSide(ctx, matrix, TradeDirection.Long, htfMismatch);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
-                return EntryDecisionPolicy.Normalize(eval);
-            }
-            else if (ctx.LogicBias == TradeDirection.Short)
-            {
-                var eval = EvaluateSide(ctx, matrix, TradeDirection.Short, htfMismatch);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
-                return EntryDecisionPolicy.Normalize(eval);
-            }
-
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
@@ -72,7 +33,7 @@ namespace GeminiV26.EntryTypes.METAL
                 Direction = TradeDirection.None,
                 Score = 0,
                 IsValid = false,
-                Reason = "NO_LOGIC_BIAS"
+                Reason = "XAU Impulse disabled"
             };
         }
         private EntryEvaluation EvaluateSide(EntryContext ctx, SessionMatrixConfig matrix, TradeDirection dir, bool htfMismatch)

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -16,6 +16,9 @@ namespace GeminiV26.EntryTypes.METAL
 
         private const int FreshImpulsePenalty = 6;
         private const int NoM1Penalty = 6;
+        private const double MinRangeThreshold = 0.35;
+        private const double StrongImpulseThreshold = 0.90;
+        private const double StrongBreakoutThreshold = 0.60;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
@@ -95,6 +98,20 @@ namespace GeminiV26.EntryTypes.METAL
                     ? ctx.BarsSinceImpulseLong_M5
                     : ctx.BarsSinceImpulseShort_M5;
 
+            double rangeWidth = ctx.MarketState?.RangeWidth ?? 0.0;
+            bool isAtrCompression = !ctx.IsAtrExpanding_M5;
+            bool isChop =
+                ctx.Adx_M5 < 18.0
+                || isAtrCompression
+                || rangeWidth < MinRangeThreshold
+                || barsSinceImpulse > 5;
+
+            if (isChop)
+            {
+                ctx.Log?.Invoke($"[XAU][CHOP] detected: ADX={ctx.Adx_M5:0.0} atrCompression={isAtrCompression} rangeWidth={rangeWidth:0.00} barsSinceImpulse={barsSinceImpulse}");
+                return InvalidDir(ctx, dir, "XAU chop environment", score);
+            }
+
             if (barsSinceImpulse > 6)
                 return InvalidDir(ctx, dir, "STALE_IMPULSE", score);
 
@@ -132,6 +149,12 @@ namespace GeminiV26.EntryTypes.METAL
                 hasImpulse &&
                 barsSinceImpulse <= 2 &&
                 ctx.LastClosedBarInTrendDirection;
+
+            if (earlyContinuation)
+            {
+                ctx.Log?.Invoke("[XAU][EARLY_BREAK] blocked");
+                return InvalidDir(ctx, dir, "Early break", score);
+            }
 
             // ha early continuation → NEM büntetjük
             if (noPullback)
@@ -233,15 +256,27 @@ namespace GeminiV26.EntryTypes.METAL
             // =========================
             // HTF (soft only)
             // =========================
-            bool against =
-                ctx.ActiveHtfDirection != TradeDirection.None &&
-                ctx.ActiveHtfDirection != dir;
+            bool htfConflict =
+                ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None &&
+                dir != ctx.ResolveAssetHtfAllowedDirection();
 
-            if (against)
+            int lastClosed = ctx.M5.Count - 2;
+            var bar = ctx.M5[lastClosed];
+            double impulseStrength = ctx.AtrM5 > 0 ? Math.Abs(bar.Close - bar.Open) / ctx.AtrM5 : 0;
+            double breakoutStrength = m1 ? 1.0 : 0.0;
+            bool strongLtf =
+                ctx.Adx_M5 > 25.0 &&
+                impulseStrength > StrongImpulseThreshold &&
+                breakoutStrength > StrongBreakoutThreshold;
+
+            if (htfConflict && !strongLtf)
             {
-                score -= 5;
-                reasons.Add("HTF_AGAINST");
+                ctx.Log?.Invoke($"[XAU][HTF_CONFLICT] blocked - weak LTF adx={ctx.Adx_M5:0.0} impulse={impulseStrength:0.00} breakout={breakoutStrength:0.00}");
+                return InvalidDir(ctx, dir, "HTF conflict without strong LTF", score);
             }
+
+            if (htfConflict && strongLtf)
+                ctx.Log?.Invoke($"[XAU][HTF_OVERRIDE] strong LTF allows trade adx={ctx.Adx_M5:0.0} impulse={impulseStrength:0.00} breakout={breakoutStrength:0.00}");
 
             bool hasFlag =
                 dir == TradeDirection.Long
@@ -278,8 +313,6 @@ namespace GeminiV26.EntryTypes.METAL
             if (hasConfirmation)
                 setupScore += 20;
 
-            int lastClosed = ctx.M5.Count - 2;
-            var bar = ctx.M5[lastClosed];
             bool breakoutDetected = breakoutConfirmed || earlyBreakout;
             bool strongCandle =
                 (dir == TradeDirection.Long && bar.Close > bar.Open) ||
@@ -311,6 +344,18 @@ namespace GeminiV26.EntryTypes.METAL
                 score = (int)Math.Round(score * 0.65);
                 ctx.Log?.Invoke(
                     $"[XAU CONTINUATION FILTER] score {scoreBeforeCompression}->{score} momentum={ctx.MarketState.IsMomentum} earlyWeakness={earlyWeakness}");
+            }
+
+            bool validEnvironment =
+                ctx.Adx_M5 > 22.0 &&
+                hasImpulse &&
+                !isAtrCompression &&
+                rangeWidth > MinRangeThreshold;
+
+            if (!validEnvironment)
+            {
+                ctx.Log?.Invoke($"[XAU][NO_MOVE] blocked adx={ctx.Adx_M5:0.0} hasImpulse={hasImpulse} atrCompression={isAtrCompression} rangeWidth={rangeWidth:0.00}");
+                return InvalidDir(ctx, dir, "No expansion environment", score);
             }
 
             bool valid = score >= minScore;


### PR DESCRIPTION
### Motivation

- Reduce low-quality / impulse-driven XAUUSD entries by disabling the Impulse entry and adding stricter environment checks.
- Avoid trades in chop/compression/no-expansion contexts while still allowing HTF-consistent trades when strong LTF momentum exists.
- Implement XAU-scoped checks and logging without modifying orchestration, exits, risk sizing, or global architecture.

### Description

- Router-level block: `EntryRouter` now explicitly skips any `EntryType.XAU_Impulse` with a debug log `[ENTRY BLOCK] XAU Impulse disabled` before evaluation. (`Core/Entry/EntryRouter.cs`).
- Hard-disable impulse entry: `XAU_ImpulseEntry.Evaluate()` now always returns invalid with `Reason = "XAU Impulse disabled"` to ensure it cannot appear in candidate lists. (`EntryTypes/METAL/XAU_ImpulseEntry.cs`).
- XAU chop detector: pullback and flag entry implementations evaluate a chop condition (`ctx.Adx_M5 < 18 || !ctx.IsAtrExpanding_M5 || RangeWidth < MinRangeThreshold || BarsSinceImpulse > 5`) and hard-invalidate with reason `"XAU chop environment"` and log `[XAU][CHOP] ...`. (`EntryTypes/METAL/XAU_PullbackEntry.cs`, `EntryTypes/METAL/XAU_FlagEntry.cs`).
- Early-break hard filter: early continuation/break cases are now hard-rejected with `Reason = "Early break"` and logged via `[XAU][EARLY_BREAK] blocked`. (`XAU_PullbackEntry`, `XAU_FlagEntry`).
- HTF conditional override: when `ResolveAssetHtfAllowedDirection()` conflicts with candidate direction, the entry is blocked only if LTF is not strong; strong-LTF conditions (ADX > 25, measured impulse/breakout strength thresholds) permit an override and log `[XAU][HTF_OVERRIDE] ...`, otherwise log `[XAU][HTF_CONFLICT] blocked - weak LTF` and return invalid. (`XAU_PullbackEntry`, `XAU_FlagEntry`).
- No-move final guard: added a final environment guard (`ctx.Adx_M5 > 22 && hasRecentImpulse && !isAtrCompression && range > MinRangeThreshold`) that rejects entries with reason `"No expansion environment"` and logs `[XAU][NO_MOVE] blocked`. (`XAU_PullbackEntry`, `XAU_FlagEntry`).
- All new conditions include explicit debug logs following existing Gemini logging style and are kept instrument-scoped to XAU files only.

### Testing

- Attempted to run a build with `dotnet build -v minimal`, but the build could not be run in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).
- No automated unit/integration tests were executed in this environment; changes are limited to `EntryRouter` and XAU-specific entry classes and should be validated by CI/build in the normal development environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad29ffa288328b3ce96f16f48c713)