### PR TITLE
Fix EntryState namespace ambiguity in TradeCore

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -67,7 +67,6 @@ using GeminiV26.Core.Analytics;
 using GeminiV26.Core.Memory;
 using GeminiV26.Core.Runtime;
 using GeminiV26.Core.Risk;
-using GeminiV26.Core.Entry.Qualification;
 using System.Linq;
 
 namespace GeminiV26.Core
@@ -1525,15 +1524,15 @@ namespace GeminiV26.Core
                     return;
                 }
 
-                var qualificationDecision = EntryQualificationEngine.Evaluate(_ctx, selected.Type);
-                if (qualificationDecision.Type == EntryDecisionType.Block)
+                var qualificationDecision = GeminiV26.Core.Entry.Qualification.EntryQualificationEngine.Evaluate(_ctx, selected.Type);
+                if (qualificationDecision.Type == GeminiV26.Core.Entry.Qualification.EntryDecisionType.Block)
                 {
                     GlobalLogger.Log(_bot, $"[ENTRY][QUALIFICATION][BLOCK] {qualificationDecision.Reason}");
                     GlobalLogger.Log(_bot, $"[ROUTER][ABORT][QUALIFICATION_BLOCK] {qualificationDecision.Reason}");
                     return;
                 }
 
-                if (qualificationDecision.Type == EntryDecisionType.Penalize)
+                if (qualificationDecision.Type == GeminiV26.Core.Entry.Qualification.EntryDecisionType.Penalize)
                 {
                     int scoreBeforePenalty = selected.Score;
                     int scorePenalty = (int)Math.Round(qualificationDecision.Penalty * 100.0, MidpointRounding.AwayFromZero);


### PR DESCRIPTION
### Motivation
- Resolve an ambiguous reference caused by a newly introduced `GeminiV26.Core.Entry.Qualification.EntryState` type colliding with the existing `Core.Entry.EntryState`, which produced compilation ambiguity in `Core/TradeCore.cs` when qualification logic is used.

### Description
- Remove the broad `using GeminiV26.Core.Entry.Qualification;` import from `Core/TradeCore.cs` and fully qualify qualification usages by calling `GeminiV26.Core.Entry.Qualification.EntryQualificationEngine.Evaluate` and referencing `GeminiV26.Core.Entry.Qualification.EntryDecisionType` at the call sites.

### Testing
- Attempted `dotnet build` in the environment but it failed because the `dotnet` CLI is not available here, so no automated build or unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc150a9720832898cf10996b82cbd8)