### PR TITLE
Fix BTC sizing truncation to 0 and add BTC execution diagnostics

### DIFF
--- a/Core/Risk/PositionSizing/CryptoPositionSizer.cs
+++ b/Core/Risk/PositionSizing/CryptoPositionSizer.cs
@@ -5,7 +5,7 @@ namespace GeminiV26.Core.Risk.PositionSizing
 {
     public static class CryptoPositionSizer
     {
-        public static long Calculate(
+        public static double Calculate(
             Robot bot,
             double riskPercent,
             double slPriceDistance,
@@ -24,15 +24,15 @@ namespace GeminiV26.Core.Risk.PositionSizing
             double finalUnits = Math.Min(rawUnits, capUnits);
             string symbol = bot.SymbolName ?? "UNKNOWN";
 
-            long normalized =
-                (long)bot.Symbol.NormalizeVolumeInUnits(
+            double normalized =
+                bot.Symbol.NormalizeVolumeInUnits(
                     finalUnits,
                     RoundingMode.Down);
 
             if (execCtx)
             {
                 GlobalLogger.Log(bot, $"[CRYPTO SIZE RAW] symbol={symbol} balance={balance:0.##} riskPercent={riskPercent:0.###} riskAmount={riskAmount:0.###} slDistance={slPriceDistance:0.########} rawUnits={rawUnits:0.###} capUnits={capUnits:0.###} finalUnits={finalUnits:0.###}");
-                GlobalLogger.Log(bot, $"[CRYPTO SIZE NORMALIZED] symbol={symbol} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} lotSize={bot.Symbol.LotSize}");
+                GlobalLogger.Log(bot, $"[CRYPTO SIZE NORMALIZED] symbol={symbol} normalizedUnits={normalized:0.########} minVolume={bot.Symbol.VolumeInUnitsMin:0.########} step={bot.Symbol.VolumeInUnitsStep:0.########} lotSize={bot.Symbol.LotSize:0.########}");
                 bool capped = rawUnits > capUnits;
                 double effectiveRisk = Math.Min(rawUnits, capUnits) * slPriceDistance;
                 double riskDeviationPercent = riskAmount > 0
@@ -45,7 +45,7 @@ namespace GeminiV26.Core.Risk.PositionSizing
             {
                 if (execCtx)
                 {
-                    GlobalLogger.Log(bot, $"[CRYPTO SIZE ZERO] symbol={symbol} reason=below_min_after_normalization finalUnits={finalUnits:0.###} normalizedUnits={normalized} minVolume={bot.Symbol.VolumeInUnitsMin} step={bot.Symbol.VolumeInUnitsStep} riskPercent={riskPercent:0.###} slDistance={slPriceDistance:0.########}");
+                    GlobalLogger.Log(bot, $"[CRYPTO SIZE ZERO] symbol={symbol} reason=below_min_after_normalization finalUnits={finalUnits:0.###} normalizedUnits={normalized:0.########} minVolume={bot.Symbol.VolumeInUnitsMin:0.########} step={bot.Symbol.VolumeInUnitsStep:0.########} riskPercent={riskPercent:0.###} slDistance={slPriceDistance:0.########}");
                 }
 
                 return 0;

--- a/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
+++ b/Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs
@@ -158,16 +158,36 @@ namespace GeminiV26.Instruments.BTCUSD
 
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
             riskPercent *= quality.RiskMultiplier;
-            long volumeUnits = CryptoPositionSizer.Calculate(
+            double accountBalance = _bot.Account.Balance;
+            double accountEquity = _bot.Account.Equity;
+            double riskAmountUsd = accountBalance * (riskPercent / 100.0);
+
+            GlobalLogger.Log(_bot,
+                $"[BTC][RISK_INPUT] balance={accountBalance:0.##} equity={accountEquity:0.##} confidence={adjustedRiskConfidence} riskPercent={riskPercent:0.####} riskAmountUsd={riskAmountUsd:0.######}");
+
+            double lotCap = _riskSizer.GetLotCap(adjustedRiskConfidence);
+            double rawUnits = riskAmountUsd / slPriceDist;
+            double capUnits = lotCap * _bot.Symbol.LotSize;
+            double preNormalizeUnits = Math.Min(rawUnits, capUnits);
+            double normalizedPreview = _bot.Symbol.NormalizeVolumeInUnits(preNormalizeUnits, RoundingMode.Down);
+            GlobalLogger.Log(_bot, $"[BTC][VOLUME_RAW] rawUnits={rawUnits:0.########} capUnits={capUnits:0.########} preNormalizeUnits={preNormalizeUnits:0.########}");
+            GlobalLogger.Log(_bot, $"[BTC][VOLUME_NORMALIZE] minUnits={_bot.Symbol.VolumeInUnitsMin:0.########} stepUnits={_bot.Symbol.VolumeInUnitsStep:0.########} maxUnits={_bot.Symbol.VolumeInUnitsMax:0.########} normalizedUnits={normalizedPreview:0.########}");
+
+            double volumeUnits = CryptoPositionSizer.Calculate(
                 _bot,
                 riskPercent,
                 slPriceDist,
-                _riskSizer.GetLotCap(adjustedRiskConfidence),
+                lotCap,
                 isExecutionContext: true);
 
             if (volumeUnits < _bot.Symbol.VolumeInUnitsMin)
             {
-                GlobalLogger.Log(_bot, $"[BTCUSD][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=volume_below_min volume={volumeUnits} minVolume={_bot.Symbol.VolumeInUnitsMin} riskPercent={riskPercent:0.##} slDistance={slPriceDist:0.########}");
+                double requiredMinUnits = _bot.Symbol.VolumeInUnitsMin;
+                double shortfall = requiredMinUnits - volumeUnits;
+                double minRiskAmountNeeded = requiredMinUnits * slPriceDist;
+                double minRiskPercentNeeded = accountBalance > 0 ? (minRiskAmountNeeded / accountBalance) * 100.0 : 0.0;
+                GlobalLogger.Log(_bot, $"[BTC][VOLUME_ABORT] reason=volume_below_min requiredMinUnits={requiredMinUnits:0.########} shortfall={shortfall:0.########} minRiskAmountNeededUsd={minRiskAmountNeeded:0.######} minRiskPercentNeeded={minRiskPercentNeeded:0.######}");
+                GlobalLogger.Log(_bot, $"[BTCUSD][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=volume_below_min volume={volumeUnits:0.########} minVolume={_bot.Symbol.VolumeInUnitsMin:0.########} riskPercent={riskPercent:0.##} slDistance={slPriceDist:0.########}");
                 GlobalLogger.Log(_bot, $"[ENTRY][EXEC][ABORT] symbol={_bot.SymbolName} entryType={entry.Type} reason=volume_below_min");
                 return;
             }
@@ -186,6 +206,13 @@ namespace GeminiV26.Instruments.BTCUSD
                 tradeType == TradeType.Buy
                     ? _bot.Symbol.Ask
                     : _bot.Symbol.Bid;
+            double stopLossPrice =
+                tradeType == TradeType.Buy
+                    ? entryPrice - slPriceDist
+                    : entryPrice + slPriceDist;
+            double slPoints = _bot.Symbol.TickSize > 0 ? slPriceDist / _bot.Symbol.TickSize : 0;
+            GlobalLogger.Log(_bot,
+                $"[BTC][SL_INPUT] entry={entryPrice:0.########} stopLoss={stopLossPrice:0.########} stopDistancePrice={slPriceDist:0.########} stopDistancePipsOrPoints={slPips:0.########} stopDistancePoints={slPoints:0.########}");
 
             double tp2Price =
                 tradeType == TradeType.Buy
@@ -210,6 +237,7 @@ namespace GeminiV26.Instruments.BTCUSD
             // =========================================================
             // SEND ORDER
             // =========================================================
+            GlobalLogger.Log(_bot, $"[BTC][EXEC_SUBMIT] finalUnits={volumeUnits:0.########}");
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[ENTRY][EXEC][REQUEST] symbol={entry.Symbol ?? entryContext.Symbol ?? _bot.SymbolName} entryType={entry.Type} pipelineId={entryContext.TempId} side={tradeType} volumeUnits={volumeUnits} slPips={slPips:0.#####} tpPips={tp2Pips:0.#####}", entryContext));
 
             var result = _bot.ExecuteMarketOrder(

--- a/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
+++ b/Instruments/ETHUSD/EthUsdInstrumentExecutor.cs
@@ -158,7 +158,7 @@ namespace GeminiV26.Instruments.ETHUSD
 
             double riskPercent = _riskSizer.GetRiskPercent(adjustedRiskConfidence);
             riskPercent *= quality.RiskMultiplier;
-            long volumeUnits = CryptoPositionSizer.Calculate(
+            double volumeUnits = CryptoPositionSizer.Calculate(
                 _bot,
                 riskPercent,
                 slPriceDist,


### PR DESCRIPTION
### Motivation
- A live BTCUSD execution aborted because normalized crypto volume (≈0.308) was truncated to `0` by an integer cast, triggering `volume_below_min`; the fix must be minimal and preserve architecture.

### Description
- Preserve fractional crypto units by changing `CryptoPositionSizer.Calculate` return type from `long` to `double` and stop casting `NormalizeVolumeInUnits` to `long` so fractional `VolumeInUnits` are retained (file: `Core/Risk/PositionSizing/CryptoPositionSizer.cs`).
- Add targeted BTC execution diagnostics and intermediate math logs in `BtcUsdInstrumentExecutor.ExecuteEntry`: `[BTC][RISK_INPUT]`, `[BTC][SL_INPUT]`, `[BTC][VOLUME_RAW]`, `[BTC][VOLUME_NORMALIZE]`, `[BTC][VOLUME_ABORT]`, and `[BTC][EXEC_SUBMIT]` (file: `Instruments/BTCUSD/BtcUsdInstrumentExecutor.cs`).
- Keep normalization behavior (`RoundingMode.Down`) and min-volume guard unchanged and compute preview metrics (raw/cap/pre-normalize/normalized) to make abort reasons explicit.
- Update ETH executor call-site to accept `double` from the shared sizer to maintain type consistency (file: `Instruments/ETHUSD/EthUsdInstrumentExecutor.cs`).

### Testing
- Inspected runtime logs demonstrating the original failure (`Logs/Logs/Runtime/BTCUSD/runtime_20260331.log`) and verified the math chain that produced `rawUnits=0.308` and normalized `0` pre-fix.
- Ran repository checks: `git diff --check` and `git status` (no diff-check issues); changes were committed successfully as `Fix crypto unit truncation causing BTC min-volume abort`.
- `dotnet build` was not executed because no solution/project was discovered in the workspace, so no binary build verification was performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbbacb9e588328a13185cd64af1c52)