### PR TITLE
Add diagnostic warning for breakout timing duplication in qualification layer

### DIFF
--- a/Core/Entry/Qualification/ContinuationPolicy.cs
+++ b/Core/Entry/Qualification/ContinuationPolicy.cs
@@ -104,6 +104,12 @@ namespace GeminiV26.Core.Entry.Qualification
                     flagBars,
                     barsSinceImpulse);
 
+                if (isBreakoutEntry)
+                {
+                    Log(ctx, "[ENTRY][WARN][BREAKOUT_TIMING_DUPLICATION]",
+                        $"barsSinceImpulse={barsSinceImpulse} layer=qualification");
+                }
+
                 Log(ctx, "[ENTRY][STRUCTURE_ZONE]",
                     $"symbol={ctx.Symbol} type={entryTypeName} zone={structureZone} metrics={metrics}");
 


### PR DESCRIPTION
### Motivation
- Add diagnostic logging to help detect overlapping/duplicated breakout timing logic between the qualification and memory layers when breakout timing is evaluated.

### Description
- Inserted a diagnostics-only warning log in `Core/Entry/Qualification/ContinuationPolicy.cs` within `ContinuationPolicy.Evaluate` for breakout entries using tag `[ENTRY][WARN][BREAKOUT_TIMING_DUPLICATION]` and payload `barsSinceImpulse=... layer=qualification`, with `symbol` preserved via the existing `Log(...)` prefix; no decision logic, thresholds, or memory-layer refactors were changed.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccdcf8b134832893ddd709a0e95bc6)