### PR TITLE
Add strict scaling audit telemetry across account sizes

### DIFF
--- a/Core/Analytics/TradeStatsTracker.cs
+++ b/Core/Analytics/TradeStatsTracker.cs
@@ -54,6 +54,16 @@ namespace GeminiV26.Core.Analytics
             public double MaeR;
             public double RMultiple;
             public double TransitionQuality;
+            public double AccountBalanceAtEntry;
+        }
+
+        private sealed class ScalingStats
+        {
+            public int Trades;
+            public int Wins;
+            public readonly List<double> RValues = new List<double>();
+            public double SumMfe;
+            public double SumMae;
         }
 
         private readonly Dictionary<string, InstrumentStats> _instrumentStats = new Dictionary<string, InstrumentStats>(StringComparer.OrdinalIgnoreCase);
@@ -62,6 +72,7 @@ namespace GeminiV26.Core.Analytics
 
         private readonly Action<string> _log;
         private int _closedTrades;
+        private readonly Dictionary<string, ScalingStats> _scalingByAccountSize = new Dictionary<string, ScalingStats>(StringComparer.OrdinalIgnoreCase);
 
         public TradeStatsTracker(Action<string> log)
         {
@@ -149,6 +160,8 @@ namespace GeminiV26.Core.Analytics
             });
 
             _closedTrades++;
+            if (snapshot != null)
+                UpdateScalingStats(snapshot);
             if (_closedTrades % 20 == 0)
                 PrintSummary();
         }
@@ -196,6 +209,68 @@ namespace GeminiV26.Core.Analytics
 
                 ExportInstrumentStatsToFile(symbol, s);
             }
+
+            PrintScalingSummary();
+        }
+
+        private void UpdateScalingStats(TradeCloseSnapshot snapshot)
+        {
+            string bucket = ResolveAccountSizeBucket(snapshot.AccountBalanceAtEntry);
+            if (!_scalingByAccountSize.TryGetValue(bucket, out var stats))
+            {
+                stats = new ScalingStats();
+                _scalingByAccountSize[bucket] = stats;
+            }
+
+            stats.Trades++;
+            if (snapshot.Profit > 0)
+                stats.Wins++;
+            stats.RValues.Add(snapshot.RMultiple);
+            stats.SumMfe += snapshot.MfeR;
+            stats.SumMae += snapshot.MaeR;
+        }
+
+        private void PrintScalingSummary()
+        {
+            foreach (var kv in _scalingByAccountSize.OrderBy(k => k.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                var bucket = kv.Key;
+                var stats = kv.Value;
+                if (stats.Trades <= 0)
+                    continue;
+
+                var orderedR = stats.RValues.OrderBy(x => x).ToList();
+                double avgR = orderedR.Average();
+                double medianR = orderedR.Count % 2 == 1
+                    ? orderedR[orderedR.Count / 2]
+                    : (orderedR[orderedR.Count / 2 - 1] + orderedR[orderedR.Count / 2]) / 2.0;
+                double winrate = (double)stats.Wins / stats.Trades;
+                double avgMfe = stats.SumMfe / stats.Trades;
+                double avgMae = stats.SumMae / stats.Trades;
+
+                _log($"[SCALING][SUMMARY] accountSize={bucket} avgR={avgR:0.####} medianR={medianR:0.####} winrate={winrate:0.####} avgMFE={avgMfe:0.####} avgMAE={avgMae:0.####} trades={stats.Trades}");
+            }
+        }
+
+        private static string ResolveAccountSizeBucket(double balance)
+        {
+            if (balance <= 0)
+                return "UNKNOWN";
+
+            double[] anchors = { 10000, 25000, 50000, 100000 };
+            double nearest = anchors[0];
+            double nearestDistance = Math.Abs(balance - nearest);
+            for (int i = 1; i < anchors.Length; i++)
+            {
+                double d = Math.Abs(balance - anchors[i]);
+                if (d < nearestDistance)
+                {
+                    nearest = anchors[i];
+                    nearestDistance = d;
+                }
+            }
+
+            return nearest.ToString("0", CultureInfo.InvariantCulture);
         }
 
         private void ExportInstrumentStatsToFile(string symbol, InstrumentStats stats)

--- a/Core/Risk/PositionSizing/CryptoPositionSizer.cs
+++ b/Core/Risk/PositionSizing/CryptoPositionSizer.cs
@@ -33,6 +33,12 @@ namespace GeminiV26.Core.Risk.PositionSizing
             {
                 GlobalLogger.Log(bot, $"[CRYPTO SIZE RAW] symbol={symbol} balance={balance:0.##} riskPercent={riskPercent:0.###} riskAmount={riskAmount:0.###} slDistance={slPriceDistance:0.########} rawUnits={rawUnits:0.###} capUnits={capUnits:0.###} finalUnits={finalUnits:0.###}");
                 GlobalLogger.Log(bot, $"[CRYPTO SIZE NORMALIZED] symbol={symbol} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} lotSize={bot.Symbol.LotSize}");
+                bool capped = rawUnits > capUnits;
+                double effectiveRisk = Math.Min(rawUnits, capUnits) * slPriceDistance;
+                double riskDeviationPercent = riskAmount > 0
+                    ? ((riskAmount - effectiveRisk) / riskAmount) * 100.0
+                    : 0.0;
+                GlobalLogger.Log(bot, $"[SCALING][LOTCAP] accountSize={balance:0.##} desiredVolume={rawUnits:0.####} actualVolume={finalUnits:0.####} capped={capped.ToString().ToLowerInvariant()} riskDeviationPercent={riskDeviationPercent:0.####}");
             }
 
             if (normalized < bot.Symbol.VolumeInUnitsMin)

--- a/Core/Risk/PositionSizing/FxPositionSizer.cs
+++ b/Core/Risk/PositionSizing/FxPositionSizer.cs
@@ -46,6 +46,12 @@ namespace GeminiV26.Core.Risk.PositionSizing
                 $"rawUnits={rawUnits:F0} " +
                 $"capUnits={capUnits:F0} normalized={normalized}");
 
+            bool capped = rawUnits > capUnits;
+            double riskDeviationPercent = riskAmount > 0
+                ? ((riskAmount - (Math.Min(rawUnits, capUnits) * slPips * pipValuePerUnit)) / riskAmount) * 100.0
+                : 0.0;
+            GlobalLogger.Log(bot, $"[SCALING][LOTCAP] accountSize={bot.Account.Balance:0.##} desiredVolume={rawUnits:0.####} actualVolume={finalUnits:0.####} capped={capped.ToString().ToLowerInvariant()} riskDeviationPercent={riskDeviationPercent:0.####}");
+
             if (normalized < bot.Symbol.VolumeInUnitsMin)
                 return 0;
 

--- a/Core/Risk/PositionSizing/IndexPositionSizer.cs
+++ b/Core/Risk/PositionSizing/IndexPositionSizer.cs
@@ -41,6 +41,13 @@ namespace GeminiV26.Core.Risk.PositionSizing
                 $"rawLots={rawLots:F4} rawUnits={rawUnits:F0} " +
                 $"capUnits={capUnits:F0} normalized={normalized}");
 
+            bool capped = rawUnits > capUnits;
+            double effectiveRisk = Math.Min(rawUnits, capUnits) * slPoints * valuePerPoint;
+            double riskDeviationPercent = riskAmount > 0
+                ? ((riskAmount - effectiveRisk) / riskAmount) * 100.0
+                : 0.0;
+            GlobalLogger.Log(bot, $"[SCALING][LOTCAP] accountSize={bot.Account.Balance:0.##} desiredVolume={rawUnits:0.####} actualVolume={finalUnits:0.####} capped={capped.ToString().ToLowerInvariant()} riskDeviationPercent={riskDeviationPercent:0.####}");
+
             if (normalized < bot.Symbol.VolumeInUnitsMin)
                 return 0;
 

--- a/Core/Risk/PositionSizing/MetalPositionSizer.cs
+++ b/Core/Risk/PositionSizing/MetalPositionSizer.cs
@@ -41,6 +41,13 @@ namespace GeminiV26.Core.Risk.PositionSizing
                 $"rawLots={rawLots:F4} rawUnits={rawUnits:F0} " +
                 $"capUnits={capUnits:F0} normalized={normalized}");
 
+            bool capped = rawUnits > capUnits;
+            double effectiveRisk = (Math.Min(rawUnits, capUnits) / bot.Symbol.LotSize) * slPips * pipValuePerLot;
+            double riskDeviationPercent = riskAmount > 0
+                ? ((riskAmount - effectiveRisk) / riskAmount) * 100.0
+                : 0.0;
+            GlobalLogger.Log(bot, $"[SCALING][LOTCAP] accountSize={bot.Account.Balance:0.##} desiredVolume={rawUnits:0.####} actualVolume={finalUnits:0.####} capped={capped.ToString().ToLowerInvariant()} riskDeviationPercent={riskDeviationPercent:0.####}");
+
             if (normalized < bot.Symbol.VolumeInUnitsMin)
                 return 0;
 

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -96,6 +96,7 @@ namespace GeminiV26.Core
         private readonly string _symbolCanonical;
         private readonly InstrumentClass _instrumentClass;
         private readonly Dictionary<string, EntryTraceSummary> _entryTraceSummaries = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<long, double> _entryBalanceByPositionId = new();
        
         private const string BotLabel = "GeminiV26";
                 
@@ -682,6 +683,8 @@ namespace GeminiV26.Core
                     _statsTracker.RegisterTradeOpen(_ctx, pos.Id);
                 }
 
+                _entryBalanceByPositionId[pos.Id] = _bot.Account.Balance;
+
                 if (_positionContexts.TryGetValue(pos.Id, out var pctx))
                 {
                     TradeDirection authoritativeFinalDirection = TradeDirection.None;
@@ -729,6 +732,7 @@ namespace GeminiV26.Core
                 _tradeMetaStore.TryGet(pos.Id, out var pendingMeta);
                 string openedEntryType = pctx?.EntryType ?? pendingMeta?.EntryType ?? "UNKNOWN";
                 GlobalLogger.Log(_bot, $"[POSITION][OPEN] symbol={pos.SymbolName ?? _bot.SymbolName} entryType={openedEntryType} positionId={pos.Id} pipelineId={pos.Id}");
+                LogScalingOpenAudit(pos, pctx);
                 _logger.OnTradeOpened(BuildLogContext(pos, pendingMeta, pctx: _positionContexts.TryGetValue(pos.Id, out var ctxValue) ? ctxValue : null));
             };
 
@@ -3439,6 +3443,9 @@ namespace GeminiV26.Core
             _tradeMetaStore.TryGet(pos.Id, out var meta);
             _positionContexts.TryGetValue(pos.Id, out var ctx);
             var entryCtx = _contextRegistry.GetEntry(pos.Id);
+            double entryBalance = _entryBalanceByPositionId.TryGetValue(pos.Id, out var mappedBalance)
+                ? mappedBalance
+                : _bot.Account.Balance;
 
             if (meta == null)
             {
@@ -3535,8 +3542,11 @@ namespace GeminiV26.Core
                     RMultiple = ComputeRMultiple(pos, ctx, sym.PipSize),
                     TransitionQuality = entryCtx?.TransitionValid == true
                         ? entryCtx.Transition?.QualityScore ?? 0.0
-                        : 0.0
+                        : 0.0,
+                    AccountBalanceAtEntry = entryBalance
                 });
+
+            LogScalingCloseAudit(pos, ctx, entryBalance);
 
             var memoryRecord = new TradeMemoryRecord
             {
@@ -3563,6 +3573,7 @@ namespace GeminiV26.Core
             _contextRegistry.RemovePosition(pos.Id);
             _contextRegistry.RemoveEntry(pos.Id);
             _tradeMetaStore.Remove(pos.Id);
+            _entryBalanceByPositionId.Remove(pos.Id);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(TradeAuditLog.BuildCleanup(pos.Id, "position_closed_event"), ctx, pos));
         }
 
@@ -4018,6 +4029,76 @@ namespace GeminiV26.Core
                 return 0.0;
 
             return (pos.Pips * pipSize) / ctx.RiskPriceDistance;
+        }
+
+        private void LogScalingOpenAudit(Position pos, PositionContext? ctx)
+        {
+            if (pos == null || ctx == null || ctx.RiskPriceDistance <= 0)
+                return;
+
+            var symbol = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
+            if (symbol == null || symbol.TickSize <= 0)
+                return;
+
+            double balance = _entryBalanceByPositionId.TryGetValue(pos.Id, out var entryBalance)
+                ? entryBalance
+                : _bot.Account.Balance;
+            double accountSize = ResolveAccountSizeAnchor(balance);
+            double valuePerPricePerUnit = symbol.TickValue / symbol.TickSize;
+            double expectedLossUsd = ctx.RiskPriceDistance * valuePerPricePerUnit * pos.VolumeInUnits;
+            double riskPercent = balance > 0 ? (expectedLossUsd / balance) * 100.0 : 0.0;
+            double slPips = symbol.PipSize > 0 ? ctx.RiskPriceDistance / symbol.PipSize : 0.0;
+            double pipValue = symbol.PipSize * valuePerPricePerUnit;
+            double lotSize = symbol.LotSize > 0 ? pos.VolumeInUnits / symbol.LotSize : 0.0;
+            double notionalExposure = pos.VolumeInUnits * pos.EntryPrice;
+            bool capped = ctx.LotCap > 0 && lotSize + 1e-9 >= ctx.LotCap;
+
+            GlobalLogger.Log(_bot, $"[SCALING][RISK] accountSize={accountSize:0} balance={balance:0.##} riskPercent={riskPercent:0.####} riskUSD={expectedLossUsd:0.####} volume={pos.VolumeInUnits:0.####} slPips={slPips:0.####} pipValue={pipValue:0.####} expectedLossUSD={expectedLossUsd:0.####}");
+            GlobalLogger.Log(_bot, $"[SCALING][POSITION] symbol={pos.SymbolName} accountSize={accountSize:0} volume={pos.VolumeInUnits:0.####} lotSize={lotSize:0.####} notionalExposure={notionalExposure:0.####} riskPercent={riskPercent:0.####}");
+            GlobalLogger.Log(_bot, $"[SCALING][TP_SL] accountSize={accountSize:0} SL_R=1 TP1_R={ctx.Tp1R:0.####} TP2_R={ctx.Tp2R:0.####} TP1_ratio={ctx.Tp1Ratio:0.####} TP2_ratio={ctx.Tp2Ratio:0.####}");
+            GlobalLogger.Log(_bot, $"[SCALING][LOTCAP] accountSize={accountSize:0} desiredVolume=NA actualVolume={pos.VolumeInUnits:0.####} capped={capped.ToString().ToLowerInvariant()} riskDeviationPercent=NA");
+        }
+
+        private void LogScalingCloseAudit(Position pos, PositionContext? ctx, double entryBalance)
+        {
+            if (pos == null || ctx == null || ctx.RiskPriceDistance <= 0)
+                return;
+
+            var symbol = _runtimeSymbols.ResolveSymbol(pos.SymbolName);
+            if (symbol == null || symbol.PipSize <= 0)
+                return;
+
+            double accountSize = ResolveAccountSizeAnchor(entryBalance);
+            double rMultiple = ComputeRMultiple(pos, ctx, symbol.PipSize);
+            double profitPercent = entryBalance > 0 ? (pos.NetProfit / entryBalance) * 100.0 : 0.0;
+            GlobalLogger.Log(_bot, $"[SCALING][RESULT] accountSize={accountSize:0} Rmultiple={rMultiple:0.####} profitUSD={pos.NetProfit:0.####} profitPercent={profitPercent:0.####} MFE_R={ctx.MfeR:0.####} MAE_R={ctx.MaeR:0.####}");
+
+            if (Math.Abs(ctx.Tp1R) < 1e-9 && Math.Abs(ctx.Tp2R) < 1e-9)
+            {
+                GlobalLogger.Log(_bot, $"[SCALING][ANOMALY] type=tp_sl_missing accountSize={accountSize:0} details=tp_structure_not_resolved");
+            }
+        }
+
+        private static double ResolveAccountSizeAnchor(double balance)
+        {
+            if (balance <= 0)
+                return 0;
+
+            double[] anchors = { 10000, 25000, 50000, 100000 };
+            double nearest = anchors[0];
+            double nearestDistance = Math.Abs(balance - nearest);
+
+            for (int i = 1; i < anchors.Length; i++)
+            {
+                double distance = Math.Abs(balance - anchors[i]);
+                if (distance < nearestDistance)
+                {
+                    nearest = anchors[i];
+                    nearestDistance = distance;
+                }
+            }
+
+            return nearest;
         }
 
         // =========================================================


### PR DESCRIPTION
### Motivation
- Provide deterministic, data-driven telemetry to verify that risk, position sizing, SL/TP structure and realized PnL scale consistently across account sizes (10K / 25K / 50K / 100K) without changing trading decisions. 
- Enable detection of lot-cap or normalization artifacts that would break linear scaling or distort percent-based R measurements. 

### Description
- Added entry-balance snapshot storage and emit detailed scaling logs at open in `Core/TradeCore.cs` using tags: `[SCALING][RISK]`, `[SCALING][POSITION]`, `[SCALING][TP_SL]`, and `[SCALING][LOTCAP]` to capture riskUSD, volume, SL pips, pip value, lot-size, and TP/SL R structure. 
- Emit close-time scaling logs in `Core/TradeCore.cs` with `[SCALING][RESULT]` and `[SCALING][ANOMALY]` containing `Rmultiple`, `profitUSD`, `profitPercent`, `MFE_R`, and `MAE_R`, and attach `AccountBalanceAtEntry` to analytics snapshots for account-size grouping. 
- Extended `Core/Analytics/TradeStatsTracker.cs` with account-size bucketing (nearest anchor 10K/25K/50K/100K) and per-bucket aggregation producing periodic `[SCALING][SUMMARY]` lines with `avgR`, `medianR`, `winrate`, `avgMFE`, `avgMAE`, and `trades`. 
- Instrumented all position sizers (`Core/Risk/PositionSizing/*`) to log `[SCALING][LOTCAP]` with `desiredVolume`, `actualVolume`, `capped` flag and `riskDeviationPercent` so lot-cap impacts on risk can be audited per instrument class. 
- This change is telemetry-only: no modifications to `Entry` logic, `RiskSizer` decision formulas, `ExitManager`, or execution behavior were made. 

### Testing
- Ran static whitespace/diff checks and local pattern scans to confirm new `[SCALING]` log tags are present in `Core/TradeCore.cs`, `Core/Analytics/TradeStatsTracker.cs`, and `Core/Risk/PositionSizing/*`, and those checks passed. 
- Verified that `AccountBalanceAtEntry` is populated in `TradeCloseSnapshot` and aggregated by the tracker producing `[SCALING][SUMMARY]` output during summary runs. 
- Confirmed updated position sizers emit `[SCALING][LOTCAP]` entries for FX/Index/Metal/Crypto calculation paths through targeted `rg`/log-tag searches. 
- No runtime behavioral tests (live execution across account sizes) were performed in this change; full validation requires running the bot on the target account sizes to collect the emitted `[SCALING]` telemetry for analysis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb9313bddc83289f9bfd1403d36533)