### PR TITLE
Add global hard session block (19:30–02:00 UTC) in GlobalSessionGate and TradeCore

### DIFF
--- a/Core/Gates/GlobalSessionGate.cs
+++ b/Core/Gates/GlobalSessionGate.cs
@@ -6,6 +6,8 @@ public class GlobalSessionGate
 {
     private readonly Robot _bot;
     private readonly SessionCalendar _calendar;
+    private int _blockedCount;
+    private int _allowedCount;
 
     public GlobalSessionGate(Robot bot)
     {
@@ -22,6 +24,32 @@ public class GlobalSessionGate
     {
         return GetDecision(symbol, tf).Allow;
     }
+
+    public bool IsBlockedSession(DateTime utcNow)
+    {
+        var time = utcNow.TimeOfDay;
+
+        // Block: 19:30 → 23:59
+        if (time >= TimeSpan.FromHours(19.5))
+            return true;
+
+        // Block: 00:00 → 02:00
+        if (time < TimeSpan.FromHours(2))
+            return true;
+
+        return false;
+    }
+
+    public void RecordHardBlock(bool blocked)
+    {
+        if (blocked)
+            _blockedCount++;
+        else
+            _allowedCount++;
+    }
+
+    public int BlockedCount => _blockedCount;
+    public int AllowedCount => _allowedCount;
 
     public SessionDecision GetDecision(string symbol, TimeFrame tf)
     {

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -983,6 +983,21 @@ namespace GeminiV26.Core
             _flagBreakoutDetector.Evaluate(_ctx);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][CTX_BUILD] sym={_bot.SymbolName} trend={_ctx.TrendDirection} impulse={_ctx.ImpulseDirection} breakout={_ctx.BreakoutDirection} reversal={_ctx.ReversalDirection}", _ctx));
 
+            DateTime utcNow = _bot.Server.Time.ToUniversalTime();
+            _bot.Print($"[SESSION][CHECK] utc={utcNow:HH:mm}");
+            bool isHardBlocked = _globalSessionGate.IsBlockedSession(utcNow);
+            _globalSessionGate.RecordHardBlock(isHardBlocked);
+            _bot.Print($"[SESSION][HARD_BLOCK] active={isHardBlocked.ToString().ToLowerInvariant()}");
+            _bot.Print($"[SESSION][STATS] blockedCount={_globalSessionGate.BlockedCount} allowedCount={_globalSessionGate.AllowedCount}");
+            if (isHardBlocked)
+            {
+                _bot.Print($"[SESSION][HARD_BLOCK] Trading disabled | UTC={utcNow:HH:mm}");
+                GlobalLogger.Log(_bot, "BLOCK: global hard session block");
+                return;
+            }
+
+            _bot.Print("[SESSION][PASS] allowed=true");
+
             // =========================
             // GLOBAL SESSION GATE + SESSION MATRIX
             // =========================


### PR DESCRIPTION
### Motivation
- Enforce a GLOBAL hard-risk session gate that blocks all trading during the post-NewYork / early-Asia window `19:30 UTC → 02:00 UTC` to protect capital from known low-liquidity and chaotic conditions.
- Implement the hard stop at the orchestration layer (GATE) to avoid touching `EntryLogic`, `RiskSizer`, `ExitManager` or per-instrument code and to keep pipeline structure intact.

### Description
- Added `IsBlockedSession(DateTime utcNow)` to `Core/Gates/GlobalSessionGate.cs` which returns true for UTC times `>= 19:30` or `< 02:00` to implement the requested cross-midnight block.  
- Added session statistics and recording methods (`RecordHardBlock`, `BlockedCount`, `AllowedCount`) to `GlobalSessionGate` for basic debug telemetry.  
- Integrated a hard-session check in `Core/TradeCore.cs` before the existing session matrix and gate flow using `_globalSessionGate.IsBlockedSession(...)`, with an immediate `return` on blocked state to guarantee no fallback or partial execution.  
- Added mandatory runtime logging via `_bot.Print` and `GlobalLogger.Log` including `[SESSION][CHECK]`, `[SESSION][HARD_BLOCK] active=true/false`, `[SESSION][PASS]`, `[SESSION][STATS] blockedCount=... allowedCount=...`, and a blocking message `[SESSION][HARD_BLOCK] Trading disabled | UTC=HH:mm` to ensure decisions are never silent.

### Testing
- Ran source validations with `rg -n "IsBlockedSession|RecordHardBlock|\[SESSION\]\[HARD_BLOCK\]|\[SESSION\]\[CHECK\]|\[SESSION\]\[PASS\]|\[SESSION\]\[STATS\]"` to confirm the new symbols and log strings are present, and the check succeeded.  
- Verified repository working state with `git status --short` which showed the two modified files, and the check succeeded.  
- Did not perform a full compilation (`dotnet build`) because a solution/project file was not available in this workspace, so no binary build test was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb90aa59c8832895e65b4e6a438b2c)