### PR TITLE
Standardize EURUSD gate null handling to fail-closed

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -1769,13 +1769,13 @@ namespace GeminiV26.Core
 
             else if (IsSymbol("EURUSD"))
             {
-                if (!EvaluateEntryGate(_ctx, selected, "SessionGate", () => _eurUsdSessionGate == null || _eurUsdSessionGate.AllowEntry(gateDir), "EUR SessionGate"))
+                if (!EvaluateEntryGate(_ctx, selected, "SessionGate", () => _eurUsdSessionGate?.AllowEntry(gateDir) ?? false, "EUR SessionGate"))
                 {
                     GlobalLogger.Log(_bot, "[TC] BLOCKED: EUR SessionGate");
                     return;
                 }
 
-                if (!EvaluateEntryGate(_ctx, selected, "ImpulseGate", () => _eurUsdImpulseGate == null || _eurUsdImpulseGate.AllowEntry(gateDir), "EUR ImpulseGate"))
+                if (!EvaluateEntryGate(_ctx, selected, "ImpulseGate", () => _eurUsdImpulseGate?.AllowEntry(gateDir) ?? false, "EUR ImpulseGate"))
                 {
                     GlobalLogger.Log(_bot, "[TC] BLOCKED: EUR ImpulseGate");
                     return;


### PR DESCRIPTION
### Motivation

- Ensure consistent null-handling for entry gates across instruments so a missing/uninitialized gate does not silently permit trades. 
- Fail-closed behavior is preferred for safety in entry risk controls so missing gates block rather than allow entries.

### Description

- Audited `Core/TradeCore.cs` and found 16 gate checks in the entry flow, with EURUSD previously using `gate == null || gate.AllowEntry(...)` (null = allow) while others used `gate?.AllowEntry(...) ?? false` (null = block). 
- Replaced the EURUSD Session and Impulse checks with the fail-closed pattern: `() => _eurUsdSessionGate?.AllowEntry(gateDir) ?? false` and `() => _eurUsdImpulseGate?.AllowEntry(gateDir) ?? false` in `Core/TradeCore.cs`. 
- Change is minimal (no refactor) and aligns EURUSD behavior with other instruments that already block on null gates.

### Testing

- Ran pattern searches with `rg` to enumerate `AllowEntry` usages and confirm EURUSD was the only instance using `== null || ...AllowEntry(...)`, and re-ran the search after the patch to confirm no `== null || ...AllowEntry(...)` remain in `Core/TradeCore.cs`. 
- Inspected the updated file contents to verify the two EURUSD lines were changed to the `?.AllowEntry(...) ?? false` form. 
- Applied the patch successfully to `Core/TradeCore.cs` and verified the modified lines match the provided patch-ready code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3be1add8832881926d87d77e97b0)