### PR TITLE
Enhance continuation qualification with structure-quality checks

### DIFF
--- a/Core/Entry/Qualification/ContinuationPolicy.cs
+++ b/Core/Entry/Qualification/ContinuationPolicy.cs
@@ -18,17 +18,6 @@ namespace GeminiV26.Core.Entry.Qualification
             Log(ctx, "[ENTRY][STATE][SUMMARY]",
                 $"trend={state.HasTrend.ToString().ToLowerInvariant()} momentum={state.HasMomentum.ToString().ToLowerInvariant()} TQ={state.TransitionQuality:0.00}");
 
-            if (IsFlagType(entryType))
-            {
-                int flagBars = Math.Max(ctx.FlagBarsLong_M5, ctx.FlagBarsShort_M5);
-
-                if (flagBars < 2)
-                {
-                    Log(ctx, "[ENTRY][BLOCK][INVALID_FLAG]", $"flagBars={flagBars}");
-                    return EntryDecision.Block("INVALID_FLAG");
-                }
-            }
-
             if (state.IsDeadMarket)
             {
                 Log(ctx, "[ENTRY][BLOCK][DEAD_MARKET_STRICT]", string.Empty);
@@ -77,6 +66,69 @@ namespace GeminiV26.Core.Entry.Qualification
                 return EntryDecision.Block("TRANSITION_COLLAPSE");
             }
 
+            string entryTypeName = entryType.ToString();
+            bool isFlagEntry = entryTypeName.IndexOf("Flag", StringComparison.OrdinalIgnoreCase) >= 0;
+            bool isPullbackEntry = entryTypeName.IndexOf("Pullback", StringComparison.OrdinalIgnoreCase) >= 0;
+            bool isBreakoutEntry = entryTypeName.IndexOf("Breakout", StringComparison.OrdinalIgnoreCase) >= 0;
+
+            int flagBars = Math.Max(ctx.FlagBarsLong_M5, ctx.FlagBarsShort_M5);
+            double pullbackDepth = Math.Max(ctx.PullbackDepthRLong_M5, ctx.PullbackDepthRShort_M5);
+            double flagToImpulseRatio = ResolveFlagToImpulseRatio(ctx);
+            int barsSinceImpulse = ctx.Memory?.BarsSinceImpulse ?? ctx.BarsSinceImpulse_M5;
+
+            if (isFlagEntry && flagToImpulseRatio > 0 && flagToImpulseRatio < 0.15)
+            {
+                Log(ctx, "[ENTRY][BLOCK][ULTRA_FLAT_FLAG]",
+                    $"symbol={ctx.Symbol} type={entryTypeName} ratio={flagToImpulseRatio:0.00}");
+                return EntryDecision.Block("ULTRA_FLAT_FLAG");
+            }
+
+            if (isPullbackEntry && pullbackDepth < 0.20)
+            {
+                Log(ctx, "[ENTRY][BLOCK][PULLBACK_TOO_SHALLOW]",
+                    $"symbol={ctx.Symbol} type={entryTypeName} depth={pullbackDepth:0.00}");
+                return EntryDecision.Block("PULLBACK_TOO_SHALLOW");
+            }
+
+            if (isBreakoutEntry && barsSinceImpulse > 8)
+            {
+                Log(ctx, "[ENTRY][BLOCK][BREAKOUT_TOO_LATE]",
+                    $"symbol={ctx.Symbol} type={entryTypeName} barsSinceImpulse={barsSinceImpulse}");
+                return EntryDecision.Block("BREAKOUT_TOO_LATE");
+            }
+
+            bool weakStructure = false;
+            string weakReason = string.Empty;
+
+            if (isFlagEntry && flagBars < 2)
+            {
+                weakStructure = true;
+                weakReason = "FLAG_TOO_SHORT";
+            }
+
+            if (isPullbackEntry && pullbackDepth < 0.25)
+            {
+                weakStructure = true;
+                weakReason = "PULLBACK_TOO_SHALLOW";
+            }
+
+            if (isBreakoutEntry && barsSinceImpulse > 5)
+            {
+                weakStructure = true;
+                weakReason = "BREAKOUT_TOO_LATE";
+            }
+
+            if (weakStructure)
+            {
+                Log(ctx, "[ENTRY][FILTER][WEAK_STRUCTURE]",
+                    $"symbol={ctx.Symbol} type={entryTypeName} reason={weakReason}");
+
+                if (instrumentClass == InstrumentClass.CRYPTO)
+                    return EntryDecision.Block(weakReason);
+
+                return EntryDecision.Penalize(0.20, weakReason);
+            }
+
             SymbolMemoryState memory = ctx.Memory;
             if (memory != null)
             {
@@ -102,8 +154,24 @@ namespace GeminiV26.Core.Entry.Qualification
             return EntryDecision.Pass();
         }
 
-        private static bool IsFlagType(EntryType entryType)
-            => entryType.ToString().IndexOf("Flag", StringComparison.OrdinalIgnoreCase) >= 0;
+        private static double ResolveFlagToImpulseRatio(EntryContext ctx)
+        {
+            double ratio = 0.0;
+
+            if (ctx.TransitionLong != null && ctx.TransitionLong.HasFlag && ctx.TransitionLong.CompressionScore > 0)
+                ratio = Math.Max(ratio, ctx.TransitionLong.CompressionScore);
+
+            if (ctx.TransitionShort != null && ctx.TransitionShort.HasFlag && ctx.TransitionShort.CompressionScore > 0)
+                ratio = Math.Max(ratio, ctx.TransitionShort.CompressionScore);
+
+            if (ratio > 0)
+                return ratio;
+
+            if (ctx.AtrM5 > 0 && ctx.FlagAtr_M5 > 0)
+                return ctx.FlagAtr_M5 / ctx.AtrM5;
+
+            return 0.0;
+        }
 
         private static InstrumentClass ResolveInstrumentClass(EntryContext ctx)
         {


### PR DESCRIPTION
### Motivation
- Strengthen continuation qualification by extending the simple TQ-based `weak continuation` rule to be aware of entry micro-structure for Flag, Pullback and Breakout setups. 
- Block obvious low-quality structures (ultra-flat flags, very shallow pullbacks, very late breakouts) and classify other weak structure for softer penalties. 
- Ensure logging of weak-structure reasons with the required `[ENTRY][FILTER][WEAK_STRUCTURE]` tag for observability.

### Description
- Inserted entry-type-aware checks after basic state gating and before memory checks in `ContinuationPolicy.Evaluate`, detecting Flag/Pullback/Breakout via `entryType.ToString()` comparisons. 
- Added derived metrics: `flagBars`, `pullbackDepth`, `flagToImpulseRatio` (via new helper `ResolveFlagToImpulseRatio`), and `barsSinceImpulse` to reason about structure quality. 
- Implemented hard blocks for `ULTRA_FLAT_FLAG` (`ratio < 0.15`), `PULLBACK_TOO_SHALLOW` (`depth < 0.20`), and `BREAKOUT_TOO_LATE` (`barsSinceImpulse > 8`). 
- Implemented `weakStructure` classification with reasons `FLAG_TOO_SHORT`, `PULLBACK_TOO_SHALLOW`, `BREAKOUT_TOO_LATE` where Crypto instruments are blocked and other instruments receive a `0.20` penalty, and added mandatory `[ENTRY][FILTER][WEAK_STRUCTURE]` logging including `symbol`, `type`, and `reason`; replaced the prior simple flag-only short check with this richer logic. 

### Testing
- Attempted to build with `dotnet build -v minimal` in this environment which failed because `dotnet` is not available. 
- Ran automated code searches (`rg`) to verify the presence of the new log tag and rule identifiers such as `WEAK_STRUCTURE`, `ULTRA_FLAT_FLAG`, `PULLBACK_TOO_SHALLOW`, `BREAKOUT_TOO_LATE`, and `ResolveFlagToImpulseRatio`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccda4dba7c83288dfe011f3abf2fb6)