### PR TITLE
Add FTMO-safe Global Daily Drawdown Guard (UTC reset, 2.9% limit)

### DIFF
--- a/Core/Risk/GeminiRiskConfig.cs
+++ b/Core/Risk/GeminiRiskConfig.cs
@@ -1,0 +1,7 @@
+namespace GeminiV26.Core.Risk
+{
+    public class GeminiRiskConfig
+    {
+        public double DailyDrawdownLimitPercent { get; set; } = 2.9;
+    }
+}

--- a/Core/Risk/GlobalRiskGuard.cs
+++ b/Core/Risk/GlobalRiskGuard.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace GeminiV26.Core.Risk
+{
+    public class GlobalRiskGuard
+    {
+        private readonly GeminiRiskConfig _config;
+        private readonly Action<string> _log;
+
+        private double _startEquity;
+        private DateTime _currentDay;
+        private bool _isBlocked;
+
+        public GlobalRiskGuard(GeminiRiskConfig config, Action<string> log)
+        {
+            _config = config ?? new GeminiRiskConfig();
+            _log = log ?? (_ => { });
+        }
+
+        public bool CanTrade(double currentEquity, DateTime utcNow)
+        {
+            DateTime nowUtc = utcNow.Kind == DateTimeKind.Utc ? utcNow : utcNow.ToUniversalTime();
+            InitializeOrResetDay(currentEquity, nowUtc);
+
+            double baselineEquity = _startEquity > 0 ? _startEquity : Math.Max(currentEquity, 1.0);
+            double dailyDrawdownPercent = (baselineEquity - currentEquity) / baselineEquity * 100.0;
+            if (dailyDrawdownPercent < 0)
+                dailyDrawdownPercent = 0;
+
+            _log($"[RISK][DD] start={baselineEquity:F2} current={currentEquity:F2} dd={dailyDrawdownPercent:F2}%");
+
+            if (dailyDrawdownPercent >= _config.DailyDrawdownLimitPercent)
+            {
+                if (!_isBlocked)
+                {
+                    _log($"[RISK][DD_BLOCK] limit={_config.DailyDrawdownLimitPercent:F1}%");
+                }
+
+                _isBlocked = true;
+                return false;
+            }
+
+            _isBlocked = false;
+            return true;
+        }
+
+        private void InitializeOrResetDay(double currentEquity, DateTime nowUtc)
+        {
+            DateTime dayUtc = nowUtc.Date;
+
+            if (_currentDay == default)
+            {
+                _currentDay = dayUtc;
+                _startEquity = currentEquity;
+                _isBlocked = false;
+                _log("[RISK][DD_RESET] new day initialized");
+                return;
+            }
+
+            if (dayUtc <= _currentDay)
+                return;
+
+            _currentDay = dayUtc;
+            _startEquity = currentEquity;
+            _isBlocked = false;
+            _log("[RISK][DD_RESET] new day initialized");
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -66,6 +66,7 @@ using GeminiV26.Core.Context;
 using GeminiV26.Core.Analytics;
 using GeminiV26.Core.Memory;
 using GeminiV26.Core.Runtime;
+using GeminiV26.Core.Risk;
 using System.Linq;
 
 namespace GeminiV26.Core
@@ -263,6 +264,8 @@ namespace GeminiV26.Core
 
         private GlobalSessionGate _globalSessionGate;
         private SessionMatrix _sessionMatrix;
+        private readonly GeminiRiskConfig _riskConfig;
+        private readonly GlobalRiskGuard _globalRiskGuard;
 
         private EntryContext _ctx;
         private long _entryRouterPassCounter;
@@ -388,6 +391,8 @@ namespace GeminiV26.Core
             _contextBuilder = new EntryContextBuilder(bot, _memoryEngine);
             _globalSessionGate = new GlobalSessionGate(_bot);
             _sessionMatrix = new SessionMatrix(new SessionMatrixProvider());
+            _riskConfig = new GeminiRiskConfig();
+            _globalRiskGuard = new GlobalRiskGuard(_riskConfig, msg => GlobalLogger.Log(_bot, msg));
 
             _xauEntryLogic = new XauEntryLogic(_bot);
             _xauSessionGate = new XauSessionGate(_bot);
@@ -1428,6 +1433,14 @@ namespace GeminiV26.Core
                 var gateDir = ToTradeTypeStrict(_ctx.FinalDirection);
                 GlobalLogger.Log(_bot, "CHECK: direction gate");
                 GlobalLogger.Log(_bot, "CHECK: entry gate");
+
+                var utcNow = _bot.Server.Time.ToUniversalTime();
+                var currentEquity = _bot.Account.Equity;
+                if (!_globalRiskGuard.CanTrade(currentEquity, utcNow))
+                {
+                    GlobalLogger.Log(_bot, "[RISK][DD_BLOCK] Daily DD limit reached");
+                    return;
+                }
 
             // === GATES ONLY ===
             if (IsSymbol("XAUUSD"))


### PR DESCRIPTION
### Motivation
- Introduce a global, FTMO-style daily drawdown guard that blocks only new entries when the daily drawdown reaches the configured limit and resets at 00:00 UTC.
- Keep changes minimal and confined to the Risk layer and a small TradeCore hook so orchestration and trade/exit logic remain untouched.

### Description
- Added `GeminiRiskConfig` with injectable `DailyDrawdownLimitPercent` defaulting to `2.9` (`Core/Risk/GeminiRiskConfig.cs`).
- Implemented `GlobalRiskGuard` in the risk layer which tracks `startOfDayEquity`, computes `dailyDrawdownPercent` with the required formula, resets at UTC day rollover, emits the required logs (`[RISK][DD]`, `[RISK][DD_RESET]`, `[RISK][DD_BLOCK]`), and only blocks new entries (`Core/Risk/GlobalRiskGuard.cs`).
- Integrated the guard into `TradeCore` with minimal changes: added risk namespace import, private `_riskConfig` and `_globalRiskGuard` fields, initialized the guard with a logging delegate, and inserted a pre-dispatch check using `Server.Time.ToUniversalTime()` and `Account.Equity` that logs and returns early when `CanTrade` is false (`Core/TradeCore.cs`).
- Design preserves existing logging conventions and does not touch EntryLogic, ExitManager, Position/Instrument internals, or trade closing behavior.

### Testing
- Ran local code inspections and repository diff validation (`git diff --check`) and static searches to verify the new symbols and integration points; checks passed.
- Verified the new files `Core/Risk/GeminiRiskConfig.cs` and `Core/Risk/GlobalRiskGuard.cs` are present and referenced from `Core/TradeCore.cs` by project-wide symbol searches; results matched expectations.
- No automated unit/compile test suite was executed in this change; manual verification of logging placement and orchestration hook was performed and found correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cadd6239c88328b57c5aa32accf849)