### PR TITLE
Centralize Entry State Evaluation and enforce qualification block reason

### DIFF
--- a/Core/Entry/Qualification/ContinuationPolicy.cs
+++ b/Core/Entry/Qualification/ContinuationPolicy.cs
@@ -12,6 +12,10 @@ namespace GeminiV26.Core.Entry.Qualification
                 return EntryDecision.Pass();
 
             InstrumentClass instrumentClass = ResolveInstrumentClass(ctx);
+            var state = EntryStateEvaluator.Evaluate(ctx);
+
+            Log(ctx, "[ENTRY][STATE][SUMMARY]",
+                $"trend={state.HasTrend.ToString().ToLowerInvariant()} momentum={state.HasMomentum.ToString().ToLowerInvariant()} TQ={state.TransitionQuality:0.00}");
 
             if (IsFlagType(entryType))
             {
@@ -24,50 +28,51 @@ namespace GeminiV26.Core.Entry.Qualification
                 }
             }
 
-            double transitionQuality = ctx.Transition?.QualityScore ?? 0.0;
-            bool hasTransition = transitionQuality >= 0.55;
-            bool hasImpulse = ctx.HasImpulse_M5 || ctx.HasImpulseLong_M5 || ctx.HasImpulseShort_M5;
-            bool hasDirectionalBias = ctx.LogicBiasDirection != TradeDirection.None;
-            bool hasStructure = hasImpulse || transitionQuality >= 0.55;
-            bool hasTrend = hasDirectionalBias && hasStructure;
-            bool hasMomentum = hasImpulse || transitionQuality >= 0.60;
-
-            Log(ctx,
-                "[ENTRY][STATE][TREND_EVAL]",
-                $"bias={hasDirectionalBias.ToString().ToLowerInvariant()} structure={hasStructure.ToString().ToLowerInvariant()} result={hasTrend.ToString().ToLowerInvariant()}");
-            Log(ctx,
-                "[ENTRY][STATE][MOMENTUM_EVAL]",
-                $"impulse={hasImpulse.ToString().ToLowerInvariant()} TQ={transitionQuality:0.00} result={hasMomentum.ToString().ToLowerInvariant()}");
-
-            bool isDeadMarket = !hasTrend && !hasMomentum;
-            if (isDeadMarket)
+            if (state.IsDeadMarket)
             {
                 Log(ctx, "[ENTRY][BLOCK][DEAD_MARKET_STRICT]", string.Empty);
-                return EntryDecision.Block("DEAD_MARKET_STRICT");
+                return EntryDecision.Block("DEAD_MARKET");
             }
 
-            if (instrumentClass == InstrumentClass.CRYPTO && !hasImpulse)
+            if (instrumentClass == InstrumentClass.INDEX)
+            {
+                if (!state.HasTrend && !state.HasMomentum)
+                {
+                    Log(ctx, "[ENTRY][INDEX][BLOCK]", "no_trend_no_momentum");
+                    return EntryDecision.Block("INDEX_NO_STATE");
+                }
+
+                if (state.HasTrend && !state.HasMomentum)
+                {
+                    Log(ctx, "[ENTRY][INDEX][PENALTY]", string.Empty);
+                    return EntryDecision.Penalize(0.20, "INDEX_NO_MOMENTUM");
+                }
+            }
+
+            if (instrumentClass == InstrumentClass.CRYPTO && !state.HasImpulse)
             {
                 Log(ctx, "[ENTRY][BLOCK][NO_IMPULSE_CRYPTO]", string.Empty);
                 return EntryDecision.Block("NO_IMPULSE_CRYPTO");
             }
 
-            bool isWeakContinuation = transitionQuality < 0.55 && !ctx.HasImpulse_M5;
-            if (isWeakContinuation)
+            bool weakContinuation =
+                state.TransitionQuality < 0.55 &&
+                !state.HasImpulse;
+
+            if (weakContinuation)
             {
-                Log(ctx,
-                    "[ENTRY][FILTER][WEAK_CONTINUATION]",
-                    $"TQ={transitionQuality:0.00} impulse={ctx.HasImpulse_M5.ToString().ToLowerInvariant()}");
+                Log(ctx, "[ENTRY][FILTER][WEAK_CONTINUATION]",
+                    $"TQ={state.TransitionQuality:0.00}");
 
                 if (instrumentClass == InstrumentClass.CRYPTO)
-                    return EntryDecision.Block("WEAK_CONTINUATION_CRYPTO");
+                    return EntryDecision.Block("WEAK_CONTINUATION");
 
                 return EntryDecision.Penalize(0.20, "WEAK_CONTINUATION");
             }
 
-            if (transitionQuality < 0.30)
+            if (state.TransitionQuality < 0.30)
             {
-                Log(ctx, "[ENTRY][BLOCK][TRANSITION_COLLAPSE]", $"TQ={transitionQuality:0.00}");
+                Log(ctx, "[ENTRY][BLOCK][TRANSITION_COLLAPSE]", $"TQ={state.TransitionQuality:0.00}");
                 return EntryDecision.Block("TRANSITION_COLLAPSE");
             }
 
@@ -87,9 +92,9 @@ namespace GeminiV26.Core.Entry.Qualification
                 }
             }
 
-            if (!hasTransition)
+            if (!state.HasTransition)
             {
-                Log(ctx, "[ENTRY][PENALTY][WEAK_STRUCTURE]", $"score={transitionQuality:0.##}");
+                Log(ctx, "[ENTRY][PENALTY][WEAK_STRUCTURE]", $"score={state.TransitionQuality:0.##}");
                 return EntryDecision.Penalize(0.15, "WEAK_STRUCTURE");
             }
 

--- a/Core/Entry/Qualification/EntryStateEvaluator.cs
+++ b/Core/Entry/Qualification/EntryStateEvaluator.cs
@@ -1,0 +1,78 @@
+using System;
+
+namespace GeminiV26.Core.Entry.Qualification
+{
+    public class EntryState
+    {
+        public bool HasDirectionalBias { get; set; }
+        public bool HasImpulse { get; set; }
+        public double TransitionQuality { get; set; }
+        public bool HasTransition { get; set; }
+        public bool HasMomentum { get; set; }
+        public bool HasStructure { get; set; }
+        public bool HasTrend { get; set; }
+        public bool IsDeadMarket { get; set; }
+    }
+
+    public static class EntryStateEvaluator
+    {
+        public static EntryState Evaluate(EntryContext ctx)
+        {
+            var state = new EntryState();
+
+            if (ctx == null)
+                return state;
+
+            // -------------------------
+            // DIRECTIONAL BIAS
+            // -------------------------
+            state.HasDirectionalBias =
+                ctx.LogicBiasDirection != TradeDirection.None;
+
+            // -------------------------
+            // IMPULSE
+            // -------------------------
+            state.HasImpulse =
+                ctx.HasImpulse_M5 ||
+                ctx.HasImpulseLong_M5 ||
+                ctx.HasImpulseShort_M5;
+
+            // -------------------------
+            // TRANSITION
+            // -------------------------
+            state.TransitionQuality = ctx.Transition?.QualityScore ?? 0.0;
+
+            state.HasTransition = state.TransitionQuality >= 0.55;
+
+            // -------------------------
+            // MOMENTUM (STRICT)
+            // -------------------------
+            state.HasMomentum =
+                state.HasImpulse ||
+                state.TransitionQuality >= 0.60;
+
+            // -------------------------
+            // STRUCTURE (STRICTER THAN BEFORE)
+            // -------------------------
+            state.HasStructure =
+                state.HasImpulse ||
+                state.TransitionQuality >= 0.65;
+
+            // -------------------------
+            // TREND (STRICT)
+            // -------------------------
+            state.HasTrend =
+                state.HasDirectionalBias &&
+                state.HasStructure;
+
+            // -------------------------
+            // DEAD MARKET
+            // -------------------------
+            state.IsDeadMarket =
+                !state.HasTrend &&
+                !state.HasMomentum;
+
+            return state;
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1529,7 +1529,7 @@ namespace GeminiV26.Core
                 if (qualificationDecision.Type == EntryDecisionType.Block)
                 {
                     GlobalLogger.Log(_bot, $"[ENTRY][QUALIFICATION][BLOCK] {qualificationDecision.Reason}");
-                    GlobalLogger.Log(_bot, "[ROUTER][ABORT][QUALIFICATION_BLOCK]");
+                    GlobalLogger.Log(_bot, $"[ROUTER][ABORT][QUALIFICATION_BLOCK] {qualificationDecision.Reason}");
                     return;
                 }
 


### PR DESCRIPTION
### Motivation
- Centralize and harden entry qualification logic into a single deterministic state model to avoid duplicated local checks and reduce false/sideways entries (e.g. GER40-type cases). 
- Provide a clean separation between state detection and decision logic so continuation rules can reference a single authoritative source. 
- Preserve existing architecture while extending only the qualification layer for deterministic behavior and better debugging. 

### Description
- Added `Core/Entry/Qualification/EntryStateEvaluator.cs` containing the `EntryState` model and `EntryStateEvaluator.Evaluate(EntryContext)` which derives directional bias, impulse, transition quality, transition/structure/momentum/trend flags and `IsDeadMarket`. 
- Updated `Core/Entry/Qualification/ContinuationPolicy.cs` to call `EntryStateEvaluator.Evaluate(ctx)`, log a concise state summary via `"[ENTRY][STATE][SUMMARY]"`, and replace all local trend/momentum/transition checks with `state.*` usages for dead-market, index, crypto, weak-continuation, transition collapse and weak-structure rules. 
- Touched `Core/TradeCore.cs` to include the qualification decision reason in the abort log so block decisions propagate their `Reason` to router logs using `"[ROUTER][ABORT][QUALIFICATION_BLOCK] {qualificationDecision.Reason}"`. 
- No architecture refactor was performed and TradeCore structure was preserved; changes are scoped to extending the qualification layer only. 

### Testing
- Ran repository inspections (`git status --short`) and file-level grep/reads to verify the new file and modified files were staged and committed successfully. (succeeded) 
- Confirmed the new `EntryStateEvaluator` and `ContinuationPolicy` diffs via file prints and `nl`/`sed` to validate insertion points and log messages. (succeeded) 
- Attempted to run a build discovery search (`rg --files -g '*.csproj' -g '*.sln'`) but no project or solution files were found in the workspace, so no compile/test run was performed in this environment. (no build executed) 
- Commit/recording of changes completed successfully. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc139f5bd88328a806a1ca59036b66)