### PR TITLE
Refine continuation entry filters: relax INDEX transition, require impulse, avoid double-filter stacking

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2736,13 +2736,21 @@ namespace GeminiV26.Core
                     candidate.TriggerConfirmed = false;
                 }
 
-                if (!ApplyContinuationTransitionNoMomentumFilter(ctx, candidate))
+                bool continuationFilterApplied = false;
+
+                if (!ApplyContinuationTransitionNoMomentumFilter(ctx, candidate, out continuationFilterApplied))
                 {
                     ClearArmedSetup(candidate);
                     continue;
                 }
 
-                if (!ApplyContinuationWeakStructureFilter(ctx, candidate))
+                if (continuationFilterApplied)
+                {
+                    string instrument = candidate.Symbol ?? ctx.Symbol ?? _bot.SymbolName;
+                    GlobalLogger.Log(_bot,
+                        $"[ENTRY][FILTER][SKIPPED] instrument={instrument} entryType={candidate.Type} reason=already_filtered");
+                }
+                else if (!ApplyContinuationWeakStructureFilter(ctx, candidate))
                 {
                     ClearArmedSetup(candidate);
                     continue;
@@ -2964,8 +2972,10 @@ namespace GeminiV26.Core
             return false;
         }
 
-        private bool ApplyContinuationTransitionNoMomentumFilter(EntryContext ctx, EntryEvaluation candidate)
+        private bool ApplyContinuationTransitionNoMomentumFilter(EntryContext ctx, EntryEvaluation candidate, out bool filterApplied)
         {
+            filterApplied = false;
+
             if (ctx == null || candidate == null)
                 return true;
 
@@ -2993,6 +3003,12 @@ namespace GeminiV26.Core
             var instrumentClass = SymbolRouting.ResolveInstrumentClass(instrument);
             int penalty = 0;
             bool block = false;
+            TransitionEvaluation transition = candidate.Direction == TradeDirection.Long
+                ? ctx.TransitionLong
+                : candidate.Direction == TradeDirection.Short
+                    ? ctx.TransitionShort
+                    : ctx.Transition;
+            double transitionQuality = transition?.QualityScore ?? ctx.Transition?.QualityScore ?? 0.0;
 
             switch (instrumentClass)
             {
@@ -3000,7 +3016,8 @@ namespace GeminiV26.Core
                     block = true;
                     break;
                 case InstrumentClass.INDEX:
-                    block = true;
+                    penalty = 8;
+                    block = transitionQuality < 0.40;
                     break;
                 case InstrumentClass.FX:
                     penalty = 8;
@@ -3009,6 +3026,8 @@ namespace GeminiV26.Core
                     penalty = 4;
                     break;
             }
+
+            filterApplied = true;
 
             if (block)
             {
@@ -3019,7 +3038,7 @@ namespace GeminiV26.Core
                     ? "[TRANSITION_NO_MOMENTUM_BLOCK]"
                     : $"{candidate.Reason} [TRANSITION_NO_MOMENTUM_BLOCK]";
                 GlobalLogger.Log(_bot,
-                    $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] instrument={instrument} entryType={candidate.Type} action=block momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()}");
+                    $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] instrument={instrument} entryType={candidate.Type} action=block momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()} transitionQuality={transitionQuality:0.00}");
                 return false;
             }
 
@@ -3029,7 +3048,7 @@ namespace GeminiV26.Core
                 ? "[TRANSITION_NO_MOMENTUM_PENALTY]"
                 : $"{candidate.Reason} [TRANSITION_NO_MOMENTUM_PENALTY]";
             GlobalLogger.Log(_bot,
-                $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] instrument={instrument} entryType={candidate.Type} action=penalty momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()} score={scoreBefore}->{candidate.Score} penalty={penalty}");
+                $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] instrument={instrument} entryType={candidate.Type} action=penalty momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()} transitionQuality={transitionQuality:0.00} score={scoreBefore}->{candidate.Score} penalty={penalty}");
             return true;
         }
 
@@ -3083,8 +3102,32 @@ namespace GeminiV26.Core
                     break;
             }
 
+            if (!transition.HasImpulse)
+            {
+                if (instrumentClass == InstrumentClass.CRYPTO)
+                {
+                    candidate.IsValid = false;
+                    candidate.TriggerConfirmed = false;
+                    candidate.State = EntryState.NONE;
+                    candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
+                        ? "[NO_IMPULSE_BLOCK]"
+                        : $"{candidate.Reason} [NO_IMPULSE_BLOCK]";
+                    GlobalLogger.Log(_bot,
+                        $"[ENTRY][FILTER][NO_IMPULSE] instrument={instrument} entryType={candidate.Type} action=block");
+                    return false;
+                }
+
+                int impulseScoreBefore = candidate.Score;
+                candidate.Score = Math.Max(0, candidate.Score - penalty);
+                candidate.Reason = string.IsNullOrWhiteSpace(candidate.Reason)
+                    ? "[NO_IMPULSE_PENALTY]"
+                    : $"{candidate.Reason} [NO_IMPULSE_PENALTY]";
+                GlobalLogger.Log(_bot,
+                    $"[ENTRY][FILTER][NO_IMPULSE] instrument={instrument} entryType={candidate.Type} action=penalty score={impulseScoreBefore}->{candidate.Score} penalty={penalty}");
+                return true;
+            }
+
             bool weakStructure =
-                !transition.HasImpulse ||
                 impulseStrength < qualityThreshold ||
                 flagQuality < flagThreshold;
 


### PR DESCRIPTION
### Motivation
- Reduce over-blocking for continuation entries by softening INDEX transition handling while preserving protection against very weak transitions.
- Enforce an explicit impulse presence check for continuation structure validation so structurally weak trades (especially crypto) are reduced.
- Prevent the same candidate from receiving stacked filters (double penalties or redundant blocks) by short-circuiting subsequent filters once one has acted.

### Description
- Added a guard to the continuation flow so `ApplyContinuationWeakStructureFilter` is skipped when `ApplyContinuationTransitionNoMomentumFilter` already acted, and emit `[ENTRY][FILTER][SKIPPED] reason=already_filtered` logs.
- Changed `ApplyContinuationTransitionNoMomentumFilter` to return an `out bool filterApplied`, to compute `transitionQuality` per-candidate, to include `transitionQuality` in logs, and to relax INDEX handling so INDEX receives a heavy penalty by default and only `block`s when `transitionQuality < 0.40`.
- Introduced an explicit `HasImpulse` requirement inside `ApplyContinuationWeakStructureFilter` that `block`s CRYPTO entries when missing and applies a penalty for other instrument classes, with `[ENTRY][FILTER][NO_IMPULSE]` logging for both outcomes.
- Removed `HasImpulse` from the proxy-only weak-structure boolean so impulse is enforced once and not double-counted as a separate weak-structure condition.

### Testing
- Attempted to run a local build with `dotnet build -v minimal`, but it failed because `dotnet` is not available in the current environment (`dotnet: command not found`), so no automated build/tests completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0091b5448328b790a42a69b80f2e)