### PR TITLE
Tighten entry trend/momentum evaluation, strict dead‑market blocking and continuation filters

### DIFF
--- a/Core/Entry/Qualification/ContinuationPolicy.cs
+++ b/Core/Entry/Qualification/ContinuationPolicy.cs
@@ -24,25 +24,26 @@ namespace GeminiV26.Core.Entry.Qualification
                 }
             }
 
-            bool hasMomentum = ctx.HasMomentum;
             double transitionQuality = ctx.Transition?.QualityScore ?? 0.0;
             bool hasTransition = transitionQuality >= 0.55;
             bool hasImpulse = ctx.HasImpulse_M5 || ctx.HasImpulseLong_M5 || ctx.HasImpulseShort_M5;
-            bool hasTrend =
-                ctx.LogicBiasDirection != TradeDirection.None ||
-                ctx.ActiveHtfDirection != TradeDirection.None ||
-                ctx.TrendDirection != TradeDirection.None;
+            bool hasDirectionalBias = ctx.LogicBiasDirection != TradeDirection.None;
+            bool hasStructure = hasImpulse || transitionQuality >= 0.55;
+            bool hasTrend = hasDirectionalBias && hasStructure;
+            bool hasMomentum = hasImpulse || transitionQuality >= 0.60;
 
-            if (instrumentClass == InstrumentClass.INDEX && !hasMomentum)
+            Log(ctx,
+                "[ENTRY][STATE][TREND_EVAL]",
+                $"bias={hasDirectionalBias.ToString().ToLowerInvariant()} structure={hasStructure.ToString().ToLowerInvariant()} result={hasTrend.ToString().ToLowerInvariant()}");
+            Log(ctx,
+                "[ENTRY][STATE][MOMENTUM_EVAL]",
+                $"impulse={hasImpulse.ToString().ToLowerInvariant()} TQ={transitionQuality:0.00} result={hasMomentum.ToString().ToLowerInvariant()}");
+
+            bool isDeadMarket = !hasTrend && !hasMomentum;
+            if (isDeadMarket)
             {
-                if (!hasTrend)
-                {
-                    Log(ctx, "[ENTRY][BLOCK][NO_MOMENTUM_INDEX]", "no_trend");
-                    return EntryDecision.Block("NO_MOMENTUM_INDEX");
-                }
-
-                Log(ctx, "[ENTRY][PENALTY][NO_MOMENTUM_INDEX]", "trend_present");
-                return EntryDecision.Penalize(0.20, "NO_MOMENTUM_INDEX");
+                Log(ctx, "[ENTRY][BLOCK][DEAD_MARKET_STRICT]", string.Empty);
+                return EntryDecision.Block("DEAD_MARKET_STRICT");
             }
 
             if (instrumentClass == InstrumentClass.CRYPTO && !hasImpulse)
@@ -51,10 +52,17 @@ namespace GeminiV26.Core.Entry.Qualification
                 return EntryDecision.Block("NO_IMPULSE_CRYPTO");
             }
 
-            if (!hasMomentum && !hasTrend)
+            bool isWeakContinuation = transitionQuality < 0.55 && !ctx.HasImpulse_M5;
+            if (isWeakContinuation)
             {
-                Log(ctx, "[ENTRY][BLOCK][DEAD_MARKET]", string.Empty);
-                return EntryDecision.Block("DEAD_MARKET");
+                Log(ctx,
+                    "[ENTRY][FILTER][WEAK_CONTINUATION]",
+                    $"TQ={transitionQuality:0.00} impulse={ctx.HasImpulse_M5.ToString().ToLowerInvariant()}");
+
+                if (instrumentClass == InstrumentClass.CRYPTO)
+                    return EntryDecision.Block("WEAK_CONTINUATION_CRYPTO");
+
+                return EntryDecision.Penalize(0.20, "WEAK_CONTINUATION");
             }
 
             if (transitionQuality < 0.30)

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1478,24 +1478,45 @@ namespace GeminiV26.Core
                 }
 
                 _ctx.FinalDirection = selected.Direction;
-                const double deadMarketMomentumThreshold = 0.55;
                 double transitionQuality = _ctx.Transition?.QualityScore ?? 0.0;
-                bool hasTrend =
-                    _ctx.FinalDirection != TradeDirection.None &&
-                    _ctx.ActiveHtfDirection == _ctx.FinalDirection;
-                bool hasMomentum = transitionQuality >= deadMarketMomentumThreshold;
+                bool hasImpulse = _ctx.HasImpulse_M5 || _ctx.HasImpulseLong_M5 || _ctx.HasImpulseShort_M5;
+                bool hasDirectionalBias = _ctx.LogicBiasDirection != TradeDirection.None;
+                bool hasStructure = hasImpulse || transitionQuality >= 0.55;
+                bool hasTrend = hasDirectionalBias && hasStructure;
+                bool hasMomentum = hasImpulse || transitionQuality >= 0.60;
                 bool isDeadMarket = !hasTrend && !hasMomentum;
 
-                bool isContinuation =
-                    selected.Type.ToString().IndexOf("Pullback", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    selected.Type.ToString().IndexOf("Flag", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    selected.Type.ToString().IndexOf("Breakout", StringComparison.OrdinalIgnoreCase) >= 0;
+                GlobalLogger.Log(_bot,
+                    $"[ENTRY][STATE][TREND_EVAL] bias={hasDirectionalBias.ToString().ToLowerInvariant()} structure={hasStructure.ToString().ToLowerInvariant()} result={hasTrend.ToString().ToLowerInvariant()}");
+                GlobalLogger.Log(_bot,
+                    $"[ENTRY][STATE][MOMENTUM_EVAL] impulse={hasImpulse.ToString().ToLowerInvariant()} TQ={transitionQuality:F2} result={hasMomentum.ToString().ToLowerInvariant()}");
 
-                if (isDeadMarket && isContinuation)
+                if (_instrumentClass == InstrumentClass.INDEX)
+                {
+                    if (!hasTrend && !hasMomentum)
+                    {
+                        GlobalLogger.Log(_bot, "[ENTRY][INDEX][EVAL] trend=false momentum=false action=block");
+                    }
+                    else if (hasTrend && !hasMomentum)
+                    {
+                        int scoreBeforeIndexPenalty = selected.Score;
+                        const int indexNoMomentumPenalty = 25;
+                        selected.Score = Math.Max(0, selected.Score - indexNoMomentumPenalty);
+                        GlobalLogger.Log(_bot, "[ENTRY][INDEX][EVAL] trend=true momentum=false action=penalty");
+                        GlobalLogger.Log(_bot,
+                            $"[ENTRY][QUALIFICATION][PENALTY] INDEX_TREND_NO_MOMENTUM penalty=0.25 score={scoreBeforeIndexPenalty}->{selected.Score}");
+                    }
+                    else
+                    {
+                        GlobalLogger.Log(_bot,
+                            $"[ENTRY][INDEX][EVAL] trend={hasTrend.ToString().ToLowerInvariant()} momentum={hasMomentum.ToString().ToLowerInvariant()} action=pass");
+                    }
+                }
+
+                if (isDeadMarket)
                 {
                     _ctx.Flags.IsDeadMarketBlocked = true;
-                    GlobalLogger.Log(_bot,
-                        $"[ENTRY][BLOCK][DEAD_MARKET] trend={hasTrend.ToString().ToLowerInvariant()} momentum={hasMomentum.ToString().ToLowerInvariant()} TQ={transitionQuality:F2}");
+                    GlobalLogger.Log(_bot, "[ENTRY][BLOCK][DEAD_MARKET_STRICT]");
                 }
 
                 if (_ctx.Flags.IsDeadMarketBlocked)
@@ -1508,6 +1529,7 @@ namespace GeminiV26.Core
                 if (qualificationDecision.Type == EntryDecisionType.Block)
                 {
                     GlobalLogger.Log(_bot, $"[ENTRY][QUALIFICATION][BLOCK] {qualificationDecision.Reason}");
+                    GlobalLogger.Log(_bot, "[ROUTER][ABORT][QUALIFICATION_BLOCK]");
                     return;
                 }
 


### PR DESCRIPTION
### Motivation
- Reduce false-positive entries from permissive trend/momentum signals by making trend require explicit logic bias + recent structure, standardizing momentum as force/speed, and preventing continuation trades in weak structure markets.
- Make INDEX behavior deterministic to stop fake continuation entries (e.g., GER40) while preserving valid trend+momentum trades.
- Ensure a qualification block cannot leak to the execution layer with an explicit abort log.

### Description
- Replaced permissive trend check with strict definition `hasTrend = hasDirectionalBias && hasStructure` where `hasDirectionalBias = ctx.LogicBiasDirection != None` and `hasStructure = HasImpulse_M5 || HasImpulseLong_M5 || HasImpulseShort_M5 || Transition.QualityScore >= 0.55` in both router and continuation qualification paths.  Log added: `[ENTRY][STATE][TREND_EVAL]`.
- Standardized momentum to represent speed/force: `hasMomentum = hasImpulse || Transition.QualityScore >= 0.60`, and added `[ENTRY][STATE][MOMENTUM_EVAL]` logging.
- Enforced strict dead‑market blocking (`!hasTrend && !hasMomentum`) for all instruments in the router and in continuation policy, emitting `[ENTRY][BLOCK][DEAD_MARKET_STRICT]` and preventing routing when set.
- Implemented INDEX-specific rules: if INDEX has neither trend nor momentum then block, if hasTrend but not hasMomentum apply a 0.25 penalty (implemented as score -25) and log `[ENTRY][INDEX][EVAL]` and `[ENTRY][QUALIFICATION][PENALTY]` for transparency.
- Strengthened continuation filter: detect `weakContinuation` when `Transition.QualityScore < 0.55 && !HasImpulse_M5`, log `[ENTRY][FILTER][WEAK_CONTINUATION]`, block for CRYPTO and penalize (0.20) for other instrument classes.
- Added defensive router log `[ROUTER][ABORT][QUALIFICATION_BLOCK]` at the qualification boundary to ensure blocked entries do not reach execution.
- All changes are local to `Core/TradeCore.cs` and `Core/Entry/Qualification/ContinuationPolicy.cs`; no architecture, HTF engines, global systems, scoring system, EntryRouter structure, ExitManager, or TVM were modified.

### Testing
- Basic repository checks and diffs were run locally: `git status` and `git show --stat` completed successfully (no build/test suite was invoked). 
- No automated unit/integration tests in CI were executed as part of this change; recommend running the project's test suite and a short replay of recent GER40/INDEX scenarios to validate behavior before deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc119c17f08328b566ac80332f41a2)