### PR TITLE
Separate momentum from transition and stabilize continuation thresholds

### DIFF
--- a/Core/Entry/Qualification/ContinuationPolicy.cs
+++ b/Core/Entry/Qualification/ContinuationPolicy.cs
@@ -24,7 +24,9 @@ namespace GeminiV26.Core.Entry.Qualification
                 }
             }
 
-            bool hasMomentum = (ctx.Transition?.QualityScore ?? 0.0) >= 0.55;
+            bool hasMomentum = ctx.HasMomentum;
+            double transitionQuality = ctx.Transition?.QualityScore ?? 0.0;
+            bool hasTransition = transitionQuality >= 0.55;
             bool hasImpulse = ctx.HasImpulse_M5 || ctx.HasImpulseLong_M5 || ctx.HasImpulseShort_M5;
             bool hasTrend =
                 ctx.LogicBiasDirection != TradeDirection.None ||
@@ -33,8 +35,14 @@ namespace GeminiV26.Core.Entry.Qualification
 
             if (instrumentClass == InstrumentClass.INDEX && !hasMomentum)
             {
-                Log(ctx, "[ENTRY][BLOCK][NO_MOMENTUM_INDEX]", string.Empty);
-                return EntryDecision.Block("NO_MOMENTUM_INDEX");
+                if (!hasTrend)
+                {
+                    Log(ctx, "[ENTRY][BLOCK][NO_MOMENTUM_INDEX]", "no_trend");
+                    return EntryDecision.Block("NO_MOMENTUM_INDEX");
+                }
+
+                Log(ctx, "[ENTRY][PENALTY][NO_MOMENTUM_INDEX]", "trend_present");
+                return EntryDecision.Penalize(0.20, "NO_MOMENTUM_INDEX");
             }
 
             if (instrumentClass == InstrumentClass.CRYPTO && !hasImpulse)
@@ -47,6 +55,12 @@ namespace GeminiV26.Core.Entry.Qualification
             {
                 Log(ctx, "[ENTRY][BLOCK][DEAD_MARKET]", string.Empty);
                 return EntryDecision.Block("DEAD_MARKET");
+            }
+
+            if (transitionQuality < 0.30)
+            {
+                Log(ctx, "[ENTRY][BLOCK][TRANSITION_COLLAPSE]", $"TQ={transitionQuality:0.00}");
+                return EntryDecision.Block("TRANSITION_COLLAPSE");
             }
 
             SymbolMemoryState memory = ctx.Memory;
@@ -65,9 +79,9 @@ namespace GeminiV26.Core.Entry.Qualification
                 }
             }
 
-            if (ctx.Transition != null && ctx.Transition.QualityScore < 50.0)
+            if (!hasTransition)
             {
-                Log(ctx, "[ENTRY][PENALTY][WEAK_STRUCTURE]", $"score={ctx.Transition.QualityScore:0.##}");
+                Log(ctx, "[ENTRY][PENALTY][WEAK_STRUCTURE]", $"score={transitionQuality:0.##}");
                 return EntryDecision.Penalize(0.15, "WEAK_STRUCTURE");
             }
 


### PR DESCRIPTION
### Motivation

- Correct conflation of momentum and transition so the system uses the canonical momentum source and an independent transition quality score. 
- Fix an incorrect scale/threshold bug in weak-structure checks that used a 50.0 value instead of the 0.55-quality threshold. 
- Reduce over-blocking for index instruments by softening the no-momentum rule when trend is present and add a deterministic early block for extremely weak transitions. 

### Description

- Use `ctx.HasMomentum` as the truth source for momentum, introduce `transitionQuality` and `hasTransition` for transition evaluations, and keep both checks separate. 
- Replace the old `QualityScore < 50.0` weak-structure branch with a `hasTransition` check (i.e., `transitionQuality < 0.55`) and log the normalized `transitionQuality`. 
- For `InstrumentClass.INDEX` change the behavior so the code blocks only when both momentum and trend are absent, and otherwise applies a 20% penalty with the new log tag `[ENTRY][PENALTY][NO_MOMENTUM_INDEX]`. 
- Add a safe hard block for transition collapse when `transitionQuality < 0.30` using the new tag `[ENTRY][BLOCK][TRANSITION_COLLAPSE]`, placed just after the dead-market check. 
- Preserve all existing required log tags and add only the permitted new tags ` [ENTRY][PENALTY][NO_MOMENTUM_INDEX]` and `[ENTRY][BLOCK][TRANSITION_COLLAPSE]`. 
- Only `Core/Entry/Qualification/ContinuationPolicy.cs` was modified; no architecture or external integrations were changed. 

### Testing

- Attempted to run `dotnet build -v minimal` against the repository, but the environment reported `dotnet` is not available so a build could not be completed. 
- Static file inspection and local verification of the changed file `Core/Entry/Qualification/ContinuationPolicy.cs` were performed and the updated logic was validated by reading the file. 
- No other automated tests were executed in this environment due to the missing `dotnet` toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0f3c75c8832893d5e1c9a007e871)