### PR TITLE
Implement TP1 Smart Exit (Trend Collapse) across ExitManagers

### DIFF
--- a/Core/Logging/CsvTradeLogger.cs
+++ b/Core/Logging/CsvTradeLogger.cs
@@ -18,7 +18,7 @@ namespace GeminiV26.Core.Logging
             "MFE_R","MAE_R","BarsInTrade","MinutesInTrade",
             "Tp1Hit","Tp2Hit","BeActivated","TrailingActivated",
             "PostTp1MaxR","PostTp1GivebackR","Tp1ProtectExitHit","Tp1ProtectExitR",
-            "Tp1ProtectScoreAtExit","Tp1ProtectMode",
+            "Tp1ProtectScoreAtExit","Tp1ProtectMode","Tp1SmartExitHit","Tp1SmartExitType","Tp1SmartExitReason","Tp1SmartExitR","Tp1SmartBarsSinceTp1",
             "ExitMode","ExitReason","ExitTime","ExitPrice",
             "NetProfit","GrossProfit","Commissions","Swap","Pips"
         };
@@ -112,6 +112,11 @@ namespace GeminiV26.Core.Logging
                     CsvNum(result?.Tp1ProtectExitR),
                     CsvInt(pctx?.Tp1ProtectExitHit == true ? pctx?.Tp1ProtectScoreAtExit : null),
                     Csv(pctx?.Tp1ProtectExitHit == true ? pctx?.Tp1ProtectMode : null),
+                    CsvBool(result?.Tp1SmartExitHit),
+                    Csv(result?.Tp1SmartExitType),
+                    Csv(result?.Tp1SmartExitReason),
+                    CsvNum(result?.Tp1SmartExitR),
+                    CsvInt(result?.Tp1SmartBarsSinceTp1),
 
                     Csv(result?.ExitMode),
                     Csv(result?.ExitReason),

--- a/Core/Logging/ITradeLogger.cs
+++ b/Core/Logging/ITradeLogger.cs
@@ -43,6 +43,11 @@ namespace GeminiV26.Core.Logging
         public double? Tp1ProtectExitR { get; set; }
         public int? Tp1ProtectScoreAtExit { get; set; }
         public string Tp1ProtectMode { get; set; }
+        public bool? Tp1SmartExitHit { get; set; }
+        public string Tp1SmartExitType { get; set; }
+        public string Tp1SmartExitReason { get; set; }
+        public double? Tp1SmartExitR { get; set; }
+        public int? Tp1SmartBarsSinceTp1 { get; set; }
     }
 
     public sealed class CompositeTradeLogger : ITradeLogger

--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -452,6 +452,18 @@ namespace GeminiV26.Core
 
         public double? PostTp1GivebackR { get; set; }
 
+        public bool Tp1SmartExitHit { get; set; }
+
+        public string Tp1SmartExitType { get; set; } = string.Empty;
+
+        public string Tp1SmartExitReason { get; set; } = string.Empty;
+
+        public double? Tp1SmartExitR { get; set; }
+
+        public int? Tp1SmartBarsSinceTp1 { get; set; }
+
+        public int Tp1HitBarIndex { get; set; } = -1;
+
         public double Tp2ExtensionMultiplierApplied { get; set; } = 1.0;
 
         public double? LastExtendedTp2 { get; set; }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -3858,7 +3858,9 @@ namespace GeminiV26.Core
 
             if (ctx != null)
             {
-                if (ctx.Tp2Hit > 0)
+                if (ctx.Tp1SmartExitHit)
+                    exitMode = "TP1_SMART";
+                else if (ctx.Tp2Hit > 0)
                     exitMode = "TP2";
                 else if (ctx.TrailingActivated)
                     exitMode = "TRAIL";
@@ -3907,7 +3909,9 @@ namespace GeminiV26.Core
                 new TradeLogResult
                 {
                     ExitMode = exitMode,
-                    ExitReason = args.Reason.ToString(),
+                    ExitReason = ctx?.Tp1SmartExitHit == true
+                        ? (string.IsNullOrWhiteSpace(ctx.Tp1SmartExitReason) ? "TREND_COLLAPSE" : ctx.Tp1SmartExitReason)
+                        : args.Reason.ToString(),
                     ExitTimeUtc = _bot.Server.Time,
                     ExitPrice = exitPrice,
                     NetProfit = pos.NetProfit,
@@ -3918,7 +3922,14 @@ namespace GeminiV26.Core
                     PostTp1MaxR = ctx?.PostTp1MaxR,
                     PostTp1GivebackR = ctx?.PostTp1GivebackR,
                     Tp1ProtectExitHit = ctx?.Tp1ProtectExitHit,
-                    Tp1ProtectExitR = ctx?.Tp1ProtectExitR
+                    Tp1ProtectExitR = ctx?.Tp1ProtectExitR,
+                    Tp1ProtectScoreAtExit = ctx?.Tp1ProtectScoreAtExit,
+                    Tp1ProtectMode = ctx?.Tp1ProtectMode,
+                    Tp1SmartExitHit = ctx?.Tp1SmartExitHit,
+                    Tp1SmartExitType = ctx?.Tp1SmartExitType,
+                    Tp1SmartExitReason = ctx?.Tp1SmartExitReason,
+                    Tp1SmartExitR = ctx?.Tp1SmartExitR,
+                    Tp1SmartBarsSinceTp1 = ctx?.Tp1SmartBarsSinceTp1
                 });
 
             _statsTracker.RegisterTradeClose(

--- a/Data/Models/TradeLogger.cs
+++ b/Data/Models/TradeLogger.cs
@@ -58,7 +58,7 @@ namespace GeminiV26.Data
 
                         // --- NEW ---
                         "RiskPercent,SlAtrMult,Tp1R,Tp2R,LotCapHit," +
-                        "BeActivated,TrailingActivated,PostTp1MaxR,PostTp1GivebackR,Tp1ProtectExitHit,Tp1ProtectExitR,Tp1ProtectScoreAtExit,Tp1ProtectMode,ExitMode," +
+                        "BeActivated,TrailingActivated,PostTp1MaxR,PostTp1GivebackR,Tp1ProtectExitHit,Tp1ProtectExitR,Tp1ProtectScoreAtExit,Tp1ProtectMode,Tp1SmartExitHit,Tp1SmartExitType,Tp1SmartExitReason,Tp1SmartExitR,Tp1SmartBarsSinceTp1,ExitMode," +
 
                         "ExitReason,NetProfit,GrossProfit,Commissions,Swap,Pips"
                     );
@@ -101,6 +101,11 @@ namespace GeminiV26.Data
                     t.Tp1ProtectExitR?.ToString(CultureInfo.InvariantCulture) ?? "",
                     t.Tp1ProtectScoreAtExit?.ToString(CultureInfo.InvariantCulture) ?? "",
                     Escape(t.Tp1ProtectMode),
+                    t.Tp1SmartExitHit?.ToString() ?? "",
+                    Escape(t.Tp1SmartExitType),
+                    Escape(t.Tp1SmartExitReason),
+                    t.Tp1SmartExitR?.ToString(CultureInfo.InvariantCulture) ?? "",
+                    t.Tp1SmartBarsSinceTp1?.ToString(CultureInfo.InvariantCulture) ?? "",
                     Escape(t.ExitMode),
                     Escape(t.ExitReason),
                     t.NetProfit.ToString(CultureInfo.InvariantCulture),

--- a/Data/Models/TradeRecord.cs
+++ b/Data/Models/TradeRecord.cs
@@ -59,6 +59,11 @@ namespace GeminiV26.Data.Models
         public double? Tp1ProtectExitR { get; set; }
         public int? Tp1ProtectScoreAtExit { get; set; }
         public string Tp1ProtectMode { get; set; } = string.Empty;
+        public bool? Tp1SmartExitHit { get; set; }
+        public string Tp1SmartExitType { get; set; } = string.Empty;
+        public string Tp1SmartExitReason { get; set; } = string.Empty;
+        public double? Tp1SmartExitR { get; set; }
+        public int? Tp1SmartBarsSinceTp1 { get; set; }
         public string ExitMode { get; set; } // TP1 / TP2 / BE / TRAIL / HARDLOSS / SL
 
     }

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.AUDNZD
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public AudNzdExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.AUDNZD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.AUDNZD
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.AUDNZD
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.AUDUSD
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public AudUsdExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.AUDUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.AUDUSD
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.AUDUSD
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -36,7 +36,10 @@ namespace GeminiV26.Instruments.BTCUSD
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         // ===== Legacy BTC trailing fallback =====
         private const double MinTrailImprovePips = 10;
@@ -478,6 +481,7 @@ namespace GeminiV26.Instruments.BTCUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             // 3) BE / protective SL after TP1
@@ -639,11 +643,16 @@ namespace GeminiV26.Instruments.BTCUSD
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -653,129 +662,179 @@ namespace GeminiV26.Instruments.BTCUSD
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -28,7 +28,10 @@ namespace GeminiV26.Instruments.ETHUSD
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         private const double MinTrailImprovePips = 50;
 
@@ -454,6 +457,7 @@ namespace GeminiV26.Instruments.ETHUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -558,11 +562,16 @@ namespace GeminiV26.Instruments.ETHUSD
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -572,129 +581,179 @@ namespace GeminiV26.Instruments.ETHUSD
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.EURJPY
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public EurJpyExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.EURJPY
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.EURJPY
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.EURJPY
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.EURUSD
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public EurUsdExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.EURUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.EURUSD
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.EURUSD
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.GBPJPY
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public GbpJpyExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.GBPJPY
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, $"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.GBPJPY
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.GBPJPY
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.GBPUSD
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public GbpUsdExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.GBPUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, $"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.GBPUSD
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.GBPUSD
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.GER40
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public Ger40ExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.GER40
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, $"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.GER40
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.GER40
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.NAS100
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public NasExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.NAS100
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.NAS100
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.NAS100
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.NZDUSD
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public NzdUsdExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.NZDUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.NZDUSD
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.NZDUSD
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.US30
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public Us30ExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.US30
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.US30
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.US30
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.USDCAD
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public UsdCadExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.USDCAD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.USDCAD
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.USDCAD
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.USDCHF
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public UsdChfExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.USDCHF
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, $"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.USDCHF
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.USDCHF
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -26,7 +26,10 @@ namespace GeminiV26.Instruments.USDJPY
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public UsdJpyExitManager(Robot bot)
         {
@@ -397,6 +400,7 @@ namespace GeminiV26.Instruments.USDJPY
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -501,11 +505,16 @@ namespace GeminiV26.Instruments.USDJPY
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -515,129 +524,179 @@ namespace GeminiV26.Instruments.USDJPY
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -56,7 +56,10 @@ namespace GeminiV26.Instruments.XAUUSD
 
         private const double Tp1ProtectMinR = 0.8;
         private const int Tp1ProtectSwingLookback = 5;
-        private const int Tp1ProtectExtremeLookback = 3;
+        private const int Tp1SmartNoNewExtremeBars = 3;
+        private const int Tp1SmartRangeLookback = 6;
+        private const double Tp1SmartSpreadGuardFactor = 0.35;
+        private const double Tp1SmartVolatilitySpikeFactor = 2.2;
 
         public XauExitManager(Robot bot)
         {
@@ -474,6 +477,7 @@ namespace GeminiV26.Instruments.XAUUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
+            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeVolume}", ctx, pos));
 
             // Remaining volume (analytics + rehydrate friendliness)
@@ -780,11 +784,16 @@ namespace GeminiV26.Instruments.XAUUSD
 
         private bool CheckPostTp1ProfitProtection(Position pos, PositionContext ctx, double currentPrice)
         {
-            if (ctx == null || pos == null)
+            if (ctx == null || pos == null || !ctx.Tp1Hit)
                 return false;
 
-            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
+            if (ctx.IsFullyClosing)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR=0 reason=TREND_COLLAPSE noAction=already_closing tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
+            ctx.RemainingVolumeInUnits = pos.VolumeInUnits;
             bool activation = ctx.Tp1ClosedVolumeInUnits > 0 && ctx.RemainingVolumeInUnits > 0;
             if (!activation)
                 return false;
@@ -794,129 +803,179 @@ namespace GeminiV26.Instruments.XAUUSD
                 return false;
 
             double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
-            bool profitThreshold = currentR >= Tp1ProtectMinR;
+            if (currentR < Tp1ProtectMinR)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 8)
+            if (!TryGetExitBars(pos, TimeFrame.Minute, out var m1, ctx) || m1 == null || m1.Count < 12)
                 return false;
 
-            var bars = m1;
-            int last = bars.Count - 2;
-            if (last < 6)
+            int last = m1.Count - 2;
+            if (last < 8)
                 return false;
+
+            var livePos = FindPosition(ctx.PositionId);
+            if (livePos == null)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=position_not_found swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
             int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
+            if (last - swingStart + 1 < 3)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
             double lastSwingLow = double.MaxValue;
             double lastSwingHigh = double.MinValue;
             for (int i = swingStart; i <= last; i++)
             {
-                if (bars.LowPrices[i] < lastSwingLow) lastSwingLow = bars.LowPrices[i];
-                if (bars.HighPrices[i] > lastSwingHigh) lastSwingHigh = bars.HighPrices[i];
+                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
+                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
             }
 
-            bool structureBreak = IsLong(ctx)
+            bool swingBroken = IsLong(ctx)
                 ? currentPrice < (lastSwingLow - eps)
                 : currentPrice > (lastSwingHigh + eps);
+            if (!swingBroken)
+                return false;
 
-            int recentStart = Math.Max(1, last - Tp1ProtectExtremeLookback + 1);
+            int recentStart = Math.Max(1, last - Tp1SmartNoNewExtremeBars + 1);
             int priorEnd = recentStart - 1;
-            int priorStart = Math.Max(1, priorEnd - Tp1ProtectExtremeLookback + 1);
+            int priorStart = Math.Max(1, priorEnd - Tp1SmartNoNewExtremeBars + 1);
+            if (priorEnd <= 0 || priorEnd - priorStart + 1 < Tp1SmartNoNewExtremeBars)
+                return false;
 
             double recentHigh = double.MinValue;
             double recentLow = double.MaxValue;
-            for (int i = recentStart; i <= last; i++)
-            {
-                if (bars.HighPrices[i] > recentHigh) recentHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < recentLow) recentLow = bars.LowPrices[i];
-            }
-
             double priorHigh = double.MinValue;
             double priorLow = double.MaxValue;
+            for (int i = recentStart; i <= last; i++)
+            {
+                if (m1.HighPrices[i] > recentHigh) recentHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < recentLow) recentLow = m1.LowPrices[i];
+            }
+
             for (int i = priorStart; i <= priorEnd; i++)
             {
-                if (bars.HighPrices[i] > priorHigh) priorHigh = bars.HighPrices[i];
-                if (bars.LowPrices[i] < priorLow) priorLow = bars.LowPrices[i];
+                if (m1.HighPrices[i] > priorHigh) priorHigh = m1.HighPrices[i];
+                if (m1.LowPrices[i] < priorLow) priorLow = m1.LowPrices[i];
             }
 
             bool noNewExtreme = IsLong(ctx)
                 ? recentHigh <= (priorHigh + eps)
                 : recentLow >= (priorLow - eps);
+            if (!noNewExtreme)
+                return false;
 
-            bool structureWeakening = IsLong(ctx)
-                ? (bars.HighPrices[last] < bars.HighPrices[last - 1] || Math.Abs(bars.HighPrices[last] - bars.HighPrices[last - 1]) <= eps)
-                : (bars.LowPrices[last] > bars.LowPrices[last - 1] || Math.Abs(bars.LowPrices[last] - bars.LowPrices[last - 1]) <= eps);
+            double currRange = Math.Max(m1.HighPrices[last] - m1.LowPrices[last], eps);
+            double prevRange = Math.Max(m1.HighPrices[last - 1] - m1.LowPrices[last - 1], eps);
+            double prev2Range = Math.Max(m1.HighPrices[last - 2] - m1.LowPrices[last - 2], eps);
 
-            double currOpen = bars.OpenPrices[last];
-            double currClose = bars.ClosePrices[last];
-            double prevOpen = bars.OpenPrices[last - 1];
-            double prevClose = bars.ClosePrices[last - 1];
-            double prev2Open = bars.OpenPrices[last - 2];
-            double prev2Close = bars.ClosePrices[last - 2];
+            double currOpen = m1.OpenPrices[last];
+            double currClose = m1.ClosePrices[last];
+            double prevOpen = m1.OpenPrices[last - 1];
+            double prevClose = m1.ClosePrices[last - 1];
+            double prev2Open = m1.OpenPrices[last - 2];
+            double prev2Close = m1.ClosePrices[last - 2];
 
             double currBody = Math.Abs(currClose - currOpen);
             double prevBody = Math.Abs(prevClose - prevOpen);
             double prev2Body = Math.Abs(prev2Close - prev2Open);
 
-            bool bodySmaller = currBody < prevBody;
-            bool twoWeakening = currBody < prevBody && prevBody < prev2Body;
+            bool transitionQualityWorse = currBody < prevBody;
+            bool impulseWeakening = currBody < prevBody && prevBody < prev2Body && currRange < prevRange;
 
-            double currRange = Math.Max(bars.HighPrices[last] - bars.LowPrices[last], eps);
-            double prevRange = Math.Max(bars.HighPrices[last - 1] - bars.LowPrices[last - 1], eps);
-            bool atrNormalizedShrink = (currBody / currRange) < (prevBody / prevRange);
+            int rangeStart = Math.Max(1, last - Tp1SmartRangeLookback + 1);
+            int mid = Math.Max(rangeStart + 1, rangeStart + (last - rangeStart + 1) / 2);
+            double recentRangeSum = 0;
+            int recentRangeCount = 0;
+            double priorRangeSum = 0;
+            int priorRangeCount = 0;
+            for (int i = rangeStart; i <= last; i++)
+            {
+                double range = Math.Max(m1.HighPrices[i] - m1.LowPrices[i], eps);
+                if (i >= mid)
+                {
+                    recentRangeSum += range;
+                    recentRangeCount++;
+                }
+                else
+                {
+                    priorRangeSum += range;
+                    priorRangeCount++;
+                }
+            }
 
-            bool strongOpposite = IsLong(ctx)
-                ? (currClose < currOpen && currBody > prevBody)
-                : (currClose > currOpen && currBody > prevBody);
+            double recentAvgRange = recentRangeCount > 0 ? recentRangeSum / recentRangeCount : currRange;
+            double priorAvgRange = priorRangeCount > 0 ? priorRangeSum / priorRangeCount : Math.Max(prevRange, prev2Range);
+            bool compressionStall = priorAvgRange > eps && recentAvgRange <= priorAvgRange * 0.70;
 
-            bool momentumCollapseStrong = strongOpposite;
-            bool momentumCollapse = bodySmaller || twoWeakening || atrNormalizedShrink || strongOpposite || momentumCollapseStrong;
+            int momentumSignals = 0;
+            if (transitionQualityWorse) momentumSignals++;
+            if (impulseWeakening) momentumSignals++;
+            if (compressionStall) momentumSignals++;
 
-            int protectScore = 0;
-            if (structureBreak) protectScore++;
-            if (noNewExtreme) protectScore++;
-            if (momentumCollapse) protectScore++;
-            if (structureWeakening) protectScore++;
+            if (momentumSignals == 0)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
 
-            bool earlyProtect = profitThreshold && protectScore >= 2;
-            bool hardProtect = currentR >= 1.0 && protectScore >= 1;
+            bool momentumWeakening = momentumSignals >= 1;
 
-            GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][SCORE]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"currentR={currentR:0.###}\n" +
-                $"protectScore={protectScore}\n" +
-                $"earlyProtect={earlyProtect}\n" +
-                $"hardProtect={hardProtect}");
-
-            if (!(earlyProtect || hardProtect))
+            if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;
 
-            bool trailingConflict = pos.StopLoss.HasValue &&
+            double currentSpread = Math.Abs(liveSymbol.Ask - liveSymbol.Bid);
+            if (currentSpread > recentAvgRange * Tp1SmartSpreadGuardFactor)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=spread_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool volatilitySpike = currRange > Math.Max(priorAvgRange, eps) * Tp1SmartVolatilitySpikeFactor;
+            if (volatilitySpike && momentumSignals < 2)
+            {
+                GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=volatility_spike_guard swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            bool trailingConflict = livePos.StopLoss.HasValue &&
                 (IsLong(ctx)
-                    ? currentPrice < (pos.StopLoss.Value - eps)
-                    : currentPrice > (pos.StopLoss.Value + eps));
+                    ? currentPrice < (livePos.StopLoss.Value - eps)
+                    : currentPrice > (livePos.StopLoss.Value + eps));
 
             if (trailingConflict)
                 return false;
 
+            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+                : 0;
+
             ctx.Tp1ProtectExitHit = true;
             ctx.Tp1ProtectExitR = currentR;
-            ctx.Tp1ProtectScoreAtExit = protectScore;
-            ctx.Tp1ProtectMode = hardProtect ? "HARD" : "EARLY";
+            ctx.Tp1ProtectScoreAtExit = momentumSignals;
+            ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
+            ctx.Tp1SmartExitHit = true;
+            ctx.Tp1SmartExitType = "TP1_SMART";
+            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
+            ctx.Tp1SmartExitR = currentR;
+            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,
-                $"[EXIT][TP1_PROTECT][TRIGGER]\n" +
-                $"symbol={pos.SymbolName}\n" +
-                $"positionId={pos.Id}\n" +
-                $"exitPrice={currentPrice:0.#####}\n" +
-                $"currentR={currentR:0.###}");
+                $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening={momentumWeakening.ToString().ToLowerInvariant()} tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()} exitType=TP1_SMART exitReason=TREND_COLLAPSE exitR={currentR:0.###} barsSinceTP1={barsSinceTp1}");
 
-            _bot.ClosePosition(pos);
+            _bot.ClosePosition(livePos);
             return true;
         }
 


### PR DESCRIPTION
### Motivation
- Reduce profit giveback after TP1 by exiting earlier when objective trend/momentum collapse is detected (reason=TREND_COLLAPSE). 
- Reuse existing lifecycle state (PositionContext), bar history, and analytics/logging pipeline without changing risk sizing, entry logic, TP2, trailing or SL mechanics. 
- Keep feature additive: overlay runs only after TP1 and uses the existing close/modify flow and GlobalLogger for all logging.

### Description
- Added a TP1 Smart Exit overlay to instrument ExitManagers by enhancing the post-TP1 protection path to require: retained profit (>= 0.8R), a structure swing break, no new extremes for recent N bars, and momentum-collapse confirmation (transition/impulse/compression proxies), plus spread and volatility spike guards; the overlay closes the remaining position via the existing `_bot.ClosePosition(...)` path when triggered and preserves trailing/TP2 behavior.  
- Instrument-level changes: replaced/augmented post-TP1 checks in all instrument ExitManagers (Instruments/*/*ExitManager.cs) with the TREND_COLLAPSE logic, added small constants (`Tp1SmartNoNewExtremeBars`, `Tp1SmartRangeLookback`, `Tp1SmartSpreadGuardFactor`, `Tp1SmartVolatilitySpikeFactor`), and set `ctx.Tp1HitBarIndex` at TP1 execution to compute `barsSinceTP1`. 
- Context & analytics changes: extended `PositionContext` with smart-exit fields (`Tp1SmartExitHit`, `Tp1SmartExitType`, `Tp1SmartExitReason`, `Tp1SmartExitR`, `Tp1SmartBarsSinceTp1`, `Tp1HitBarIndex`), extended `TradeLogResult` and trade CSV/record models to carry the new smart-exit analytics, and prioritized reporting `ExitMode = TP1_SMART` and `ExitReason = TREND_COLLAPSE` when applicable. 
- Logging & integration: all logging uses the existing `GlobalLogger.Log(...)` convention and emits the mandatory tag/payload `[EXIT][TP1_SMART_EXIT]` and explicit no-action logs (spread spike, missing swing, insufficient threshold, no collapse confirmation) and integrates into the existing analytics/trade-close path (no new logger or CSV writer was introduced).

### Testing
- Attempted build: ran `dotnet build` in this environment and it failed because `dotnet` is not installed here, so no compile-time or unit test run was possible (failure: `/bin/bash: dotnet: command not found`).  
- Basic repository checks: repository diffs/stat and commit were created successfully in the environment (local verification only), but these are not a substitute for a .NET build.  
- Recommendation: run full `dotnet build` and existing unit/integration tests in your CI/.NET environment to validate compilation and runtime behavior before deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccdf1e99e48328a31d615c4f4f1122)