### PR TITLE
Unify Transition Quality to 0..1 and recalibrate qualification thresholds

### DIFF
--- a/Core/Entry/Qualification/ContinuationPolicy.cs
+++ b/Core/Entry/Qualification/ContinuationPolicy.cs
@@ -7,6 +7,9 @@ namespace GeminiV26.Core.Entry.Qualification
 {
     public static class ContinuationPolicy
     {
+        private const double WeakContinuationThreshold = 0.45;
+        private const double TransitionCollapseThreshold = 0.30;
+
         private enum StructureQualityZone
         {
             HardBlock,
@@ -54,7 +57,7 @@ namespace GeminiV26.Core.Entry.Qualification
             }
 
             bool weakContinuation =
-                state.TransitionQuality < 0.55 &&
+                state.TransitionQuality < WeakContinuationThreshold &&
                 !state.HasImpulse;
 
             if (weakContinuation)
@@ -68,7 +71,7 @@ namespace GeminiV26.Core.Entry.Qualification
                 return EntryDecision.Penalize(0.20, "WEAK_CONTINUATION");
             }
 
-            if (state.TransitionQuality < 0.30)
+            if (state.TransitionQuality < TransitionCollapseThreshold)
             {
                 Log(ctx, "[ENTRY][BLOCK][TRANSITION_COLLAPSE]", $"TQ={state.TransitionQuality:0.00}");
                 return EntryDecision.Block("TRANSITION_COLLAPSE");

--- a/Core/Entry/Qualification/EntryStateEvaluator.cs
+++ b/Core/Entry/Qualification/EntryStateEvaluator.cs
@@ -17,6 +17,10 @@ namespace GeminiV26.Core.Entry.Qualification
 
     public static class EntryStateEvaluator
     {
+        private const double TransitionThreshold = 0.42;
+        private const double MomentumThreshold = 0.47;
+        private const double StructureThreshold = 0.52;
+
         public static EntryState Evaluate(EntryContext ctx)
         {
             var state = new EntryState();
@@ -42,24 +46,24 @@ namespace GeminiV26.Core.Entry.Qualification
             // TRANSITION
             // -------------------------
             double rawTQ = ctx.Transition?.QualityScore ?? 0.0;
-            double tq = rawTQ > 1.0 ? rawTQ / 100.0 : rawTQ;
+            double tq = ctx.Transition?.QualityScore01 ?? 0.0;
             state.TransitionQuality = tq;
 
-            state.HasTransition = tq >= 0.55;
+            state.HasTransition = tq >= TransitionThreshold;
 
             // -------------------------
             // MOMENTUM (STRICT)
             // -------------------------
             state.HasMomentum =
                 state.HasImpulse ||
-                tq >= 0.60;
+                tq >= MomentumThreshold;
 
             // -------------------------
             // STRUCTURE (STRICTER THAN BEFORE)
             // -------------------------
             state.HasStructure =
                 state.HasImpulse ||
-                tq >= 0.65;
+                tq >= StructureThreshold;
 
             // -------------------------
             // TREND (STRICT)
@@ -72,6 +76,8 @@ namespace GeminiV26.Core.Entry.Qualification
                 $"[ENTRY][STATE][TREND_EVAL] rawTQ={rawTQ:0.00} tq={tq:0.00} trend={state.HasTrend.ToString().ToLowerInvariant()}");
             Log(ctx,
                 $"[ENTRY][STATE][MOMENTUM_EVAL] rawTQ={rawTQ:0.00} tq={tq:0.00} momentum={state.HasMomentum.ToString().ToLowerInvariant()}");
+            Log(ctx,
+                $"[QUAL][TQ] tq={tq:0.00} hasTransition={state.HasTransition.ToString().ToLowerInvariant()} hasMomentum={state.HasMomentum.ToString().ToLowerInvariant()} hasStructure={state.HasStructure.ToString().ToLowerInvariant()}");
 
             // -------------------------
             // DEAD MARKET

--- a/Core/Entry/TransitionDetector.cs
+++ b/Core/Entry/TransitionDetector.cs
@@ -89,7 +89,8 @@ namespace GeminiV26.Core.Entry
                 FlagBars = Math.Max(longSide.FlagBars, shortSide.FlagBars),
                 PullbackDepthR = Math.Max(longSide.PullbackDepthR, shortSide.PullbackDepthR),
                 CompressionScore = Math.Max(longSide.CompressionScore, shortSide.CompressionScore),
-                QualityScore = Math.Max(longSide.QualityScore, shortSide.QualityScore),
+                QualityScore01 = Math.Max(longSide.QualityScore, shortSide.QualityScore),
+                QualityScore = Math.Max(longSide.QualityScore, shortSide.QualityScore) * 100.0,
 
                 IsValid = false,
                 BonusScore = 0,
@@ -124,14 +125,14 @@ namespace GeminiV26.Core.Entry
                 $"impulse={longSide.HasImpulse.ToString().ToLowerInvariant()} barsSince={longSide.BarsSinceImpulse} " +
                 $"pullback={longSide.HasPullback.ToString().ToLowerInvariant()} pbBars={longSide.PullbackBars} pbDepthR={longSide.PullbackDepthR:0.00} " +
                 $"flagState={longSide.HasFlag.ToString().ToLowerInvariant()} flagBars={longSide.FlagBars} comp={longSide.CompressionScore:0.00} " +
-                $"tradable={longSide.IsTradable.ToString().ToLowerInvariant()} score={longSide.QualityScore:0.00} bonus={longSide.BonusScore} reason={longSide.Reason}");
+                $"tradable={longSide.IsTradable.ToString().ToLowerInvariant()} score01={longSide.QualityScore:0.00} scoreLegacy={(longSide.QualityScore * 100.0):0.00} bonus={longSide.BonusScore} reason={longSide.Reason}");
 
             ctx.Log?.Invoke(
                 $"[TRANSITION][SHORT] phase={shortSide.Phase} " +
                 $"impulse={shortSide.HasImpulse.ToString().ToLowerInvariant()} barsSince={shortSide.BarsSinceImpulse} " +
                 $"pullback={shortSide.HasPullback.ToString().ToLowerInvariant()} pbBars={shortSide.PullbackBars} pbDepthR={shortSide.PullbackDepthR:0.00} " +
                 $"flagState={shortSide.HasFlag.ToString().ToLowerInvariant()} flagBars={shortSide.FlagBars} comp={shortSide.CompressionScore:0.00} " +
-                $"tradable={shortSide.IsTradable.ToString().ToLowerInvariant()} score={shortSide.QualityScore:0.00} bonus={shortSide.BonusScore} reason={shortSide.Reason}");
+                $"tradable={shortSide.IsTradable.ToString().ToLowerInvariant()} score01={shortSide.QualityScore:0.00} scoreLegacy={(shortSide.QualityScore * 100.0):0.00} bonus={shortSide.BonusScore} reason={shortSide.Reason}");
 
             ctx.Log?.Invoke(
                 $"[TRACE][TRANSITION_STATE] symbol={ctx.Symbol} " +
@@ -150,7 +151,8 @@ namespace GeminiV26.Core.Entry
                 FlagBars = Math.Max(longSide.FlagBars, shortSide.FlagBars),
                 PullbackDepthR = Math.Max(longSide.PullbackDepthR, shortSide.PullbackDepthR),
                 CompressionScore = Math.Max(longSide.CompressionScore, shortSide.CompressionScore),
-                QualityScore = Math.Max(longSide.QualityScore, shortSide.QualityScore),
+                QualityScore01 = Math.Max(longSide.QualityScore, shortSide.QualityScore),
+                QualityScore = Math.Max(longSide.QualityScore, shortSide.QualityScore) * 100.0,
                 IsValid = longSide.IsTradable || shortSide.IsTradable,
                 BonusScore = Math.Max(longSide.BonusScore, shortSide.BonusScore),
                 Reason = longSide.IsTradable && shortSide.IsTradable
@@ -545,7 +547,8 @@ namespace GeminiV26.Core.Entry
                 FlagBars = side.FlagBars,
                 PullbackDepthR = side.PullbackDepthR,
                 CompressionScore = side.CompressionScore,
-                QualityScore = side.QualityScore,
+                QualityScore01 = side.QualityScore,
+                QualityScore = side.QualityScore * 100.0,
 
                 IsValid = false,
                 BonusScore = 0,
@@ -567,7 +570,8 @@ namespace GeminiV26.Core.Entry
                 FlagBars = side.FlagBars,
                 PullbackDepthR = side.PullbackDepthR,
                 CompressionScore = side.CompressionScore,
-                QualityScore = side.QualityScore,
+                QualityScore01 = side.QualityScore,
+                QualityScore = side.QualityScore * 100.0,
                 IsValid = side.IsTradable,
                 BonusScore = side.BonusScore,
                 Reason = side.Reason
@@ -800,6 +804,7 @@ namespace GeminiV26.Core.Entry
                 FlagBars = flagBars,
                 PullbackDepthR = pullbackDepthR,
                 CompressionScore = compressionScore,
+                QualityScore01 = 0.0,
                 QualityScore = 0.0,
                 IsValid = false,
                 BonusScore = 0,

--- a/Core/Entry/TransitionEvaluation.cs
+++ b/Core/Entry/TransitionEvaluation.cs
@@ -12,6 +12,7 @@ namespace GeminiV26.Core.Entry
 
         public double PullbackDepthR { get; init; }
         public double CompressionScore { get; init; }
+        public double QualityScore01 { get; init; }
         public double QualityScore { get; init; }
 
         public bool IsValid { get; init; }

--- a/Core/Logging/CsvAnalyticsLogger.cs
+++ b/Core/Logging/CsvAnalyticsLogger.cs
@@ -78,7 +78,7 @@ namespace GeminiV26.Core.Logging
 
                     Csv(context.PendingMeta?.EntryType ?? pctx?.EntryType),
                     CsvNum(pctx?.EntryScore),
-                    CsvNum(transition?.QualityScore),
+                    CsvNum(transition?.QualityScore01),
                     CsvNum(ectx?.TransitionScoreBonus),
 
                     CsvNum(ectx?.AdxSlope_M5),

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1565,13 +1565,22 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot, $"[POS ?] [ENTRY] symbol={selected.Symbol ?? _bot.SymbolName} score={selected.Score} direction={selected.Direction}");
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][ROUTED] sym={_bot.SymbolName} type={selected.Type} routedDir={selected.Direction} score={selected.Score}", _ctx));
                 GlobalLogger.Log(_bot, $"[ENTRY][WINNER] symbol={selected.Symbol ?? _bot.SymbolName} entryType={selected.Type} positionId=0 pipelineId={_ctx?.TempId} score={selected.Score:0.##} confidence={selected.LogicConfidence:0.##}");
+                double finalRawTq = _ctx?.Transition?.QualityScore ?? 0.0;
+                double finalTq = _ctx?.Transition?.QualityScore01 ?? 0.0;
+                bool structureAligned = _ctx?.QualificationState?.HasStructure == true;
+                GlobalLogger.Log(_bot,
+                    $"[ENTRY][TQ_TRACE] symbol={selected.Symbol ?? _bot.SymbolName} type={selected.Type} rawTQ={finalRawTq:0.00} tq={finalTq:0.00} thresholds=transition:0.42,momentum:0.47,structure:0.52 structureAligned={structureAligned.ToString().ToLowerInvariant()} decision=pending");
 
                 if (!PassFinalAcceptance(_ctx, selected))
                 {
+                    GlobalLogger.Log(_bot,
+                        $"[ENTRY][TQ_TRACE] symbol={selected.Symbol ?? _bot.SymbolName} type={selected.Type} rawTQ={finalRawTq:0.00} tq={finalTq:0.00} thresholds=transition:0.42,momentum:0.47,structure:0.52 structureAligned={structureAligned.ToString().ToLowerInvariant()} decision=block");
                     LogHtfFlowStage(_ctx, selected, "FINAL_DECISION", nameof(PassFinalAcceptance));
                     GlobalLogger.Log(_bot, "BLOCK: final acceptance gate");
                     return;
                 }
+                GlobalLogger.Log(_bot,
+                    $"[ENTRY][TQ_TRACE] symbol={selected.Symbol ?? _bot.SymbolName} type={selected.Type} rawTQ={finalRawTq:0.00} tq={finalTq:0.00} thresholds=transition:0.42,momentum:0.47,structure:0.52 structureAligned={structureAligned.ToString().ToLowerInvariant()} decision=pass");
 
                 _ctx.RoutedDirection = selected.Direction;
                 _ctx.FinalDirection = selected.Direction;
@@ -3024,19 +3033,20 @@ namespace GeminiV26.Core
                 : candidate.Direction == TradeDirection.Short
                     ? ctx.TransitionShort
                     : ctx.Transition;
-            double transitionQuality = transition?.QualityScore ?? ctx.Transition?.QualityScore ?? 0.0;
+            double rawTransitionQuality = transition?.QualityScore ?? ctx.Transition?.QualityScore ?? 0.0;
+            double transitionQuality = transition?.QualityScore01 ?? ctx.Transition?.QualityScore01 ?? 0.0;
 
             if (!hasMomentum.HasValue)
             {
                 GlobalLogger.Log(_bot,
-                    $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] TQ={transitionQuality:0.00} action=none instrument={instrument} entryType={candidate.Type} momentum=missing transition={isTransition.ToString().ToLowerInvariant()}");
+                    $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] rawTQ={rawTransitionQuality:0.00} tq={transitionQuality:0.00} action=none instrument={instrument} entryType={candidate.Type} momentum=missing transition={isTransition.ToString().ToLowerInvariant()}");
                 return true;
             }
 
             if (!isTransition || hasMomentum.Value)
             {
                 GlobalLogger.Log(_bot,
-                    $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] TQ={transitionQuality:0.00} action=none instrument={instrument} entryType={candidate.Type} momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()}");
+                    $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] rawTQ={rawTransitionQuality:0.00} tq={transitionQuality:0.00} action=none instrument={instrument} entryType={candidate.Type} momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()}");
                 return true;
             }
 
@@ -3056,7 +3066,7 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot,
                     $"[ENTRY][BLOCK][NO_MOMENTUM_INDEX] symbol={instrument} entryType={candidate.Type}");
                 GlobalLogger.Log(_bot,
-                    $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] TQ={transitionQuality:0.00} action=block instrument={instrument} entryType={candidate.Type} momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()}");
+                    $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] rawTQ={rawTransitionQuality:0.00} tq={transitionQuality:0.00} action=block instrument={instrument} entryType={candidate.Type} momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()}");
                 return false;
             }
 
@@ -3088,7 +3098,7 @@ namespace GeminiV26.Core
                     ? "[TRANSITION_NO_MOMENTUM_BLOCK]"
                     : $"{candidate.Reason} [TRANSITION_NO_MOMENTUM_BLOCK]";
                 GlobalLogger.Log(_bot,
-                    $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] TQ={transitionQuality:0.00} action=block instrument={instrument} entryType={candidate.Type} momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()}");
+                    $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] rawTQ={rawTransitionQuality:0.00} tq={transitionQuality:0.00} action=block instrument={instrument} entryType={candidate.Type} momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()}");
                 return false;
             }
 
@@ -3098,7 +3108,7 @@ namespace GeminiV26.Core
                 ? "[TRANSITION_NO_MOMENTUM_PENALTY]"
                 : $"{candidate.Reason} [TRANSITION_NO_MOMENTUM_PENALTY]";
             GlobalLogger.Log(_bot,
-                $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] TQ={transitionQuality:0.00} action=penalty instrument={instrument} entryType={candidate.Type} momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()} score={scoreBefore}->{candidate.Score} penalty={penalty}");
+                $"[ENTRY][FILTER][TRANSITION_NO_MOMENTUM] rawTQ={rawTransitionQuality:0.00} tq={transitionQuality:0.00} action=penalty instrument={instrument} entryType={candidate.Type} momentum={hasMomentum.Value.ToString().ToLowerInvariant()} transition={isTransition.ToString().ToLowerInvariant()} score={scoreBefore}->{candidate.Score} penalty={penalty}");
             return true;
         }
 
@@ -3125,7 +3135,7 @@ namespace GeminiV26.Core
             }
 
             double flagQuality = transition.CompressionScore;
-            double impulseStrength = transition.QualityScore;
+            double impulseStrength = transition.QualityScore01;
             var instrumentClass = SymbolRouting.ResolveInstrumentClass(instrument);
 
             double qualityThreshold = 0.35;
@@ -3955,9 +3965,7 @@ namespace GeminiV26.Core
                     MfeR = ctx?.MfeR ?? 0.0,
                     MaeR = ctx != null ? -Math.Abs(ctx.MaeR) : 0.0,
                     RMultiple = ComputeRMultiple(pos, ctx, sym.PipSize),
-                    TransitionQuality = entryCtx?.TransitionValid == true
-                        ? entryCtx.Transition?.QualityScore ?? 0.0
-                        : 0.0,
+                    TransitionQuality = entryCtx?.Transition?.QualityScore01 ?? 0.0,
                     AccountBalanceAtEntry = entryBalance
                 });
 
@@ -3973,9 +3981,7 @@ namespace GeminiV26.Core
                 MFE = ctx?.MfeR ?? 0.0,
                 MAE = ctx != null ? -Math.Abs(ctx.MaeR) : 0.0,
                 MarketRegime = ResolveMarketRegime(entryCtx),
-                TransitionQuality = entryCtx?.TransitionValid == true
-                    ? entryCtx.Transition?.QualityScore ?? 0.0
-                    : 0.0,
+                TransitionQuality = entryCtx?.Transition?.QualityScore01 ?? 0.0,
                 Confidence = ctx?.FinalConfidence ?? meta?.EntryScore ?? 0.0,
                 EntryTime = ctx?.EntryTime ?? pos.EntryTime,
                 ExitTime = _bot.Server.Time


### PR DESCRIPTION
### Motivation
- Remove mixed 0..1 vs 0..100 scale errors that produced dead conditions and incorrect gating across the entry pipeline.
- Recalibrate qualification thresholds to match observed TQ distribution (mean ~0.41) so gates are realistic and not overly strict.
- Maintain backward compatibility by keeping a legacy 0..100 field while making 0..1 the single source of truth for logic, and add explicit debug logging for traceability.

### Description
- Expose dual-scale fields in the transition payload by adding `QualityScore01` (0..1 primary) while retaining `QualityScore` (legacy 0..100) and update the detector to populate both (legacy is derived as `QualityScore01 * 100`). Files: `Core/Entry/TransitionEvaluation.cs` and `Core/Entry/TransitionDetector.cs`. 
- Replaced all logic consumption to use `QualityScore01` and removed implicit normalizations; recalibrated qualification thresholds to constants: `HasTransition=0.42`, `HasMomentum=0.47`, `HasStructure=0.52`, `WeakContinuation=0.45`, `TransitionCollapse=0.30`, and added `[QUAL][TQ]` trace logging in `Core/Entry/Qualification/EntryStateEvaluator.cs` and `Core/Entry/Qualification/ContinuationPolicy.cs`.
- Fixed TradeCore filters to use `QualityScore01` (kept raw legacy value only for debug traces), added mandatory `[ENTRY][TQ_TRACE]` final-entry logging (pending/block/pass) and ensured analytics persistence uses `QualityScore01` when transition data is present; changes in `Core/TradeCore.cs` and `Core/Logging/CsvAnalyticsLogger.cs`.
- Files changed in this PR: `Core/Entry/TransitionEvaluation.cs`, `Core/Entry/TransitionDetector.cs`, `Core/Entry/Qualification/EntryStateEvaluator.cs`, `Core/Entry/Qualification/ContinuationPolicy.cs`, `Core/TradeCore.cs`, `Core/Logging/CsvAnalyticsLogger.cs`.

### Testing
- Automated static scans were run searching for remaining implicit normalizations or mixed-scale conditions and confirmed logic now reads `QualityScore01` as the decision source and that legacy `QualityScore` appears only in payload/trace contexts (scan succeeded). 
- Diff/inspection of modified files verified `TransitionDetector` writes both scales and that qualification and TradeCore use the new thresholds constants (inspection succeeded). 
- CSV analytics export was validated to emit the 0..1 `QualityScore01` field instead of legacy values (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd1c2ea5cc8328a9a6e6b80d2fbdfd)