### PR TITLE
Fix duplicate utcNow local variable in TradeCore

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1561,9 +1561,9 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot, "CHECK: direction gate");
                 GlobalLogger.Log(_bot, "CHECK: entry gate");
 
-                var utcNow = _bot.Server.Time.ToUniversalTime();
+                var utcNowRisk = _bot.Server.Time.ToUniversalTime();
                 var currentEquity = _bot.Account.Equity;
-                if (!_globalRiskGuard.CanTrade(currentEquity, utcNow))
+                if (!_globalRiskGuard.CanTrade(currentEquity, utcNowRisk))
                 {
                     GlobalLogger.Log(_bot, "[RISK][DD_BLOCK] Daily DD limit reached");
                     return;


### PR DESCRIPTION
### Motivation
- Resolve a compile error (CS0128) caused by defining a second local `utcNow` in the same scope and ensure the risk check uses the correct timestamp.

### Description
- Rename the second local `utcNow` to `utcNowRisk` in `Core/TradeCore.cs` around the risk check and update the `_globalRiskGuard.CanTrade` call to use `utcNowRisk`.

### Testing
- Verified the change by inspecting the file and committing the updated `Core/TradeCore.cs` (commit succeeded), attempted a project-file search which returned no .sln/.csproj files in the repo, and no automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb91ce95c48328b70a3b64201b4d0c)