### PR TITLE
Use canonical FinalConfidence for analytics on trade close

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -3388,7 +3388,7 @@ namespace GeminiV26.Core
                     OpenTimeUtc = pos.EntryTime.ToUniversalTime(),
                     CloseTimeUtc = _bot.Server.Time.ToUniversalTime(),
                     Score = null,
-                    Confidence = meta?.EntryScore,
+                    Confidence = ctx?.FinalConfidence ?? meta?.EntryScore,
                     SetupType = ResolveSetupType(meta?.EntryType),
                     EntryType = meta?.EntryType ?? ctx?.EntryType ?? "UNKNOWN",
                     MarketRegime = ResolveMarketRegime(entryCtx),


### PR DESCRIPTION
### Motivation
- Align analytics output with the canonical confidence value: record `FinalConfidence` in closed-trade snapshots when a `PositionContext` is available rather than preferring the pending `meta.EntryScore`.

### Description
- Small, focused change in `Core/TradeCore.cs`: `TradeCloseSnapshot.Confidence` now uses `ctx?.FinalConfidence ?? meta?.EntryScore` instead of `meta?.EntryScore`, affecting only the analytics/metrics payload and not trading logic.

### Testing
- Repository-wide static inspection and code review were performed (`rg` / file reads) to verify the `FinalConfidence` lifecycle and analytics write path, and the changed line was inspected in `Core/TradeCore.cs` before commit.
- The change is a single-line, non-executing analytics field selection and no automated unit tests were available or executed for this edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb832f851c8328afc0abe9e0f13317)