### PR TITLE
Add ExecutionQualityPolicy and wire into instrument executors

### DIFF
--- a/Core/Execution/ExecutionQualityPolicy.cs
+++ b/Core/Execution/ExecutionQualityPolicy.cs
@@ -1,0 +1,91 @@
+using System;
+using GeminiV26.Core.Entry;
+
+namespace GeminiV26.Core.Execution
+{
+    public enum ExecutionQualityTier
+    {
+        Full,
+        Reduced,
+        Salvage
+    }
+
+    public sealed class ExecutionQualityDecision
+    {
+        public ExecutionQualityTier Tier { get; init; }
+        public double RiskMultiplier { get; init; }
+        public bool ForceFastBE { get; init; }
+        public bool ForceTightTrailing { get; init; }
+        public string Reason { get; init; }
+    }
+
+    public static class ExecutionQualityPolicy
+    {
+        public static ExecutionQualityDecision Decide(
+            EntryContext ctx,
+            EntryEvaluation eval)
+        {
+            bool htfMismatch = false;
+
+            if (ctx != null &&
+                ctx.HtfAllowedDirection != TradeDirection.None)
+            {
+                htfMismatch = ctx.FinalDirection != ctx.HtfAllowedDirection;
+            }
+
+            bool lowScore = eval != null && eval.Score < 50;
+
+            var decision = new ExecutionQualityDecision
+            {
+                Tier = ExecutionQualityTier.Full,
+                RiskMultiplier = 1.0,
+                ForceFastBE = false,
+                ForceTightTrailing = false,
+                Reason = "FULL_QUALITY"
+            };
+
+            if (htfMismatch && lowScore)
+            {
+                double instrumentMultiplier = GetInstrumentMultiplier(ctx?.SymbolName);
+
+                decision = new ExecutionQualityDecision
+                {
+                    Tier = ExecutionQualityTier.Reduced,
+                    RiskMultiplier = instrumentMultiplier,
+                    ForceFastBE = true,
+                    ForceTightTrailing = true,
+                    Reason = "HTF_MISMATCH_LOW_SCORE"
+                };
+            }
+
+            ctx?.Log?.Invoke($"[EXEC_QUALITY] tier={decision.Tier} mult={decision.RiskMultiplier} reason={decision.Reason}");
+
+            return decision;
+        }
+
+        private static double GetInstrumentMultiplier(string symbol)
+        {
+            if (string.IsNullOrWhiteSpace(symbol))
+                return 0.5;
+
+            if (Contains(symbol, "US30") || Contains(symbol, "US TECH") || Contains(symbol, "NAS"))
+                return 0.4;
+
+            if (Contains(symbol, "XAU"))
+                return 0.3;
+
+            if (Contains(symbol, "USD") || Contains(symbol, "EUR") || Contains(symbol, "JPY"))
+                return 0.5;
+
+            if (Contains(symbol, "BTC") || Contains(symbol, "ETH"))
+                return 0.35;
+
+            return 0.5;
+        }
+
+        private static bool Contains(string value, string token)
+        {
+            return value.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+}

--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -27,6 +27,7 @@ using System;
 using cAlgo.API;
 using Gemini.Memory;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 
 namespace GeminiV26.Core
 {
@@ -158,6 +159,15 @@ namespace GeminiV26.Core
         public BeMode BeMode { get; set; }
 
         public TrailingMode TrailingMode { get; set; }
+
+        // =========================
+        // Execution quality policy hints
+        // =========================
+        public ExecutionQualityTier QualityTier { get; set; } = ExecutionQualityTier.Full;
+
+        public bool ForceFastBE { get; set; }
+
+        public bool ForceTightTrailing { get; set; }
 
         // =========================================================
         // RiskSizer → ExitManager bridge

--- a/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
+++ b/Instruments/AUDNZD/AudNzdInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -162,7 +163,10 @@ namespace GeminiV26.Instruments.AUDNZD
 
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
             {
@@ -239,6 +243,9 @@ namespace GeminiV26.Instruments.AUDNZD
                 // ✅ Rulebook-kompatibilis mezők
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
 
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,

--- a/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
+++ b/Instruments/AUDUSD/AudUsdInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -161,7 +162,10 @@ namespace GeminiV26.Instruments.AUDUSD
 
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
             {
@@ -240,6 +244,9 @@ namespace GeminiV26.Instruments.AUDUSD
                 // =========================
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 // FinalConfidence-t ComputeFinalConfidence tölti
 
                 EntryTime = _bot.Server.Time,

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.Risk.PositionSizing;
 using GeminiV26.Instruments.CRYPTO;
@@ -153,7 +154,10 @@ namespace GeminiV26.Instruments.BTCUSD
             // =========================================================
             // RISK-BASED VOLUME (CRYPTO POSITION SIZER)
             // =========================================================
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
             long volumeUnits = CryptoPositionSizer.Calculate(
                 _bot,
                 riskPercent,
@@ -256,6 +260,9 @@ namespace GeminiV26.Instruments.BTCUSD
 
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
 
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.Risk.PositionSizing;
 using GeminiV26.Instruments.CRYPTO;
@@ -153,7 +154,10 @@ namespace GeminiV26.Instruments.ETHUSD
             // =========================================================
             // RISK-BASED VOLUME (CRYPTO POSITION SIZER)
             // =========================================================
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
             long volumeUnits = CryptoPositionSizer.Calculate(
                 _bot,
                 riskPercent,
@@ -255,6 +259,9 @@ namespace GeminiV26.Instruments.ETHUSD
 
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
 
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,

--- a/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
+++ b/Instruments/EURJPY/EurJpyInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -161,7 +162,10 @@ namespace GeminiV26.Instruments.EURJPY
 
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
             {
@@ -240,6 +244,9 @@ namespace GeminiV26.Instruments.EURJPY
                 // =========================
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 // FinalConfidence-t ComputeFinalConfidence tölti
 
                 EntryTime = _bot.Server.Time,

--- a/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
+++ b/Instruments/EURUSD/EurUsdInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -144,7 +145,10 @@ namespace GeminiV26.Instruments.EURUSD
                 $"[EUR EXEC] CONF entryScore={entry.Score} logic={logicConfidence} final={ctx.FinalConfidence} statePenalty={statePenalty} riskConf={adjustedRiskConfidence}"
             );
 
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
             {
@@ -229,6 +233,9 @@ namespace GeminiV26.Instruments.EURUSD
                 // ✅ Rulebook mezők rendbetéve (viselkedést nem változtat)
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 // FinalConfidence-t ComputeFinalConfidence tölti
 
                 EntryTime = _bot.Server.Time,

--- a/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
+++ b/Instruments/GBPJPY/GbpJpyInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -161,7 +162,10 @@ namespace GeminiV26.Instruments.GBPJPY
 
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
             {
@@ -240,6 +244,9 @@ namespace GeminiV26.Instruments.GBPJPY
                 // =========================
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 // FinalConfidence-t ComputeFinalConfidence tölti
 
                 EntryTime = _bot.Server.Time,

--- a/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
+++ b/Instruments/GBPUSD/GbpUsdInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using cAlgo.API.Indicators;
@@ -175,7 +176,10 @@ namespace GeminiV26.Instruments.GBPUSD
                     ? TradeType.Buy
                     : TradeType.Sell;
 
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
             if (riskPercent <= 0)
                 return;
 
@@ -264,6 +268,9 @@ namespace GeminiV26.Instruments.GBPUSD
                 FinalDirection = entryContext.FinalDirection,
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
 

--- a/Instruments/GER40/Ger40InstrumentExecutor.cs
+++ b/Instruments/GER40/Ger40InstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.INDEX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -133,7 +134,10 @@ namespace GeminiV26.Instruments.GER40
             // =========================
             // RISK POLICY
             // =========================
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
                 return;
@@ -233,6 +237,9 @@ namespace GeminiV26.Instruments.GER40
                 FinalDirection = entryContext.FinalDirection,
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
 
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,

--- a/Instruments/NAS100/NasInstrumentExecutor.cs
+++ b/Instruments/NAS100/NasInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.INDEX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -144,7 +145,10 @@ namespace GeminiV26.Instruments.NAS100
             // =========================
             // RISK POLICY
             // =========================
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
                 return;
@@ -243,6 +247,9 @@ namespace GeminiV26.Instruments.NAS100
                 FinalDirection = entryContext.FinalDirection,
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
 

--- a/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
+++ b/Instruments/NZDUSD/NzdUsdInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -161,7 +162,10 @@ namespace GeminiV26.Instruments.NZDUSD
 
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
             {
@@ -240,6 +244,9 @@ namespace GeminiV26.Instruments.NZDUSD
                 // =========================
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 // FinalConfidence-t ComputeFinalConfidence tölti
 
                 EntryTime = _bot.Server.Time,

--- a/Instruments/US30/Us30InstrumentExecutor.cs
+++ b/Instruments/US30/Us30InstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.INDEX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -136,7 +137,10 @@ namespace GeminiV26.Instruments.US30
                     ? TradeType.Buy
                     : TradeType.Sell;
 
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
                 return;
@@ -218,6 +222,9 @@ namespace GeminiV26.Instruments.US30
                 FinalDirection = entryContext.FinalDirection,
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 EntryTime = _bot.Server.Time,
                 EntryPrice = result.Position.EntryPrice,
 

--- a/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
+++ b/Instruments/USDCAD/UsdCadInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -161,7 +162,10 @@ namespace GeminiV26.Instruments.USDCAD
 
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
             {
@@ -240,6 +244,9 @@ namespace GeminiV26.Instruments.USDCAD
                 // =========================
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 // FinalConfidence-t ComputeFinalConfidence tölti
 
                 EntryTime = _bot.Server.Time,

--- a/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
+++ b/Instruments/USDCHF/UsdChfInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -161,7 +162,10 @@ namespace GeminiV26.Instruments.USDCHF
 
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[SOFT_PENALTY] value={statePenalty} riskFinal={adjustedRiskConfidence}", entryContext));
 
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
             {
@@ -240,6 +244,9 @@ namespace GeminiV26.Instruments.USDCHF
                 // =========================
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 // FinalConfidence-t ComputeFinalConfidence tölti
 
                 EntryTime = _bot.Server.Time,

--- a/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
+++ b/Instruments/USDJPY/UsdJpyInstrumentExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Instruments.FX;
 using GeminiV26.Core.Risk.PositionSizing;
@@ -167,7 +168,10 @@ namespace GeminiV26.Instruments.USDJPY
                 out double tp2Ratio);
 
             // === RISK ===
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
 
             if (riskPercent <= 0)
                 return;
@@ -240,6 +244,9 @@ namespace GeminiV26.Instruments.USDJPY
                 // =========================
                 EntryScore = entry.Score,
                 LogicConfidence = logicConfidence,
+                QualityTier = quality.Tier,
+                ForceFastBE = quality.ForceFastBE,
+                ForceTightTrailing = quality.ForceTightTrailing,
                 // FinalConfidence-t ComputeFinalConfidence tölti
 
                 EntryTime = _bot.Server.Time,

--- a/Instruments/XAUUSD/XauInstrumentExecutor.cs
+++ b/Instruments/XAUUSD/XauInstrumentExecutor.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Execution;
 using GeminiV26.Core.Logging;
 using GeminiV26.Core.Risk.PositionSizing;
 using GeminiV26.Instruments.METAL;
@@ -249,7 +250,13 @@ namespace GeminiV26.Instruments.XAUUSD
             // =====================================================
             // 6️⃣ VOLUME POLICY – METAL POSITION SIZER (XAU)
             // =====================================================
+            var quality = ExecutionQualityPolicy.Decide(entryContext, entry);
+            ctx.QualityTier = quality.Tier;
+            ctx.ForceFastBE = quality.ForceFastBE;
+            ctx.ForceTightTrailing = quality.ForceTightTrailing;
+
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
+            riskPercent *= quality.RiskMultiplier;
             long volumeUnits = MetalPositionSizer.Calculate(
                 _bot,
                 riskPercent,


### PR DESCRIPTION
### Motivation
- Introduce a shared execution-quality policy to detect low-quality setups (HTF direction mismatch + entry score < 50) and provide non-blocking risk reductions and exit hints to executors.
- Apply instrument-specific risk multipliers and execution hints so executors can reduce risk and bias exit behavior without changing core trade routing, SL/TP formulas, or entry gating.

### Description
- Added `Core/Execution/ExecutionQualityPolicy.cs` implementing `ExecutionQualityTier`, `ExecutionQualityDecision`, and `Decide(EntryContext, EntryEvaluation)` with HTF mismatch + low score detection, instrument multipliers, and structured logging via `ctx.Log`.
- Extended `Core/PositionContext` with quality metadata fields `QualityTier`, `ForceFastBE`, and `ForceTightTrailing` and added the required `using` import so executors can persist hints into the SSOT `PositionContext`.
- Minimally updated all instrument executors to `using GeminiV26.Core.Execution;` and to call `var quality = ExecutionQualityPolicy.Decide(entryContext, entry);` before final sizing, apply `riskPercent *= quality.RiskMultiplier;`, and store quality hints into the created `PositionContext` (XAU uses `MetalPositionSizer` path accordingly), without changing SL/TP formulas, penalties, routing, or TradeCore logic.
- Preserved existing structured logging and added a single `[EXEC_QUALITY] tier=... mult=... reason=...` log emitted via the provided context logger.

### Testing
- Verified policy is wired into all executors by running `rg "ExecutionQualityPolicy.Decide(entryContext, entry)" Instruments/*/*InstrumentExecutor.cs` which found `16` integrations (success).
- Verified multiplier application with `rg "riskPercent \*= quality.RiskMultiplier;" Instruments/*/*InstrumentExecutor.cs` which found `16` occurrences, and persistence checks with `rg "QualityTier = quality.Tier|ctx.QualityTier = quality.Tier" Instruments/*/*InstrumentExecutor.cs` which also found `16` occurrences (success).
- Ran a repository consistency check to ensure no executor had the quality evaluation placed after context persistence and fixed an ordering issue in `XauInstrumentExecutor` (validation script finished `ok`).
- Could not perform a full solution build in this environment because no `.sln`/project files were found via `rg --files -g '*.csproj' -g '*.sln'`, so a complete compile check was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad9e3e0c483289365d5c1aeafe29d)