### PR TITLE
Add post‑TP1 profit‑protection logic and expose telemetry in logs/CSV

### DIFF
--- a/Core/Logging/CsvTradeLogger.cs
+++ b/Core/Logging/CsvTradeLogger.cs
@@ -17,6 +17,8 @@ namespace GeminiV26.Core.Logging
             "InitialRiskR","RiskPercent","StopDistanceATR","SlAtrMult","LotCapHit",
             "MFE_R","MAE_R","BarsInTrade","MinutesInTrade",
             "Tp1Hit","Tp2Hit","BeActivated","TrailingActivated",
+            "PostTp1MaxR","PostTp1GivebackR","Tp1ProtectExitHit","Tp1ProtectExitR",
+            "Tp1ProtectScoreAtExit","Tp1ProtectMode",
             "ExitMode","ExitReason","ExitTime","ExitPrice",
             "NetProfit","GrossProfit","Commissions","Swap","Pips"
         };
@@ -104,6 +106,12 @@ namespace GeminiV26.Core.Logging
                     CsvBool((pctx != null) ? (bool?)(pctx.Tp2Hit > 0) : null),
                     CsvBool(pctx?.BeActivated),
                     CsvBool(pctx?.TrailingActivated),
+                    CsvNum(result?.PostTp1MaxR),
+                    CsvNum(result?.PostTp1GivebackR),
+                    CsvBool(result?.Tp1ProtectExitHit),
+                    CsvNum(result?.Tp1ProtectExitR),
+                    CsvInt(pctx?.Tp1ProtectExitHit == true ? pctx?.Tp1ProtectScoreAtExit : null),
+                    Csv(pctx?.Tp1ProtectExitHit == true ? pctx?.Tp1ProtectMode : null),
 
                     Csv(result?.ExitMode),
                     Csv(result?.ExitReason),
@@ -148,6 +156,11 @@ namespace GeminiV26.Core.Logging
         }
 
         private static string CsvNum(double? value)
+        {
+            return value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : "";
+        }
+
+        private static string CsvInt(int? value)
         {
             return value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : "";
         }

--- a/Core/Logging/ITradeLogger.cs
+++ b/Core/Logging/ITradeLogger.cs
@@ -37,6 +37,12 @@ namespace GeminiV26.Core.Logging
         public double? Commissions { get; set; }
         public double? Swap { get; set; }
         public double? Pips { get; set; }
+        public double? PostTp1MaxR { get; set; }
+        public double? PostTp1GivebackR { get; set; }
+        public bool? Tp1ProtectExitHit { get; set; }
+        public double? Tp1ProtectExitR { get; set; }
+        public int? Tp1ProtectScoreAtExit { get; set; }
+        public string Tp1ProtectMode { get; set; }
     }
 
     public sealed class CompositeTradeLogger : ITradeLogger

--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -438,6 +438,20 @@ namespace GeminiV26.Core
 
         public string PostTp1TrailingMode { get; set; } = string.Empty;
 
+        public double PostTp1MaxR { get; set; }
+
+        public double PostTp1MaxPrice { get; set; }
+
+        public bool Tp1ProtectExitHit { get; set; }
+
+        public double? Tp1ProtectExitR { get; set; }
+
+        public int? Tp1ProtectScoreAtExit { get; set; }
+
+        public string Tp1ProtectMode { get; set; } = string.Empty;
+
+        public double? PostTp1GivebackR { get; set; }
+
         public double Tp2ExtensionMultiplierApplied { get; set; } = 1.0;
 
         public double? LastExtendedTp2 { get; set; }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -3542,7 +3542,11 @@ namespace GeminiV26.Core
                     GrossProfit = pos.GrossProfit,
                     Commissions = pos.Commissions,
                     Swap = pos.Swap,
-                    Pips = pos.Pips
+                    Pips = pos.Pips,
+                    PostTp1MaxR = ctx?.PostTp1MaxR,
+                    PostTp1GivebackR = ctx?.PostTp1GivebackR,
+                    Tp1ProtectExitHit = ctx?.Tp1ProtectExitHit,
+                    Tp1ProtectExitR = ctx?.Tp1ProtectExitR
                 });
 
             _statsTracker.RegisterTradeClose(

--- a/Data/Models/TradeLogger.cs
+++ b/Data/Models/TradeLogger.cs
@@ -58,7 +58,7 @@ namespace GeminiV26.Data
 
                         // --- NEW ---
                         "RiskPercent,SlAtrMult,Tp1R,Tp2R,LotCapHit," +
-                        "BeActivated,TrailingActivated,ExitMode," +
+                        "BeActivated,TrailingActivated,PostTp1MaxR,PostTp1GivebackR,Tp1ProtectExitHit,Tp1ProtectExitR,Tp1ProtectScoreAtExit,Tp1ProtectMode,ExitMode," +
 
                         "ExitReason,NetProfit,GrossProfit,Commissions,Swap,Pips"
                     );
@@ -95,6 +95,12 @@ namespace GeminiV26.Data
                     t.LotCapHit?.ToString() ?? "",
                     t.BeActivated?.ToString() ?? "",
                     t.TrailingActivated?.ToString() ?? "",
+                    t.PostTp1MaxR?.ToString(CultureInfo.InvariantCulture) ?? "",
+                    t.PostTp1GivebackR?.ToString(CultureInfo.InvariantCulture) ?? "",
+                    t.Tp1ProtectExitHit?.ToString() ?? "",
+                    t.Tp1ProtectExitR?.ToString(CultureInfo.InvariantCulture) ?? "",
+                    t.Tp1ProtectScoreAtExit?.ToString(CultureInfo.InvariantCulture) ?? "",
+                    Escape(t.Tp1ProtectMode),
                     Escape(t.ExitMode),
                     Escape(t.ExitReason),
                     t.NetProfit.ToString(CultureInfo.InvariantCulture),

--- a/Data/Models/TradeRecord.cs
+++ b/Data/Models/TradeRecord.cs
@@ -53,6 +53,12 @@ namespace GeminiV26.Data.Models
         // --- Exit diagnostics ---
         public bool? BeActivated { get; set; }
         public bool? TrailingActivated { get; set; }
+        public double? PostTp1MaxR { get; set; }
+        public double? PostTp1GivebackR { get; set; }
+        public bool? Tp1ProtectExitHit { get; set; }
+        public double? Tp1ProtectExitR { get; set; }
+        public int? Tp1ProtectScoreAtExit { get; set; }
+        public string Tp1ProtectMode { get; set; } = string.Empty;
         public string ExitMode { get; set; } // TP1 / TP2 / BE / TRAIL / HARDLOSS / SL
 
     }

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.AUDNZD
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public AudNzdExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.AUDNZD
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.AUDNZD
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.AUDUSD
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public AudUsdExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.AUDUSD
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.AUDUSD
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -34,6 +34,10 @@ namespace GeminiV26.Instruments.BTCUSD
         // ===== TP1 / BE =====
         private const double BeOffsetR = 0.05;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         // ===== Legacy BTC trailing fallback =====
         private const double MinTrailImprovePips = 10;
         private const double TrailTight = 1.2;
@@ -380,6 +384,11 @@ namespace GeminiV26.Instruments.BTCUSD
                 // =========================
                 // TP1 után: TTM + adaptive trailing
                 // =========================
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -608,6 +617,168 @@ namespace GeminiV26.Instruments.BTCUSD
                 _ => TrailNormal
             };
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -26,6 +26,10 @@ namespace GeminiV26.Instruments.ETHUSD
 
         private const double BeOffsetR = 0.05;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         private const double MinTrailImprovePips = 50;
 
         private const double TrailTight = 1.0;
@@ -360,6 +364,11 @@ namespace GeminiV26.Instruments.ETHUSD
                 // TP1 után: TTM + trailing
                 // =========================
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
 
                 var structure = _structureTracker.GetSnapshot();
@@ -527,6 +536,168 @@ namespace GeminiV26.Instruments.ETHUSD
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.EURJPY
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public EurJpyExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.EURJPY
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.EURJPY
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.EURUSD
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public EurUsdExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.EURUSD
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.EURUSD
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.GBPJPY
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public GbpJpyExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.GBPJPY
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.GBPJPY
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.GBPUSD
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public GbpUsdExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.GBPUSD
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.GBPUSD
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.GER40
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public Ger40ExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.GER40
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.GER40
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.NAS100
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public NasExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.NAS100
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.NAS100
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.NZDUSD
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public NzdUsdExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.NZDUSD
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.NZDUSD
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.US30
 
         private const double BeOffsetR = 0.12;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public Us30ExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.US30
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.US30
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.USDCAD
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public UsdCadExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.USDCAD
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.USDCAD
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.USDCHF
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public UsdChfExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.USDCHF
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.USDCHF
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -24,6 +24,10 @@ namespace GeminiV26.Instruments.USDJPY
 
         private const double BeOffsetR = 0.10;
 
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public UsdJpyExitManager(Robot bot)
         {
             _bot = bot;
@@ -323,6 +327,11 @@ namespace GeminiV26.Instruments.USDJPY
                     continue;
                 }
 
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -470,6 +479,168 @@ namespace GeminiV26.Instruments.USDJPY
             double d2 = Math.Abs(pos.EntryPrice - pos.StopLoss.Value);
             return d2 > 0 ? d2 : 0;
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -53,6 +53,11 @@ namespace GeminiV26.Instruments.XAUUSD
         private readonly Dictionary<long, PositionContext> _contexts = new();
         private readonly HashSet<long> _rehydratedResolverSkipLogged = new();
 
+
+        private const double Tp1ProtectMinR = 0.8;
+        private const int Tp1ProtectSwingLookback = 5;
+        private const int Tp1ProtectExtremeLookback = 3;
+
         public XauExitManager(Robot bot)
         {
             _bot = bot;
@@ -410,6 +415,11 @@ namespace GeminiV26.Instruments.XAUUSD
                 // =========================
                 // TRAILING (TP1 után)
                 // =========================
+                UpdatePostTp1ProtectionState(ctx, currentPrice, rDist);
+
+                if (CheckPostTp1ProfitProtection(ctx, currentPrice))
+                    continue;
+
                 var profile = TrailingProfiles.ResolveBySymbol(pos.SymbolName);
                 var structure = _structureTracker.GetSnapshot();
                 var decision = _trendTradeManager.Evaluate(pos, ctx, profile, structure);
@@ -748,6 +758,168 @@ namespace GeminiV26.Instruments.XAUUSD
                 GlobalLogger.Log(_bot, $"[XAU REHYDRATE] pos={pos.Id}");
             }
         }
+
+        private void UpdatePostTp1ProtectionState(PositionContext ctx, double currentPrice, double rDist)
+        {
+            if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
+                return;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            if (currentR > ctx.PostTp1MaxR)
+            {
+                ctx.PostTp1MaxR = currentR;
+                ctx.PostTp1MaxPrice = currentPrice;
+            }
+        }
+
+        public bool CheckPostTp1ProfitProtection(PositionContext ctx, double currentPrice)
+        {
+            var pos = ctx == null ? null : FindPosition(ctx.PositionId);
+            return CheckPostTp1ProfitProtection(pos, ctx, currentPrice);
+        }
+
+        private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
+        {
+            if (ctx == null || pos == null)
+                return false;
+
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+
+            bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
+            if (!activation)
+                return false;
+
+            double rDist = GetRiskDistance(pos, ctx);
+            if (rDist <= 0)
+                return false;
+
+            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            bool profitThreshold = currentR >= Tp1ProtectMinR;
+
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+                return false;
+
+            var bars = m1;
+            int last = bars.Count - 2;
+            if (last < 6)
+                return false;
+
+            double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
+            double eps = Math.Max(1e-8, tickSize * 0.5);
+
+            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            double lastSwingLow = double.MaxValue;
+            double lastSwingHigh = double.MinValue;
+            for (int i = swingStart; i <= last; i++)
+            {
+                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
+                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+            }
+
+            bool structureBreak = IsLong(ctx)
+                ? currentPrice < (lastSwingLow - eps)
+                : currentPrice > (lastSwingHigh + eps);
+
+            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int priorEnd = recentStart - 1;
+            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+
+            double recentHigh = double.MinValue;
+            double recentLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
+            }
+
+            double priorHigh = double.MinValue;
+            double priorLow = double.MaxValue;
+            for (int i = priorStart; i <= priorEnd; i++)
+            {
+                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
+                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+            }
+
+            bool noNewExtreme = IsLong(ctx)
+                ? recentHigh <= (priorHigh + eps)
+                : recentLow >= (priorLow - eps);
+
+            bool structureWeakening = IsLong(ctx)
+                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
+                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+
+            double currOpen = bars.OpenPrices[last];
+            double currClose = bars.ClosePrices[last];
+            double prevOpen = bars.OpenPrices[last - 1];
+            double prevClose = bars.ClosePrices[last - 1];
+            double prev2Open = bars.OpenPrices[last - 2];
+            double prev2Close = bars.ClosePrices[last - 2];
+
+            double currBody = Math.Abs(currClose - currOpen);
+            double prevBody = Math.Abs(prevClose - prevOpen);
+            double prev2Body = Math.Abs(prev2Close - prev2Open);
+
+            bool bodySmaller = currBody < prevBody;
+            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+
+            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
+            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
+            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+
+            bool strongOpposite = IsLong(ctx)
+                ? (currClose < currOpen && currBody > prevBody)
+                : (currClose > currOpen && currBody > prevBody);
+
+            bool momentumCollapseStrong = strongOpposite;
+            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+
+            int protectScore = 0;
+            if (structureBreak) protectScore++;
+            if (noNewExtreme) protectScore++;
+            if (momentumCollapse) protectScore++;
+            if (structureWeakening) protectScore++;
+
+            bool earlyProtect = profitThreshold && protectScore >= 2;
+            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][SCORE]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"currentR={currentR:0.###}\n" +
+                $"protectScore={protectScore}\n" +
+                $"earlyProtect={earlyProtect}\n" +
+                $"hardProtect={hardProtect}");
+
+            if (!(earlyProtect || hardProtect))
+                return false;
+
+            bool trailingConflict = pos.StopLoss.HasValue &&
+                (IsLong(ctx)
+                    ? currentPrice < (pos.StopLoss.Value - eps)
+                    : currentPrice > (pos.StopLoss.Value + eps));
+
+            if (trailingConflict)
+                return false;
+
+            ctx.Tp1ProtectExitHit = true;
+            ctx.Tp1ProtectExitR = currentR;
+            ctx.Tp1ProtectScoreAtExit = protectScore;
+            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.IsFullyClosing = true;
+
+            GlobalLogger.Log(_bot,
+                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
+                $"symbol={pos.SymbolName}\n" +
+                $"positionId={pos.Id}\n" +
+                $"exitPrice={currentPrice:0.#####}\n" +
+                $"currentR={currentR:0.###}");
+
+            _bot.ClosePosition(pos);
+            return true;
+        }
+
 
         private void TryExtendTp2(Position pos, PositionContext ctx, TrendDecision decision)
         {


### PR DESCRIPTION
### Motivation

- Implement an automatic profit‑protection mechanism that can trigger an early or hard exit after TP1 when post‑TP1 price behaviour suggests weakening momentum or structure break. 
- Record additional post‑TP1 metrics and protection diagnostics so exits and analytics capture the maximum post‑TP1 run, giveback and protection metadata. 
- Surface the new metrics through the trade logging pipeline and legacy CSV outputs for analysis and backtesting.

### Description

- Extended `PositionContext` with post‑TP1 state fields: `PostTp1MaxR`, `PostTp1MaxPrice`, `Tp1ProtectExitHit`, `Tp1ProtectExitR`, `Tp1ProtectScoreAtExit`, `Tp1ProtectMode`, and `PostTp1GivebackR`.
- Added new fields to `TradeLogResult` and to the data model `TradeRecord`/legacy `TradeLogger` outputs and updated `CsvTradeLogger` header and value serialization (added `CsvInt` helper) to include `PostTp1MaxR`, `PostTp1GivebackR`, `Tp1ProtectExitHit`, `Tp1ProtectExitR`, `Tp1ProtectScoreAtExit` and `Tp1ProtectMode`.
- Plumbed the protection telemetry into `TradeCore` so closed trades include the new `TradeLogResult` properties.
- Implemented post‑TP1 protection routines in per‑instrument exit managers: added `UpdatePostTp1ProtectionState` to update running maxima and `CheckPostTp1ProfitProtection` which evaluates structure/momentum rules (swing/extreme lookbacks, body/range comparisons, trailing conflicts) and when conditions meet either `EARLY` or `HARD` protection criteria it flags the context, sets giveback, logs diagnostic messages and closes the position.
- Added small configuration constants (`Tp1ProtectMinR`, `Tp1ProtectSwingLookback`, `Tp1ProtectExtremeLookback`) and integrated the protection check into the main per‑tick TP1+ flow before trailing and TP2 extension logic.

### Testing

- The solution was built successfully after the changes and compilation errors were resolved.
- Existing automated unit/integration tests were executed and completed without failures (no new automated tests were added as part of this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf99ee8048328bbfc12a5911593c4)