### PR TITLE
Fix HTF direction access in ExecutionQualityPolicy

### DIFF
--- a/Core/Execution/ExecutionQualityPolicy.cs
+++ b/Core/Execution/ExecutionQualityPolicy.cs
@@ -26,11 +26,12 @@ namespace GeminiV26.Core.Execution
             EntryEvaluation eval)
         {
             bool htfMismatch = false;
+            TradeDirection allowedDirection = ctx?.ResolveAssetHtfAllowedDirection() ?? TradeDirection.None;
 
             if (ctx != null &&
-                ctx.HtfAllowedDirection != TradeDirection.None)
+                allowedDirection != TradeDirection.None)
             {
-                htfMismatch = ctx.FinalDirection != ctx.HtfAllowedDirection;
+                htfMismatch = ctx.FinalDirection != allowedDirection;
             }
 
             bool lowScore = eval != null && eval.Score < 50;


### PR DESCRIPTION
### Motivation
- The `ExecutionQualityPolicy` referenced a removed `EntryContext.HtfAllowedDirection` API which caused a compile-time mismatch after the daily DD changes, so the runtime should use the resolved HTF direction source instead.

### Description
- Replaced direct use of the removed property with a local `allowedDirection` obtained from `ctx?.ResolveAssetHtfAllowedDirection() ?? TradeDirection.None` and updated the mismatch check to `ctx.FinalDirection != allowedDirection` in `Core/Execution/ExecutionQualityPolicy.cs`.

### Testing
- Ran repository searches (`rg`) to confirm `HtfAllowedDirection` is no longer referenced in the updated code and that `ResolveAssetHtfAllowedDirection()` exists on `EntryContext`, and those checks succeeded; no solution/project files (`.sln/.csproj`) were present so an automated build/compile was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cadef25d4c8328b3b5014ff0facacc)