### PR TITLE
Add TP1 smart-exit compatibility accessors and update exit flow to use them

### DIFF
--- a/Core/PositionContextTp1SmartCompatExtensions.cs
+++ b/Core/PositionContextTp1SmartCompatExtensions.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace GeminiV26.Core
+{
+    /// <summary>
+    /// Compatibility shim for TP1 smart-exit fields so exit managers can compile
+    /// against both older and newer PositionContext shapes.
+    /// </summary>
+    public static class PositionContextTp1SmartCompatExtensions
+    {
+        private sealed class CompatState
+        {
+            public int Tp1HitBarIndex = -1;
+            public bool Tp1SmartExitHit;
+            public string Tp1SmartExitType = string.Empty;
+            public string Tp1SmartExitReason = string.Empty;
+            public double? Tp1SmartExitR;
+            public int? Tp1SmartBarsSinceTp1;
+        }
+
+        private static readonly Dictionary<long, CompatState> _fallbackByPositionId = new Dictionary<long, CompatState>();
+
+        private static CompatState GetFallbackState(PositionContext ctx)
+        {
+            if (!_fallbackByPositionId.TryGetValue(ctx.PositionId, out var state))
+            {
+                state = new CompatState();
+                _fallbackByPositionId[ctx.PositionId] = state;
+            }
+
+            return state;
+        }
+
+        private static PropertyInfo FindProperty(string propertyName)
+        {
+            return typeof(PositionContext).GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
+        }
+
+        public static void SetTp1HitBarIndex(this PositionContext ctx, int value)
+        {
+            var p = FindProperty("Tp1HitBarIndex");
+            if (p != null && p.CanWrite)
+            {
+                p.SetValue(ctx, value);
+                return;
+            }
+
+            GetFallbackState(ctx).Tp1HitBarIndex = value;
+        }
+
+        public static int GetTp1HitBarIndex(this PositionContext ctx)
+        {
+            var p = FindProperty("Tp1HitBarIndex");
+            if (p != null)
+            {
+                var raw = p.GetValue(ctx);
+                if (raw is int v)
+                    return v;
+            }
+
+            return GetFallbackState(ctx).Tp1HitBarIndex;
+        }
+
+        public static void SetTp1SmartExitHit(this PositionContext ctx, bool value)
+        {
+            var p = FindProperty("Tp1SmartExitHit");
+            if (p != null && p.CanWrite)
+            {
+                p.SetValue(ctx, value);
+                return;
+            }
+
+            GetFallbackState(ctx).Tp1SmartExitHit = value;
+        }
+
+        public static bool GetTp1SmartExitHit(this PositionContext ctx)
+        {
+            var p = FindProperty("Tp1SmartExitHit");
+            if (p != null)
+            {
+                var raw = p.GetValue(ctx);
+                if (raw is bool v)
+                    return v;
+            }
+
+            return GetFallbackState(ctx).Tp1SmartExitHit;
+        }
+
+        public static void SetTp1SmartExitType(this PositionContext ctx, string value)
+        {
+            var p = FindProperty("Tp1SmartExitType");
+            if (p != null && p.CanWrite)
+            {
+                p.SetValue(ctx, value ?? string.Empty);
+                return;
+            }
+
+            GetFallbackState(ctx).Tp1SmartExitType = value ?? string.Empty;
+        }
+
+        public static string GetTp1SmartExitType(this PositionContext ctx)
+        {
+            var p = FindProperty("Tp1SmartExitType");
+            if (p != null)
+            {
+                var raw = p.GetValue(ctx) as string;
+                return raw ?? string.Empty;
+            }
+
+            return GetFallbackState(ctx).Tp1SmartExitType;
+        }
+
+        public static void SetTp1SmartExitReason(this PositionContext ctx, string value)
+        {
+            var p = FindProperty("Tp1SmartExitReason");
+            if (p != null && p.CanWrite)
+            {
+                p.SetValue(ctx, value ?? string.Empty);
+                return;
+            }
+
+            GetFallbackState(ctx).Tp1SmartExitReason = value ?? string.Empty;
+        }
+
+        public static string GetTp1SmartExitReason(this PositionContext ctx)
+        {
+            var p = FindProperty("Tp1SmartExitReason");
+            if (p != null)
+            {
+                var raw = p.GetValue(ctx) as string;
+                return raw ?? string.Empty;
+            }
+
+            return GetFallbackState(ctx).Tp1SmartExitReason;
+        }
+
+        public static void SetTp1SmartExitR(this PositionContext ctx, double? value)
+        {
+            var p = FindProperty("Tp1SmartExitR");
+            if (p != null && p.CanWrite)
+            {
+                p.SetValue(ctx, value);
+                return;
+            }
+
+            GetFallbackState(ctx).Tp1SmartExitR = value;
+        }
+
+        public static double? GetTp1SmartExitR(this PositionContext ctx)
+        {
+            var p = FindProperty("Tp1SmartExitR");
+            if (p != null)
+            {
+                var raw = p.GetValue(ctx);
+                if (raw is double v)
+                    return v;
+                return raw as double?;
+            }
+
+            return GetFallbackState(ctx).Tp1SmartExitR;
+        }
+
+        public static void SetTp1SmartBarsSinceTp1(this PositionContext ctx, int? value)
+        {
+            var p = FindProperty("Tp1SmartBarsSinceTp1");
+            if (p != null && p.CanWrite)
+            {
+                p.SetValue(ctx, value);
+                return;
+            }
+
+            GetFallbackState(ctx).Tp1SmartBarsSinceTp1 = value;
+        }
+
+        public static int? GetTp1SmartBarsSinceTp1(this PositionContext ctx)
+        {
+            var p = FindProperty("Tp1SmartBarsSinceTp1");
+            if (p != null)
+            {
+                var raw = p.GetValue(ctx);
+                if (raw is int v)
+                    return v;
+                return raw as int?;
+            }
+
+            return GetFallbackState(ctx).Tp1SmartBarsSinceTp1;
+        }
+    }
+}

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -3858,7 +3858,7 @@ namespace GeminiV26.Core
 
             if (ctx != null)
             {
-                if (ctx.Tp1SmartExitHit)
+                if (ctx.GetTp1SmartExitHit())
                     exitMode = "TP1_SMART";
                 else if (ctx.Tp2Hit > 0)
                     exitMode = "TP2";
@@ -3909,8 +3909,8 @@ namespace GeminiV26.Core
                 new TradeLogResult
                 {
                     ExitMode = exitMode,
-                    ExitReason = ctx?.Tp1SmartExitHit == true
-                        ? (string.IsNullOrWhiteSpace(ctx.Tp1SmartExitReason) ? "TREND_COLLAPSE" : ctx.Tp1SmartExitReason)
+                    ExitReason = ctx?.GetTp1SmartExitHit() == true
+                        ? (string.IsNullOrWhiteSpace(ctx.GetTp1SmartExitReason()) ? "TREND_COLLAPSE" : ctx.GetTp1SmartExitReason())
                         : args.Reason.ToString(),
                     ExitTimeUtc = _bot.Server.Time,
                     ExitPrice = exitPrice,
@@ -3925,11 +3925,11 @@ namespace GeminiV26.Core
                     Tp1ProtectExitR = ctx?.Tp1ProtectExitR,
                     Tp1ProtectScoreAtExit = ctx?.Tp1ProtectScoreAtExit,
                     Tp1ProtectMode = ctx?.Tp1ProtectMode,
-                    Tp1SmartExitHit = ctx?.Tp1SmartExitHit,
-                    Tp1SmartExitType = ctx?.Tp1SmartExitType,
-                    Tp1SmartExitReason = ctx?.Tp1SmartExitReason,
-                    Tp1SmartExitR = ctx?.Tp1SmartExitR,
-                    Tp1SmartBarsSinceTp1 = ctx?.Tp1SmartBarsSinceTp1
+                    Tp1SmartExitHit = ctx?.GetTp1SmartExitHit(),
+                    Tp1SmartExitType = ctx?.GetTp1SmartExitType(),
+                    Tp1SmartExitReason = ctx?.GetTp1SmartExitReason(),
+                    Tp1SmartExitR = ctx?.GetTp1SmartExitR(),
+                    Tp1SmartBarsSinceTp1 = ctx?.GetTp1SmartBarsSinceTp1()
                 });
 
             _statsTracker.RegisterTradeClose(

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.AUDNZD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.AUDNZD
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.AUDNZD
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.AUDUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.AUDUSD
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.AUDUSD
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -481,7 +481,7 @@ namespace GeminiV26.Instruments.BTCUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             // 3) BE / protective SL after TP1
@@ -815,8 +815,8 @@ namespace GeminiV26.Instruments.BTCUSD
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -824,11 +824,11 @@ namespace GeminiV26.Instruments.BTCUSD
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -457,7 +457,7 @@ namespace GeminiV26.Instruments.ETHUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -734,8 +734,8 @@ namespace GeminiV26.Instruments.ETHUSD
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -743,11 +743,11 @@ namespace GeminiV26.Instruments.ETHUSD
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.EURJPY
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.EURJPY
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.EURJPY
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.EURUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.EURUSD
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.EURUSD
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.GBPJPY
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, $"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.GBPJPY
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.GBPJPY
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.GBPUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, $"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.GBPUSD
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.GBPUSD
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.GER40
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, $"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.GER40
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.GER40
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.NAS100
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.NAS100
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.NAS100
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.NZDUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.NZDUSD
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.NZDUSD
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.US30
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.US30
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.US30
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.USDCAD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.USDCAD
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.USDCAD
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.USDCHF
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, $"[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.USDCHF
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.USDCHF
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -400,7 +400,7 @@ namespace GeminiV26.Instruments.USDJPY
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeUnits}", ctx, pos));
 
             var live = _bot.Positions.Find(pos.Label, pos.SymbolName, pos.TradeType);
@@ -677,8 +677,8 @@ namespace GeminiV26.Instruments.USDJPY
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -686,11 +686,11 @@ namespace GeminiV26.Instruments.USDJPY
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -477,7 +477,7 @@ namespace GeminiV26.Instruments.XAUUSD
             ctx.Tp1Hit = true;
             GlobalLogger.Log(_bot, "[TP1] hit → MFE continues tracking");
             ctx.Tp1Executed = true;
-            ctx.Tp1HitBarIndex = ctx.BarsSinceEntryM5;
+            ctx.SetTp1HitBarIndex(ctx.BarsSinceEntryM5);
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[TP1][EXECUTED]\ntp1={ctx.Tp1Price:0.#####}\nclosedUnits={closeVolume}", ctx, pos));
 
             // Remaining volume (analytics + rehydrate friendliness)
@@ -956,8 +956,8 @@ namespace GeminiV26.Instruments.XAUUSD
             if (trailingConflict)
                 return false;
 
-            int barsSinceTp1 = ctx.Tp1HitBarIndex >= 0
-                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.Tp1HitBarIndex)
+            int barsSinceTp1 = ctx.GetTp1HitBarIndex() >= 0
+                ? Math.Max(0, ctx.BarsSinceEntryM5 - ctx.GetTp1HitBarIndex())
                 : 0;
 
             ctx.Tp1ProtectExitHit = true;
@@ -965,11 +965,11 @@ namespace GeminiV26.Instruments.XAUUSD
             ctx.Tp1ProtectScoreAtExit = momentumSignals;
             ctx.Tp1ProtectMode = "TP1_SMART";
             ctx.PostTp1GivebackR = Math.Max(0, ctx.PostTp1MaxR - currentR);
-            ctx.Tp1SmartExitHit = true;
-            ctx.Tp1SmartExitType = "TP1_SMART";
-            ctx.Tp1SmartExitReason = "TREND_COLLAPSE";
-            ctx.Tp1SmartExitR = currentR;
-            ctx.Tp1SmartBarsSinceTp1 = barsSinceTp1;
+            ctx.SetTp1SmartExitHit(true);
+            ctx.SetTp1SmartExitType("TP1_SMART");
+            ctx.SetTp1SmartExitReason("TREND_COLLAPSE");
+            ctx.SetTp1SmartExitR(currentR);
+            ctx.SetTp1SmartBarsSinceTp1(barsSinceTp1);
             ctx.IsFullyClosing = true;
 
             GlobalLogger.Log(_bot,


### PR DESCRIPTION
### Motivation
- A refactor to TP1 exit handling removed TP1 smart-exit fields from the canonical `PositionContext`, causing widespread compile-time errors in exit managers and close-path logging that still referenced those members.

### Description
- Add `Core/PositionContextTp1SmartCompatExtensions.cs` which provides reflection-based `Get/Set` accessors for TP1 fields plus a per-position fallback state for environments where those properties are missing.
- Replace direct `PositionContext` reads/writes of `Tp1HitBarIndex` and `Tp1SmartExit*` in all instrument ExitManagers with the new `GetTp1HitBarIndex`/`SetTp1HitBarIndex` and `Get/SetTp1SmartExit*` accessors.
- Update `Core/TradeCore` close-path logic to read TP1 smart-exit state via the compatibility accessors so exit mode, reason and `TradeLogResult` mapping are consistent with the new approach.

### Testing
- Attempted `dotnet build`, but the `.NET` SDK is not available in this environment so a full build could not be executed here (build was not run).
- Verified with recursive code search (`rg`) that exit-flow code now uses compatibility accessors instead of direct `PositionContext` TP1 smart-exit properties.
- Performed diff and static checks to confirm the set of exit managers and `Core/TradeCore` were updated to use the new accessor methods and that a compatibility shim file was added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cce1faa2f88328829f51ae53ba9645)