### PR TITLE
Fix EntryDirectionQuality logging to use GlobalLogger

### DIFF
--- a/EntryTypes/EntryDirectionQuality.cs
+++ b/EntryTypes/EntryDirectionQuality.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
+using GeminiV26.Core.Logging;
 
 namespace GeminiV26.EntryTypes
 {
@@ -230,10 +231,8 @@ namespace GeminiV26.EntryTypes
                 {
                     int cap = EntryDecisionPolicy.MinScoreThreshold - 1;
 
-                    Log.Debug(
-                        "[ENTRY][QUALITY][DEAD_MARKET_BLOCK] continuation + noTrend + noMomentum → score capped below threshold ({0})",
-                        cap
-                    );
+                    GlobalLogger.Log(
+                        $"[ENTRY][QUALITY][DEAD_MARKET_BLOCK] continuation + noTrend + noMomentum -> score capped below threshold ({cap})");
 
                     score = Math.Min(score, cap);
                 }
@@ -250,12 +249,12 @@ namespace GeminiV26.EntryTypes
                 impulseAligned ? "ImpulseAligned" :
                 "None";
 
-            ctx.Log?.Invoke(
+            GlobalLogger.Log(
                 $"[DIR QUALITY] type={request.TypeTag} side={direction} structure={structure} " +
                 $"logicBias={logicBias} logicConf={logicConfidence} htfDir={htfDirection} htfConf={htfConfidence:F2} " +
                 $"regime={regime} penalty={penalty} marketStatePenalty={marketStateAdditivePenalty} bonus={bonus} finalScore={score}");
 
-            ctx.Log?.Invoke(
+            GlobalLogger.Log(
                 $"[ENTRY SCORE FLOW] type={request.TypeTag} side={direction} " +
                 $"baseScore={baseScoreFlow:F1} afterAdditive={afterAdditiveFlow:F1} " +
                 $"afterTrendScaling={afterTrendFlow:F1} afterMomentumScaling={afterMomentumFlow:F1} " +
@@ -282,7 +281,7 @@ namespace GeminiV26.EntryTypes
                 eval.PostCapScore = trace.PostCapScore;
                 eval.HasQualityScoreTrace = true;
             }
-            ctx?.Log?.Invoke(
+            GlobalLogger.Log(
                 $"[DIR FLOW] type={typeTag} logicBias={ctx?.LogicBiasDirection ?? TradeDirection.None} evalDir={eval?.Direction ?? TradeDirection.None} score={eval?.Score ?? 0}");
         }
 


### PR DESCRIPTION
### Motivation
- A recent change introduced a call to an undefined `Log.Debug(...)`, causing an invalid reference and breaking the intended global logging policy.
- The project uses centralized logging via `GlobalLogger`, so `EntryDirectionQuality` needs to follow that convention for consistent runtime logging and to avoid compile errors.

### Description
- Added `using GeminiV26.Core.Logging;` to `EntryTypes/EntryDirectionQuality.cs` to access `GlobalLogger`.
- Replaced the invalid `Log.Debug(...)` call with `GlobalLogger.Log(...)` and adapted the message formatting.
- Replaced `ctx.Log?.Invoke(...)` calls in this file with `GlobalLogger.Log(...)` so logging is routed through the global logger.

### Testing
- Ran `rg -n "Log.Debug\(" EntryTypes/EntryDirectionQuality.cs` and verified no `Log.Debug` usages remain, which succeeded.
- Searched `EntryDirectionQuality.cs` for logging occurrences and confirmed the file now references `GlobalLogger` and contains the new `using` statement, which succeeded.
- Performed basic file-level checks to ensure the edited file is syntactically consistent after the changes, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe64d5cd08328a8ababc49c8db5e6)