### PR TITLE
Normalize TransitionQuality and delegate TradeCore state to Qualification

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -30,6 +30,7 @@ namespace GeminiV26.Core.Entry
         }
         public Action<string> Log { get; set; }
         public EntryContextFlags Flags { get; set; } = new EntryContextFlags();
+        public GeminiV26.Core.Entry.Qualification.EntryState QualificationState { get; set; }
 
         public DateTime LastUpdateUtc { get; set; } = DateTime.UtcNow;
         public Robot Bot { get; }

--- a/Core/Entry/Qualification/ContinuationPolicy.cs
+++ b/Core/Entry/Qualification/ContinuationPolicy.cs
@@ -12,7 +12,8 @@ namespace GeminiV26.Core.Entry.Qualification
                 return EntryDecision.Pass();
 
             InstrumentClass instrumentClass = ResolveInstrumentClass(ctx);
-            var state = EntryStateEvaluator.Evaluate(ctx);
+            var state = ctx.QualificationState ?? EntryStateEvaluator.Evaluate(ctx);
+            ctx.QualificationState = state;
 
             Log(ctx, "[ENTRY][STATE][SUMMARY]",
                 $"trend={state.HasTrend.ToString().ToLowerInvariant()} momentum={state.HasMomentum.ToString().ToLowerInvariant()} TQ={state.TransitionQuality:0.00}");

--- a/Core/Entry/Qualification/EntryQualificationEngine.cs
+++ b/Core/Entry/Qualification/EntryQualificationEngine.cs
@@ -9,6 +9,8 @@ namespace GeminiV26.Core.Entry.Qualification
             if (ctx == null)
                 return EntryDecision.Pass();
 
+            ctx.QualificationState = EntryStateEvaluator.Evaluate(ctx);
+
             if (IsContinuationEntry(entryType))
                 return ContinuationPolicy.Evaluate(ctx, entryType);
 

--- a/Core/Entry/Qualification/EntryStateEvaluator.cs
+++ b/Core/Entry/Qualification/EntryStateEvaluator.cs
@@ -1,4 +1,5 @@
 using System;
+using GeminiV26.Core.Logging;
 
 namespace GeminiV26.Core.Entry.Qualification
 {
@@ -40,23 +41,25 @@ namespace GeminiV26.Core.Entry.Qualification
             // -------------------------
             // TRANSITION
             // -------------------------
-            state.TransitionQuality = ctx.Transition?.QualityScore ?? 0.0;
+            double rawTQ = ctx.Transition?.QualityScore ?? 0.0;
+            double tq = rawTQ > 1.0 ? rawTQ / 100.0 : rawTQ;
+            state.TransitionQuality = tq;
 
-            state.HasTransition = state.TransitionQuality >= 0.55;
+            state.HasTransition = tq >= 0.55;
 
             // -------------------------
             // MOMENTUM (STRICT)
             // -------------------------
             state.HasMomentum =
                 state.HasImpulse ||
-                state.TransitionQuality >= 0.60;
+                tq >= 0.60;
 
             // -------------------------
             // STRUCTURE (STRICTER THAN BEFORE)
             // -------------------------
             state.HasStructure =
                 state.HasImpulse ||
-                state.TransitionQuality >= 0.65;
+                tq >= 0.65;
 
             // -------------------------
             // TREND (STRICT)
@@ -64,6 +67,11 @@ namespace GeminiV26.Core.Entry.Qualification
             state.HasTrend =
                 state.HasDirectionalBias &&
                 state.HasStructure;
+
+            Log(ctx,
+                $"[ENTRY][STATE][TREND_EVAL] rawTQ={rawTQ:0.00} tq={tq:0.00} trend={state.HasTrend.ToString().ToLowerInvariant()}");
+            Log(ctx,
+                $"[ENTRY][STATE][MOMENTUM_EVAL] rawTQ={rawTQ:0.00} tq={tq:0.00} momentum={state.HasMomentum.ToString().ToLowerInvariant()}");
 
             // -------------------------
             // DEAD MARKET
@@ -73,6 +81,18 @@ namespace GeminiV26.Core.Entry.Qualification
                 !state.HasMomentum;
 
             return state;
+        }
+
+        private static void Log(EntryContext ctx, string message)
+        {
+            if (ctx?.Log != null)
+            {
+                ctx.Log(message);
+                return;
+            }
+
+            if (ctx?.Bot != null)
+                GlobalLogger.Log(ctx.Bot, message);
         }
     }
 }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1477,18 +1477,15 @@ namespace GeminiV26.Core
                 }
 
                 _ctx.FinalDirection = selected.Direction;
-                double transitionQuality = _ctx.Transition?.QualityScore ?? 0.0;
-                bool hasImpulse = _ctx.HasImpulse_M5 || _ctx.HasImpulseLong_M5 || _ctx.HasImpulseShort_M5;
-                bool hasDirectionalBias = _ctx.LogicBiasDirection != TradeDirection.None;
-                bool hasStructure = hasImpulse || transitionQuality >= 0.55;
-                bool hasTrend = hasDirectionalBias && hasStructure;
-                bool hasMomentum = hasImpulse || transitionQuality >= 0.60;
-                bool isDeadMarket = !hasTrend && !hasMomentum;
+                var qualificationDecision = GeminiV26.Core.Entry.Qualification.EntryQualificationEngine.Evaluate(_ctx, selected.Type);
+                var qState = _ctx.QualificationState;
+                bool hasTrend = qState != null && qState.HasTrend;
+                bool hasMomentum = qState != null && qState.HasMomentum;
+                bool hasStructure = qState != null && qState.HasStructure;
+                bool isDeadMarket = qState != null && qState.IsDeadMarket;
 
                 GlobalLogger.Log(_bot,
-                    $"[ENTRY][STATE][TREND_EVAL] bias={hasDirectionalBias.ToString().ToLowerInvariant()} structure={hasStructure.ToString().ToLowerInvariant()} result={hasTrend.ToString().ToLowerInvariant()}");
-                GlobalLogger.Log(_bot,
-                    $"[ENTRY][STATE][MOMENTUM_EVAL] impulse={hasImpulse.ToString().ToLowerInvariant()} TQ={transitionQuality:F2} result={hasMomentum.ToString().ToLowerInvariant()}");
+                    $"[TRADECORE][STATE_DELEGATED] trend={hasTrend.ToString().ToLowerInvariant()} momentum={hasMomentum.ToString().ToLowerInvariant()} structure={hasStructure.ToString().ToLowerInvariant()} dead={isDeadMarket.ToString().ToLowerInvariant()}");
 
                 if (_instrumentClass == InstrumentClass.INDEX)
                 {
@@ -1524,7 +1521,6 @@ namespace GeminiV26.Core
                     return;
                 }
 
-                var qualificationDecision = GeminiV26.Core.Entry.Qualification.EntryQualificationEngine.Evaluate(_ctx, selected.Type);
                 if (qualificationDecision.Type == GeminiV26.Core.Entry.Qualification.EntryDecisionType.Block)
                 {
                     GlobalLogger.Log(_bot, $"[ENTRY][QUALIFICATION][BLOCK] {qualificationDecision.Reason}");


### PR DESCRIPTION
### Motivation

- Fix incorrect scale usage where `Transition.QualityScore` (0–100) was compared against thresholds expressed in 0–1, causing wrong state decisions and dead-market detection.
- Eliminate duplicated state authority by ensuring TradeCore uses the single qualification truth produced by the Entry qualification pipeline to avoid divergence.

### Description

- Files changed: `Core/Entry/Qualification/EntryStateEvaluator.cs`, `Core/Entry/Qualification/EntryQualificationEngine.cs`, `Core/Entry/Qualification/ContinuationPolicy.cs`, `Core/Entry/EntryContext.cs`, and `Core/TradeCore.cs`.
- Normalize transition quality in `EntryStateEvaluator` by computing `rawTQ = ctx.Transition?.QualityScore ?? 0.0` and `tq = rawTQ > 1.0 ? rawTQ / 100.0 : rawTQ`, then use `tq` for all threshold decisions (`0.55`, `0.60`, `0.65`) and store `tq` in `EntryState.TransitionQuality`.
- Add evaluator logs (using existing `ctx.Log` / `GlobalLogger`) with tags and content required: `[ENTRY][STATE][TREND_EVAL] rawTQ=... tq=... trend=...` and `[ENTRY][STATE][MOMENTUM_EVAL] rawTQ=... tq=... momentum=...`.
- Persist the evaluated `EntryState` to `EntryContext.QualificationState` inside `EntryQualificationEngine` and update `ContinuationPolicy` to reuse `ctx.QualificationState` (fall back to evaluator only if missing).
- Replace TradeCore's local derivation of `trend`, `momentum`, `structure`, and `dead market` with delegated reads from `ctx.QualificationState` and add a delegation log `[TRADECORE][STATE_DELEGATED] trend=... momentum=... structure=... dead=...` while preserving surrounding flow and behavior.

### Testing

- Attempted an automated build with `dotnet build`, but the environment lacks the .NET SDK (`/bin/bash: line 1: dotnet: command not found`), so no compile/run verification was performed.
- No other automated tests were executed in this environment; changes are limited and low-risk but recommend running CI/build on a proper .NET environment to validate compilation and runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd7453ac08328be5cae72b9550e69)