### PR TITLE
Make TP1 smart-exit directional and use structural swing reference across exit managers

### DIFF
--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.AUDNZD
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.AUDNZD
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.AUDNZD
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.AUDNZD
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.AUDUSD
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.AUDUSD
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.AUDUSD
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.AUDUSD
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -627,7 +627,7 @@ namespace GeminiV26.Instruments.BTCUSD
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -661,7 +661,7 @@ namespace GeminiV26.Instruments.BTCUSD
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -685,24 +685,20 @@ namespace GeminiV26.Instruments.BTCUSD
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -782,13 +778,13 @@ namespace GeminiV26.Instruments.BTCUSD
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -546,7 +546,7 @@ namespace GeminiV26.Instruments.ETHUSD
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -580,7 +580,7 @@ namespace GeminiV26.Instruments.ETHUSD
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -604,24 +604,20 @@ namespace GeminiV26.Instruments.ETHUSD
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -701,13 +697,13 @@ namespace GeminiV26.Instruments.ETHUSD
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.EURJPY
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.EURJPY
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.EURJPY
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.EURJPY
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.EURUSD
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.EURUSD
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.EURUSD
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.EURUSD
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.GBPJPY
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.GBPJPY
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.GBPJPY
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.GBPJPY
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.GBPUSD
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.GBPUSD
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.GBPUSD
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.GBPUSD
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.GER40
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.GER40
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.GER40
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.GER40
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.NAS100
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.NAS100
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.NAS100
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.NAS100
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.NZDUSD
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.NZDUSD
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.NZDUSD
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.NZDUSD
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.US30
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.US30
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.US30
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.US30
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.USDCAD
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.USDCAD
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.USDCAD
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.USDCAD
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.USDCHF
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.USDCHF
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.USDCHF
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.USDCHF
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -489,7 +489,7 @@ namespace GeminiV26.Instruments.USDJPY
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -523,7 +523,7 @@ namespace GeminiV26.Instruments.USDJPY
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -547,24 +547,20 @@ namespace GeminiV26.Instruments.USDJPY
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -644,13 +640,13 @@ namespace GeminiV26.Instruments.USDJPY
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -768,7 +768,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (ctx == null || !ctx.Tp1Hit || rDist <= 0)
                 return;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR > ctx.PostTp1MaxR)
             {
                 ctx.PostTp1MaxR = currentR;
@@ -802,7 +802,7 @@ namespace GeminiV26.Instruments.XAUUSD
             if (rDist <= 0)
                 return false;
 
-            double currentR = Math.Abs(currentPrice - ctx.EntryPrice) / rDist;
+            double currentR = (IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)) / rDist;
             if (currentR < Tp1ProtectMinR)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=insufficient_profit_threshold swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
@@ -826,24 +826,20 @@ namespace GeminiV26.Instruments.XAUUSD
             double tickSize = _bot.Symbols.GetSymbol(pos.SymbolName)?.TickSize ?? 1e-5;
             double eps = Math.Max(1e-8, tickSize * 0.5);
 
-            int swingStart = Math.Max(1, last - Tp1ProtectSwingLookback + 1);
-            if (last - swingStart + 1 < 3)
+            var structure = _structureTracker.GetSnapshot();
+            double? structuralSwingRef = IsLong(ctx)
+                ? structure?.LastSwingLow?.Price
+                : structure?.LastSwingHigh?.Price;
+
+            if (!structuralSwingRef.HasValue || structuralSwingRef.Value <= 0)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=missing_safe_swing_reference swingBroken=false noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            double lastSwingLow = double.MaxValue;
-            double lastSwingHigh = double.MinValue;
-            for (int i = swingStart; i <= last; i++)
-            {
-                if (m1.LowPrices[i] < lastSwingLow) lastSwingLow = m1.LowPrices[i];
-                if (m1.HighPrices[i] > lastSwingHigh) lastSwingHigh = m1.HighPrices[i];
-            }
-
             bool swingBroken = IsLong(ctx)
-                ? currentPrice < (lastSwingLow - eps)
-                : currentPrice > (lastSwingHigh + eps);
+                ? currentPrice < (structuralSwingRef.Value - eps)
+                : currentPrice > (structuralSwingRef.Value + eps);
             if (!swingBroken)
                 return false;
 
@@ -923,13 +919,13 @@ namespace GeminiV26.Instruments.XAUUSD
             if (impulseWeakening) momentumSignals++;
             if (compressionStall) momentumSignals++;
 
-            if (momentumSignals == 0)
+            if (momentumSignals < 2)
             {
                 GlobalLogger.Log(_bot, $"[EXIT][TP1_SMART_EXIT] symbol={pos.SymbolName} side={(IsLong(ctx) ? "LONG" : "SHORT")} entry={ctx.EntryPrice:0.#####} currentPrice={currentPrice:0.#####} currentR={currentR:0.###} reason=TREND_COLLAPSE noAction=no_collapse_confirmation swingBroken={swingBroken.ToString().ToLowerInvariant()} noNewExtremeBars={Tp1SmartNoNewExtremeBars} momentumWeakening=false tp1Hit={ctx.Tp1Hit.ToString().ToLowerInvariant()}");
                 return false;
             }
 
-            bool momentumWeakening = momentumSignals >= 1;
+            bool momentumWeakening = momentumSignals >= 2;
 
             if (!TryResolveExitSymbol(pos, out var liveSymbol, ctx))
                 return false;


### PR DESCRIPTION
### Motivation

- Ensure post-TP1 profit protection measures compute profit ratio directionally (long vs short) instead of using absolute distance.  
- Use a single structural swing reference from the global structure tracker as a safer swing-break reference instead of re-scanning minute bars in each instrument.  
- Tighten collapse/momentum confirmation so that stronger evidence is required before triggering smart exits.

### Description

- Replaced `Math.Abs(currentPrice - ctx.EntryPrice) / rDist` with a direction-aware computation `IsLong(ctx) ? (currentPrice - ctx.EntryPrice) : (ctx.EntryPrice - currentPrice)` when calculating `currentR` in `UpdatePostTp1ProtectionState` and `CheckPostTp1ProfitProtection`.  
- Removed per-file minute-bar scanning to compute last swing extrema and instead retrieve a `structuralSwingRef` from `_structureTracker.GetSnapshot()` and require it to be present and positive before proceeding.  
- Switched the swing-broken checks to compare `currentPrice` against `structuralSwingRef` (with `eps`) for both long and short cases.  
- Increased the momentum confirmation requirement by changing checks from `momentumSignals == 0` to `momentumSignals < 2` and updated `momentumWeakening` to require `momentumSignals >= 2`.  
- Applied these changes consistently across many instrument-specific `ExitManager` classes (examples: `AUDUSD`, `EURUSD`, `BTCUSD`, `XAUUSD`, `GBPUSD`, `NAS100`, `US30`, `USDJPY`, and others under `Instruments/*`).

### Testing

- Performed a full solution build to verify there are no compile errors after the cross-file changes and the build completed successfully.  
- Ran the existing automated unit test suite and CI checks and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cce38b287483289c33ef8d4af257e7)