### PR TITLE
Add continuation entry qualification engine and pre-execution TradeCore gate

### DIFF
--- a/Core/Entry/Qualification/ContinuationPolicy.cs
+++ b/Core/Entry/Qualification/ContinuationPolicy.cs
@@ -1,0 +1,113 @@
+using Gemini.Memory;
+using GeminiV26.Instruments;
+using System;
+
+namespace GeminiV26.Core.Entry.Qualification
+{
+    public static class ContinuationPolicy
+    {
+        public static EntryDecision Evaluate(EntryContext ctx, EntryType entryType)
+        {
+            if (ctx == null)
+                return EntryDecision.Pass();
+
+            InstrumentClass instrumentClass = ResolveInstrumentClass(ctx);
+
+            if (IsFlagType(entryType))
+            {
+                int flagBars = Math.Max(ctx.FlagBarsLong_M5, ctx.FlagBarsShort_M5);
+
+                if (flagBars < 2)
+                {
+                    Log(ctx, "[ENTRY][BLOCK][INVALID_FLAG]", $"flagBars={flagBars}");
+                    return EntryDecision.Block("INVALID_FLAG");
+                }
+            }
+
+            bool hasMomentum = (ctx.Transition?.QualityScore ?? 0.0) >= 0.55;
+            bool hasImpulse = ctx.HasImpulse_M5 || ctx.HasImpulseLong_M5 || ctx.HasImpulseShort_M5;
+            bool hasTrend =
+                ctx.LogicBiasDirection != TradeDirection.None ||
+                ctx.ActiveHtfDirection != TradeDirection.None ||
+                ctx.TrendDirection != TradeDirection.None;
+
+            if (instrumentClass == InstrumentClass.INDEX && !hasMomentum)
+            {
+                Log(ctx, "[ENTRY][BLOCK][NO_MOMENTUM_INDEX]", string.Empty);
+                return EntryDecision.Block("NO_MOMENTUM_INDEX");
+            }
+
+            if (instrumentClass == InstrumentClass.CRYPTO && !hasImpulse)
+            {
+                Log(ctx, "[ENTRY][BLOCK][NO_IMPULSE_CRYPTO]", string.Empty);
+                return EntryDecision.Block("NO_IMPULSE_CRYPTO");
+            }
+
+            if (!hasMomentum && !hasTrend)
+            {
+                Log(ctx, "[ENTRY][BLOCK][DEAD_MARKET]", string.Empty);
+                return EntryDecision.Block("DEAD_MARKET");
+            }
+
+            SymbolMemoryState memory = ctx.Memory;
+            if (memory != null)
+            {
+                if (memory.BarsSinceImpulse < 2)
+                {
+                    Log(ctx, "[ENTRY][BLOCK][TOO_EARLY]", string.Empty);
+                    return EntryDecision.Block("TOO_EARLY");
+                }
+
+                if (memory.MoveAgeBars > 20)
+                {
+                    Log(ctx, "[ENTRY][BLOCK][TOO_LATE]", string.Empty);
+                    return EntryDecision.Block("TOO_LATE");
+                }
+            }
+
+            if (ctx.Transition != null && ctx.Transition.QualityScore < 50.0)
+            {
+                Log(ctx, "[ENTRY][PENALTY][WEAK_STRUCTURE]", $"score={ctx.Transition.QualityScore:0.##}");
+                return EntryDecision.Penalize(0.15, "WEAK_STRUCTURE");
+            }
+
+            return EntryDecision.Pass();
+        }
+
+        private static bool IsFlagType(EntryType entryType)
+            => entryType.ToString().IndexOf("Flag", StringComparison.OrdinalIgnoreCase) >= 0;
+
+        private static InstrumentClass ResolveInstrumentClass(EntryContext ctx)
+        {
+            string symbol = ctx.Symbol ?? string.Empty;
+            if (symbol.IndexOf("BTC", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                symbol.IndexOf("ETH", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return InstrumentClass.CRYPTO;
+            }
+
+            if (symbol.IndexOf("XAU", StringComparison.OrdinalIgnoreCase) >= 0)
+                return InstrumentClass.METAL;
+
+            if (symbol.IndexOf("NAS", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                symbol.IndexOf("US30", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                symbol.IndexOf("GER40", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return InstrumentClass.INDEX;
+            }
+
+            return InstrumentClass.FX;
+        }
+
+        private static void Log(EntryContext ctx, string tag, string details)
+        {
+            if (ctx.Log != null)
+            {
+                ctx.Log($"{tag} symbol={ctx.Symbol} {details}".TrimEnd());
+                return;
+            }
+
+            Console.WriteLine($"{tag} symbol={ctx.Symbol} {details}".TrimEnd());
+        }
+    }
+}

--- a/Core/Entry/Qualification/EntryDecision.cs
+++ b/Core/Entry/Qualification/EntryDecision.cs
@@ -1,0 +1,30 @@
+namespace GeminiV26.Core.Entry.Qualification
+{
+    public enum EntryDecisionType
+    {
+        Block,
+        Penalize,
+        Pass
+    }
+
+    public sealed class EntryDecision
+    {
+        public EntryDecisionType Type { get; set; }
+        public double Penalty { get; set; } = 0.0;
+        public string Reason { get; set; } = string.Empty;
+
+        public static EntryDecision Block(string reason)
+            => new EntryDecision { Type = EntryDecisionType.Block, Reason = reason ?? string.Empty };
+
+        public static EntryDecision Pass()
+            => new EntryDecision { Type = EntryDecisionType.Pass };
+
+        public static EntryDecision Penalize(double penalty, string reason)
+            => new EntryDecision
+            {
+                Type = EntryDecisionType.Penalize,
+                Penalty = penalty < 0 ? 0 : penalty,
+                Reason = reason ?? string.Empty
+            };
+    }
+}

--- a/Core/Entry/Qualification/EntryQualificationEngine.cs
+++ b/Core/Entry/Qualification/EntryQualificationEngine.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace GeminiV26.Core.Entry.Qualification
+{
+    public static class EntryQualificationEngine
+    {
+        public static EntryDecision Evaluate(EntryContext ctx, EntryType entryType)
+        {
+            if (ctx == null)
+                return EntryDecision.Pass();
+
+            if (IsContinuationEntry(entryType))
+                return ContinuationPolicy.Evaluate(ctx, entryType);
+
+            return EntryDecision.Pass();
+        }
+
+        private static bool IsContinuationEntry(EntryType entryType)
+        {
+            string typeName = entryType.ToString();
+            return typeName.IndexOf("Flag", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   typeName.IndexOf("Pullback", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   typeName.IndexOf("Breakout", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -67,6 +67,7 @@ using GeminiV26.Core.Analytics;
 using GeminiV26.Core.Memory;
 using GeminiV26.Core.Runtime;
 using GeminiV26.Core.Risk;
+using GeminiV26.Core.Entry.Qualification;
 using System.Linq;
 
 namespace GeminiV26.Core
@@ -1501,6 +1502,22 @@ namespace GeminiV26.Core
                 {
                     GlobalLogger.Log(_bot, "[ROUTER][BLOCK][DEAD_MARKET]");
                     return;
+                }
+
+                var qualificationDecision = EntryQualificationEngine.Evaluate(_ctx, selected.Type);
+                if (qualificationDecision.Type == EntryDecisionType.Block)
+                {
+                    GlobalLogger.Log(_bot, $"[ENTRY][QUALIFICATION][BLOCK] {qualificationDecision.Reason}");
+                    return;
+                }
+
+                if (qualificationDecision.Type == EntryDecisionType.Penalize)
+                {
+                    int scoreBeforePenalty = selected.Score;
+                    int scorePenalty = (int)Math.Round(qualificationDecision.Penalty * 100.0, MidpointRounding.AwayFromZero);
+                    selected.Score = Math.Max(0, selected.Score - scorePenalty);
+                    GlobalLogger.Log(_bot,
+                        $"[ENTRY][QUALIFICATION][PENALTY] {qualificationDecision.Reason} penalty={qualificationDecision.Penalty:0.##} score={scoreBeforePenalty}->{selected.Score}");
                 }
 
 


### PR DESCRIPTION
### Motivation

- Improve entry quality for continuation setups (Flag, Pullback, Breakout) by gating them with a lightweight, pre-execution qualification step that is additive and non-invasive to existing pipeline semantics.
- Provide deterministic outcomes: Block / Penalize / Pass for continuation entries to reduce false setups (early/late/fake flags, no-momentum index, no-impulse crypto) while preserving existing architecture and final acceptance rules.

### Description

- Added `Core/Entry/Qualification/EntryDecision.cs` implementing `EntryDecisionType` and `EntryDecision` constructors for `Block`, `Penalize`, and `Pass` outcomes.
- Added `Core/Entry/Qualification/EntryQualificationEngine.cs` which evaluates only continuation-style entries (name-based match on `Flag` / `Pullback` / `Breakout`) and delegates to the continuation policy.
- Added `Core/Entry/Qualification/ContinuationPolicy.cs` implementing the policy: flag bar validation (`INVALID_FLAG`), index momentum requirement (`NO_MOMENTUM_INDEX`), crypto impulse requirement (`NO_IMPULSE_CRYPTO`), dead-market / early/late memory blocks (`DEAD_MARKET`, `TOO_EARLY`, `TOO_LATE`) and a weak-structure penalty (`WEAK_STRUCTURE`) that returns a fractional penalty.
- Integrated the engine into `TradeCore.OnBar()` immediately after the dead-market check and before meta registration/execution (approx. around line ~1507), logging `[ENTRY][QUALIFICATION][BLOCK]` and `[ENTRY][QUALIFICATION][PENALTY]`, and applying penalties to `selected.Score` by converting fractional penalty to points (`penalty * 100`, rounded) without modifying other filters, FinalAcceptance, ExitManager, or risk sizing logic.

### Testing

- Performed automated repository inspections to verify files and integration presence using `rg` to locate `EntryQualificationEngine`, `EntryDecisionType`, `ContinuationPolicy` and the integration site in `TradeCore` and confirmed the new files exist and the insertion point is present.
- Verified the new logging tags appear in code (`[ENTRY][QUALIFICATION][BLOCK]`, `[ENTRY][QUALIFICATION][PENALTY]`, `[ENTRY][BLOCK][INVALID_FLAG]`, `[ENTRY][BLOCK][NO_MOMENTUM_INDEX]`, `[ENTRY][BLOCK][NO_IMPULSE_CRYPTO]`).
- Attempted to run a full build but no solution/project files were detected at repository root in this environment, so a complete compile/run test was not executed.
- No unit/integration tests were added or executed as part of this change (static/grep checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0d4e9204832888f9ff1492d51bd5)