### PR TITLE
Add TransitionQuality (TQ) audit report for FX/JPY and scale/threshold findings

### DIFF
--- a/TQ_AUDIT_2026-04-01.md
+++ b/TQ_AUDIT_2026-04-01.md
@@ -1,0 +1,135 @@
+# TransitionQuality (TQ) audit — Gemini V26 (2026-04-01)
+
+## Scope
+- Pipeline traced from `TransitionDetector` compute path to qualification, entry filtering, and analytics persistence.
+- Focused review on FX behavior with explicit checks on JPY pairs via runtime logs.
+
+## 1) Full TQ pipeline
+
+### Compute point
+- TQ is computed in `TransitionDetector.EvaluateSide(...)` and stored as `qualityScore`.
+
+### Inputs
+- `impulseStrength` (ATR-normalized impulse range):
+  - `impulseStrength = Clamp01(range / (AtrM5 * ImpulseNormalizationAtrFactor))`
+- `compressionScore`:
+  - `compression = avgRange(flagWindow) / impulseRange`
+  - `compressionScore = Clamp01(1.0 - compression)`
+- `pullbackQuality`:
+  - `pullbackQuality = Clamp01(1.0 - abs(pullbackDepthR - OptimalPullbackDepthR))`
+
+### Final formula
+- `qualityScore01 = 0.4*impulseStrength + 0.3*compressionScore + 0.3*pullbackQuality`
+- `QualityScore = clamp(qualityScore01*100, 0, 100)`
+
+### Normalization/clamping behavior
+- Internal component inputs are clamped to `[0,1]`.
+- Final `QualityScore` is clamped to `[0,100]` in `TransitionDetector`.
+- `EntryStateEvaluator` later normalizes for qualification:
+  - `tq = rawTQ > 1.0 ? rawTQ/100.0 : rawTQ`
+  - so qualification logic uses `[0,1]` scale.
+
+## 2) Scale drift and range checks
+
+### Historical (pre-normalization fix)
+- Before commit `948f852`, qualification used raw `ctx.Transition?.QualityScore` directly against thresholds like `0.55/0.60/0.65`.
+- Since detector emitted `0..100`, these thresholds were effectively near-zero barriers; any non-trivial transition passed.
+
+### Current effective state
+- After `948f852`, qualification uses normalized `0..1` `tq`.
+- Runtime score logs sampled from `Logs/*/RealTime/log.txt` (`[SCORE][TRANSITION] raw=... normalized=...`) show:
+  - all symbols: count=1992, min=23.01, max=91.55, mean=41.54 (on 0..100 scale)
+  - mapped to 0..1: approx min=0.2301, max=0.9155, mean=0.4154
+
+### JPY-focused observed range
+- EURJPY: count=110, min=25.23, max=69.17, mean=37.80
+- GBPJPY: count=139, min=25.02, max=91.29, mean=38.60
+- USDJPY: count=154, min=25.19, max=84.21, mean=39.99
+- Combined JPY mean ≈ 38.91 (0..100), i.e. ≈ 0.3891 normalized.
+
+### Compression assessment
+- Scores are not compressed into a tiny `0.2–0.4` only band; full non-zero spread is roughly `0.23–0.92`.
+- However, the center of mass is below `0.5`, so post-fix thresholds at `0.55/0.60/0.65` are materially stricter than pre-fix behavior.
+
+## 3) Threshold usage map
+
+### Direct TQ thresholds
+- `EntryStateEvaluator`
+  - `HasTransition: tq >= 0.55`
+  - `HasMomentum: tq >= 0.60` (or impulse true)
+  - `HasStructure: tq >= 0.65` (or impulse true)
+
+- `ContinuationPolicy`
+  - weak continuation if `TransitionQuality < 0.55 && !HasImpulse`
+  - hard block on `TransitionQuality < 0.30` (`TRANSITION_COLLAPSE`)
+
+### TradeCore filters using `QualityScore`
+- `ApplyContinuationTransitionNoMomentumFilter`
+  - uses raw `transitionQuality` from `transition.QualityScore`
+  - INDEX block condition: `transitionQuality < 0.40` (mismatched scale assumption vs detector 0..100)
+  - FX/METAL path currently penalty-only here (no hard block by TQ)
+
+- `ApplyContinuationWeakStructureFilter`
+  - `impulseStrength = transition.QualityScore` (naming misleading; this is full TQ 0..100)
+  - compared against thresholds `0.35/0.45/0.40` depending instrument class
+  - this condition is almost always false for non-zero transitions, effectively neutralizing impulse-side weak-structure check.
+
+### Instrument-specific overrides (relevant to TQ)
+- Qualification thresholds (`0.55/0.60/0.65`) are global.
+- ContinuationPolicy penalties/blocks vary by class (CRYPTO blocks more aggressively).
+- TradeCore no-momentum filter:
+  - INDEX may block (`<0.40`), FX penalty-only, METAL smaller penalty, CRYPTO hard block.
+
+## 4) Hidden hard gates / indirect rejection
+
+- TQ indirectly contributes to `DEAD_MARKET` via `HasTrend` + `HasMomentum` derivation in qualification.
+- `!HasTransition` introduces `WEAK_STRUCTURE` penalty in continuation qualification.
+- Notably, many rejects in FX logs are `INVALID_STRUCTURE` from entry-direction structure alignment logic (separate from TQ).
+- No direct evidence that TQ alone triggers `INVALID_STRUCTURE`; it more often influences state/penalty, not that specific reason code.
+
+## 5) Math/normalization correctness findings
+
+### Confirmed issues
+1. **Scale mismatch in TradeCore filters**
+   - Raw `QualityScore` (0..100) is compared to sub-unit thresholds (e.g. `0.40`, `0.35`, `0.45`).
+   - This is mathematically inconsistent with detector output scale.
+
+2. **Qualification scale fix changed behavior materially**
+   - `948f852` corrected normalization in qualification.
+   - This likely lowered pass rates versus previous (incorrectly permissive) behavior.
+
+3. **Analytics transition quality is hard-zeroed**
+   - Trade close snapshots write `TransitionQuality = entryCtx.Transition?.QualityScore` only when `entryCtx.TransitionValid == true`.
+   - `TransitionValid` is set to `false` in detector and never set to `true` anywhere in Core.
+   - Result: persisted analytics/memory TQ becomes zero, masking real runtime TQ and harming post-trade analysis.
+
+### Checked and not found
+- No integer-division bug in formula components.
+- No obvious inverted ratio in core `qualityScore01` blend.
+- Clamp implementation for final TQ itself is correct (`0..100`).
+
+## 6) Logging gap analysis
+
+Current state:
+- TQ is logged in transition scoring (`[SCORE][TRANSITION]`) and state eval logs.
+- Entry decision/reject logs frequently omit explicit TQ alongside structure flags and reason.
+
+Recommended exact line at final decision point:
+
+```csharp
+GlobalLogger.Log(_bot,
+    $"[ENTRY][DECISION][TQ_TRACE] symbol={candidate.Symbol ?? ctx.Symbol} type={candidate.Type} side={candidate.Direction} " +
+    $"rawTQ={(ctx.Transition?.QualityScore ?? 0.0):0.00} tqNorm={((ctx.Transition?.QualityScore ?? 0.0) > 1.0 ? (ctx.Transition.QualityScore / 100.0) : (ctx.Transition?.QualityScore ?? 0.0)):0.00} " +
+    $"structureAligned={structureAligned.ToString().ToLowerInvariant()} entryScore={candidate.Score} reason={candidate.Reason}");
+```
+
+(Use whichever scope has `structureAligned`; if unavailable there, include the nearest equivalent structure flag already produced in the decision path.)
+
+## 7) Final answer to core question
+
+**Is TQ currently suppressing valid FX trades due to scaling or logic error?**
+
+- **Partly yes, but indirectly and unevenly.**
+- The largest recent change is the normalization fix in qualification (0..100 → 0..1), which made `0.55/0.60/0.65` thresholds truly strict. Given observed FX/JPY mean TQ around `~0.39`, this can suppress setups that previously passed.
+- At the same time, there are opposite-direction scale mismatches in TradeCore filters where raw 0..100 TQ is compared to tiny sub-unit thresholds, making those checks too lenient or effectively inert.
+- Therefore, the system is currently **inconsistent across modules** (some paths stricter than intended, others weaker than intended), and this inconsistency can absolutely distort FX trade admission behavior.


### PR DESCRIPTION
### Motivation
- Provide a focused audit of the TransitionQuality (TQ) compute and usage across the entry pipeline (qualification, TradeCore filters, analytics) to detect scale distortion, threshold mismatches, logic bugs, and hidden hard filtering for FX instruments (with emphasis on JPY pairs).

### Description
- Add `TQ_AUDIT_2026-04-01.md` documenting the full TQ pipeline, exact formula, input normalization (0..100 detector output vs 0..1 qualification), per-module threshold usages, JPY-focused runtime distributions, identified scale mismatches, analytics persistence issue, and a proposed decision-path log line to surface TQ in entry decisions.

### Testing
- Performed code inspection and automated scans with `rg` and file dumps (`nl`/`sed`) plus log aggregation scripts (`python`) to extract `[SCORE][TRANSITION]` and `[TRANSITION][LONG|SHORT]` values and symbol distributions, and all checks completed successfully and support the findings in the audit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd1792b4f88328a1d98e35e948204a)