### PR TITLE
Replace stale TimeInTradeBars references with BarsSinceEntryM5 in TVM

### DIFF
--- a/Core/TradeViabilityMonitor.cs
+++ b/Core/TradeViabilityMonitor.cs
@@ -80,13 +80,13 @@ namespace GeminiV26.Core
             bool compressionDetected = IsCompressionState(pos.TradeType, m5);
             bool noProgress =
                 ctx.MfeR < 0.25
-                && ctx.TimeInTradeBars >= 6;
+                && ctx.BarsSinceEntryM5 >= 6;
             bool baseValid =
                 !structureBreakDetected &&
                 !strongOppositeImpulseDetected &&
                 !strongHtfConflictDetected;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds(
-                $"[TVM][PROGRESS] mfe={ctx.MfeR:0.00} bars={ctx.TimeInTradeBars} noProgress={noProgress}", ctx));
+                $"[TVM][PROGRESS] mfe={ctx.MfeR:0.00} bars={ctx.BarsSinceEntryM5} noProgress={noProgress}", ctx));
 
             if (!baseValid && noProgress)
             {
@@ -702,7 +702,7 @@ namespace GeminiV26.Core
             bool weakProgress =
                 _activeContext != null &&
                 _activeContext.MfeR < 0.25
-                && _activeContext.TimeInTradeBars >= 6;
+                && _activeContext.BarsSinceEntryM5 >= 6;
             bool detected =
                 rangeShrinking &&
                 !IsStrongOppositeImpulse(tradeType, m5) &&


### PR DESCRIPTION
### Motivation
- PositionContext no longer exposes `TimeInTradeBars`, and TVM logic/logging still referenced it leading to inconsistent bar-age usage and compile-time errors.

### Description
- Replaced `ctx.TimeInTradeBars` and `_activeContext.TimeInTradeBars` uses in `Core/TradeViabilityMonitor.cs` with `BarsSinceEntryM5` for the `noProgress` check, progress log, and compression weak-progress guard so the TVM uses the existing position state consistently.

### Testing
- Ran a code search `rg -n "TimeInTradeBars" Core/TradeViabilityMonitor.cs Core/PositionContext.cs` and confirmed no remaining references, indicating the stale field uses were removed.
- Reviewed the modified lines to verify the progress log now reports `BarsSinceEntryM5` and the compression guard uses the same bar-age field.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf362cb708328b117eade3b880c50)