### PR TITLE
Rehydrate: avoid synthetic confidence and add SAFE_MODE for missing confidence

### DIFF
--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -339,7 +339,14 @@ namespace GeminiV26.Core
                 return;
 
             FinalConfidence = ComputeFinalConfidenceValue(EntryScore, LogicConfidence);
-            if (AdjustedRiskConfidence <= 0)
+            if (RehydratedWithoutConfidence)
+            {
+                // Rehydrate SAFE MODE:
+                // confidence-dependent branching must observe disabled risk confidence.
+                AdjustedRiskConfidence = 0;
+                GlobalLogger.Log(Bot, "[REHYDRATE][SAFE_MODE] confidence_dependent_logic_disabled=true");
+            }
+            else if (AdjustedRiskConfidence <= 0)
             {
                 // Failsafe fallback – MUST be visible
                 AdjustedRiskConfidence = FinalConfidence;
@@ -389,6 +396,12 @@ namespace GeminiV26.Core
         /// Csak meta / debug cél.
         /// </summary>
         public bool IsRehydrated { get; set; }
+
+        /// <summary>
+        /// Rehydrate restored lifecycle state but no persisted confidence inputs were available.
+        /// SAFE MODE must avoid synthetic confidence assumptions.
+        /// </summary>
+        public bool RehydratedWithoutConfidence { get; set; }
 
         /// <summary>
         /// Rehydrate meta timestamp UTC-ban.

--- a/Core/Runtime/RehydrateService.cs
+++ b/Core/Runtime/RehydrateService.cs
@@ -230,8 +230,7 @@ namespace GeminiV26.Core.Runtime
                     EntryType = "REHYDRATED",
                     EntryReason = "Startup rehydrate from live open position",
                     FinalDirection = position.TradeType == TradeType.Buy ? TradeDirection.Long : TradeDirection.Short,
-                    EntryScore = 50,
-                    LogicConfidence = 50,
+                    RehydratedWithoutConfidence = true,
                     EntryTime = position.EntryTime,
                     EntryTimeUtc = position.EntryTime.ToUniversalTime(),
                     EntryPrice = position.EntryPrice,
@@ -246,6 +245,8 @@ namespace GeminiV26.Core.Runtime
                     MarketTrend = true,
                     Adx_M5 = 0
                 };
+                GlobalLogger.Log(_bot, $"[REHYDRATE][CONFIDENCE_MISSING] pos={positionKey} symbol={position.SymbolName} reason=resolver_failed_no_persisted_confidence");
+                GlobalLogger.Log(_bot, $"[REHYDRATE][SAFE_MODE] pos={positionKey} symbol={position.SymbolName} mode=rehydrated_without_confidence");
                 unresolvedContext.ComputeFinalConfidence();
                 result.Context = unresolvedContext;
                 result.UsedFallback = true;
@@ -387,11 +388,7 @@ namespace GeminiV26.Core.Runtime
                 EntryType = "REHYDRATED",
                 EntryReason = "Startup rehydrate from live open position",
                 FinalDirection = direction,
-                // Ambiguity note:
-                // original entry evaluation is runtime-only and cannot be recovered safely after restart,
-                // so we restore with neutral placeholders and keep FinalConfidence deterministic via ComputeFinalConfidence().
-                EntryScore = 50,
-                LogicConfidence = 50,
+                RehydratedWithoutConfidence = true,
                 EntryTime = position.EntryTime,
                 EntryTimeUtc = position.EntryTime.ToUniversalTime(),
                 EntryPrice = entryPrice,
@@ -419,6 +416,8 @@ namespace GeminiV26.Core.Runtime
                 Adx_M5 = 0,
                 RuntimeSymbolAvailable = true
             };
+            GlobalLogger.Log(_bot, $"[REHYDRATE][CONFIDENCE_MISSING] pos={positionKey} symbol={position.SymbolName} reason=no_persisted_confidence_inputs");
+            GlobalLogger.Log(_bot, $"[REHYDRATE][SAFE_MODE] pos={positionKey} symbol={position.SymbolName} mode=rehydrated_without_confidence");
 
             if (!ctx.InitialStopLossPrice.HasValue && stopLoss != null)
             {

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -738,9 +738,7 @@ namespace GeminiV26.Instruments.XAUUSD
                     RemainingVolumeInUnits = pos.VolumeInUnits,
                     InitialVolumeInUnits = pos.VolumeInUnits,
 
-                    // Neutral confidence placeholders (same rehydrate convention as RehydrateService).
-                    EntryScore = 50,
-                    LogicConfidence = 50,
+                    RehydratedWithoutConfidence = true,
 
                     // SSOT snapshot
                     RiskPriceDistance = rDist,
@@ -750,6 +748,8 @@ namespace GeminiV26.Instruments.XAUUSD
                     Tp1Hit = false,
                     IsRehydrated = true
                 };
+                GlobalLogger.Log(_bot, $"[REHYDRATE][CONFIDENCE_MISSING] pos={pos.Id} symbol={pos.SymbolName} reason=xau_live_rehydrate_no_persisted_confidence");
+                GlobalLogger.Log(_bot, $"[REHYDRATE][SAFE_MODE] pos={pos.Id} symbol={pos.SymbolName} mode=rehydrated_without_confidence");
 
                 // AGENTS rule: PositionContext létrehozás után azonnal számoljuk a FinalConfidence-t.
                 ctx.ComputeFinalConfidence();


### PR DESCRIPTION
### Motivation
- Fix rehydrate path that injected synthetic confidence (e.g. `EntryScore = 50`, `LogicConfidence = 50`) which distorted risk and exit logic. 
- Ensure rehydrated contexts without persisted confidence do not fabricate values and do not cause over-risking. 
- Provide visible logs and a conservative safe-mode to make behavior auditable and deterministic when confidence is missing.

### Description
- Remove synthetic placeholder assignments in rehydrate flows and mark those contexts explicitly with `RehydratedWithoutConfidence = true` in `Core/Runtime/RehydrateService.cs` and `Instruments/XAUUSD/XauExitManager.cs` instead of setting `EntryScore`/`LogicConfidence` to `50`.
- Add `public bool RehydratedWithoutConfidence` to `Core/PositionContext.cs` and update `ComputeFinalConfidence()` so that when `RehydratedWithoutConfidence` is true it forces `AdjustedRiskConfidence = 0` (SAFE MODE) and logs `[REHYDRATE][SAFE_MODE]` rather than injecting a synthetic risk value.
- Add audit logs at rehydrate time: `[REHYDRATE][CONFIDENCE_MISSING]` and `[REHYDRATE][SAFE_MODE]` in the rehydrate code paths so missing-confidence cases are recorded.
- Kept the change minimal and localized to `Core/PositionContext.cs`, `Core/Runtime/RehydrateService.cs`, and `Instruments/XAUUSD/XauExitManager.cs` to preserve existing behavior where persisted confidence exists.

### Testing
- Attempted an automated build with `dotnet build -v minimal`, but it could not run in this environment because `dotnet` is not installed (build failed due to missing toolchain).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd390d59208328b249b5416946f24a)