### PR TITLE
Use RangeBreakAtrSize_M5 in XAU pullback to fix compile error

### DIFF
--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -98,7 +98,10 @@ namespace GeminiV26.EntryTypes.METAL
                     ? ctx.BarsSinceImpulseLong_M5
                     : ctx.BarsSinceImpulseShort_M5;
 
-            double rangeWidth = ctx.MarketState?.RangeWidth ?? 0.0;
+            bool hasValidRange = ctx.RangeBreakAtrSize_M5 > 0.0;
+            double rangeWidth = hasValidRange
+                ? ctx.RangeBreakAtrSize_M5
+                : 0.0;
             bool isAtrCompression = !ctx.IsAtrExpanding_M5;
             bool isChop =
                 ctx.Adx_M5 < 18.0


### PR DESCRIPTION
### Motivation
- Fix a compilation error caused by referencing a non-existent `RangeWidth` property on the market state when evaluating XAU pullback, by sourcing the range from an existing field.

### Description
- Updated `EntryTypes/METAL/XAU_PullbackEntry.cs` to compute `rangeWidth` from `ctx.RangeBreakAtrSize_M5` with a safe validity check (`ctx.RangeBreakAtrSize_M5 > 0.0`) instead of `ctx.MarketState?.RangeWidth`, preserving the downstream chop/no-expansion checks and logs.

### Testing
- Ran repository checks (`rg` to locate related files), verified the modified file shows in `git status --short`, and committed the change with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad4e420988328bd0b01c5e0fc8375)