### PR TITLE
XAU: allow flag-like continuations inside chop regime gate

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1466,16 +1466,64 @@ namespace GeminiV26.Core
                 {
                     xauState = _xauMarketStateDetector.Evaluate();
 
-                    if (xauState != null && xauState.IsRange && !xauState.IsTrend)
+                    if (xauState != null)
                     {
-                        LogEntryTraceGate(_ctx, selected, "MarketStateGate", selected.Direction, true, "XAU_RANGE_REGIME");
-                        GlobalLogger.Log(_bot, 
-                            $"[TC] ENTRY BLOCKED: XAU RANGE REGIME" +
-                            $"Width={xauState.RangeWidth:F2} " +
-                            $"ADX={xauState.Adx:F1} " +
-                            $"ATR={xauState.Atr:F2}"
-                        );
-                        return;
+                        bool isChop = xauState.IsRange && !xauState.IsTrend;
+
+                        bool hasDirectionalImpulse =
+                            selected.Direction == TradeDirection.Long
+                                ? _ctx.HasImpulseLong_M5
+                                : selected.Direction == TradeDirection.Short
+                                    ? _ctx.HasImpulseShort_M5
+                                    : false;
+
+                        int barsSinceImpulse =
+                            selected.Direction == TradeDirection.Long
+                                ? _ctx.BarsSinceImpulseLong_M5
+                                : selected.Direction == TradeDirection.Short
+                                    ? _ctx.BarsSinceImpulseShort_M5
+                                    : 999;
+
+                        double transitionQuality =
+                            _ctx.Transition?.QualityScore01 > 0
+                                ? _ctx.Transition.QualityScore01
+                                : _ctx.Transition?.QualityScore ?? 0.0;
+
+                        bool hasRecentImpulse =
+                            hasDirectionalImpulse &&
+                            transitionQuality >= 0.60 &&
+                            barsSinceImpulse <= 5;
+
+                        bool isCompressionStructure =
+                            _ctx.Transition != null &&
+                            transitionQuality >= 0.50 &&
+                            xauState.RangeWidthAtr < 0.50;
+
+                        bool isFlagLike = hasRecentImpulse && isCompressionStructure;
+
+                        GlobalLogger.Log(_bot,
+                            $"[XAU][REGIME][STATE] chop={isChop.ToString().ToLowerInvariant()} impulse={hasRecentImpulse.ToString().ToLowerInvariant()} compression={isCompressionStructure.ToString().ToLowerInvariant()}");
+
+                        if (isChop)
+                        {
+                            if (isFlagLike)
+                            {
+                                GlobalLogger.Log(_bot,
+                                    $"[XAU][REGIME][FLAG_ALLOW] impulse={hasRecentImpulse.ToString().ToLowerInvariant()} compression={isCompressionStructure.ToString().ToLowerInvariant()} tq={transitionQuality:F2}");
+                                LogEntryTraceGate(_ctx, selected, "MarketStateGate", selected.Direction, false, "XAU_FLAG_ALLOW");
+                            }
+                            else
+                            {
+                                bool noImpulse = !hasRecentImpulse;
+                                bool noCompression = !isCompressionStructure;
+                                LogEntryTraceGate(_ctx, selected, "MarketStateGate", selected.Direction, true, "XAU_CHOP_NO_FLAG");
+                                GlobalLogger.Log(_bot,
+                                    $"[XAU][REGIME][CHOP_BLOCK] noImpulse={noImpulse.ToString().ToLowerInvariant()} noCompression={noCompression.ToString().ToLowerInvariant()}");
+                                GlobalLogger.Log(_bot,
+                                    $"[TC] ENTRY BLOCKED: XAU RANGE REGIME Width={xauState.RangeWidth:F2} ADX={xauState.Adx:F1} ATR={xauState.Atr:F2}");
+                                return;
+                            }
+                        }
                     }
 
                     LogEntryTraceGate(_ctx, selected, "MarketStateGate", selected.Direction, false, "PASS");


### PR DESCRIPTION
### Motivation
- Fix false-negative XAU trades caused by blanket chop/range blocking by permitting valid flag/compression continuation setups inside chop regimes while preserving protection against dead sideways markets.
- Limit the change to the Metal (XAU) path so FX, Index, and Crypto behavior and core risk/execution logic remain untouched.
- Add observability for the new decision branches so operators can audit when chop is allowed vs blocked.

### Description
- Extended the XAU market-state gate in `Core/TradeCore.cs` to compute `isChop`, `hasDirectionalImpulse`, `barsSinceImpulse`, `transitionQuality`, `hasRecentImpulse`, `isCompressionStructure`, and `isFlagLike` and use those to decide gating for XAU only.
- New gating behavior: if XAU is in chop and `isFlagLike` is true then allow the entry to pass the gate, otherwise block as before; if not chop, preserve existing pass behavior.
- Added logging lines: `[XAU][REGIME][STATE] chop=... impulse=... compression=...`, `[XAU][REGIME][FLAG_ALLOW] ...`, and `[XAU][REGIME][CHOP_BLOCK] ...` to provide traceability for each branch.
- Change is scoped to the XAU pathway guarded by `IsSymbol("XAUUSD")` and does not modify TQ normalization, entry scoring, risk sizing, or other instrument logic.

### Testing
- Ran code searches with `rg` to verify the new gating branch and log lines were inserted into `Core/TradeCore.cs` and to confirm no other instruments were modified; the expected log patterns were found.
- Performed a static review of the modified branch to ensure the new boolean checks and log messages follow the requested rules and scope restrictions.
- Attempted to run the `dotnet` CLI in this environment but it is unavailable, so no compile or runtime automated tests could be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd223ca04c8328936c6db1b8acf864)