### PR TITLE
Add dead-market gating for continuation entries and introduce EntryContext flags

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -10,6 +10,11 @@ using System;
 
 namespace GeminiV26.Core.Entry
 {
+    public sealed class EntryContextFlags
+    {
+        public bool IsDeadMarketBlocked { get; set; }
+    }
+
     public class EntryContext
     {
         // =========================
@@ -24,6 +29,7 @@ namespace GeminiV26.Core.Entry
             set => TempId = value;
         }
         public Action<string> Log { get; set; }
+        public EntryContextFlags Flags { get; set; } = new EntryContextFlags();
 
         public DateTime LastUpdateUtc { get; set; } = DateTime.UtcNow;
         public Robot Bot { get; }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -955,6 +955,7 @@ namespace GeminiV26.Core
             }
 
             _ctx.BarsSinceStart = BotRestartState.BarsSinceStart;
+            _ctx.Flags.IsDeadMarketBlocked = false;
 
 
             if (isMetalSymbol)
@@ -1473,6 +1474,33 @@ namespace GeminiV26.Core
                     }
 
                     LogEntryTraceGate(_ctx, selected, "MarketStateGate", selected.Direction, false, "PASS");
+                }
+
+                _ctx.FinalDirection = selected.Direction;
+                const double deadMarketMomentumThreshold = 0.55;
+                double transitionQuality = _ctx.Transition?.QualityScore ?? 0.0;
+                bool hasTrend =
+                    _ctx.FinalDirection != TradeDirection.None &&
+                    _ctx.ActiveHtfDirection == _ctx.FinalDirection;
+                bool hasMomentum = transitionQuality >= deadMarketMomentumThreshold;
+                bool isDeadMarket = !hasTrend && !hasMomentum;
+
+                bool isContinuation =
+                    selected.Type.ToString().IndexOf("Pullback", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    selected.Type.ToString().IndexOf("Flag", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    selected.Type.ToString().IndexOf("Breakout", StringComparison.OrdinalIgnoreCase) >= 0;
+
+                if (isDeadMarket && isContinuation)
+                {
+                    _ctx.Flags.IsDeadMarketBlocked = true;
+                    GlobalLogger.Log(_bot,
+                        $"[ENTRY][BLOCK][DEAD_MARKET] trend={hasTrend.ToString().ToLowerInvariant()} momentum={hasMomentum.ToString().ToLowerInvariant()} TQ={transitionQuality:F2}");
+                }
+
+                if (_ctx.Flags.IsDeadMarketBlocked)
+                {
+                    GlobalLogger.Log(_bot, "[ROUTER][BLOCK][DEAD_MARKET]");
+                    return;
                 }
 
 


### PR DESCRIPTION
### Motivation
- Prevent continuation-style entries from being taken in markets with neither trend nor momentum (a "dead market").
- Provide a place to store entry-level boolean flags on `EntryContext` to control routing behavior.

### Description
- Add a new `EntryContextFlags` class and expose it as `Flags` on `EntryContext` with a default instance and an `IsDeadMarketBlocked` boolean flag.
- Ensure the `EntryContext` is ready before routing and initialize `Flags.IsDeadMarketBlocked` to `false` when building the context via `TradeCore`.
- Compute `FinalDirection`, read `Transition.QualityScore`, and determine `hasTrend` and `hasMomentum` using a momentum threshold of `0.55`, and classify the entry as a continuation when `selected.Type` contains `Pullback`, `Flag`, or `Breakout`.
- When both `isDeadMarket` and `isContinuation` are true, set `Flags.IsDeadMarketBlocked` and log the block, and short-circuit entry routing when the flag is set.

### Testing
- Project build was executed and completed successfully.
- Existing automated unit tests were run and all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf21842d08328ba21b7119e2d5713)