### PR TITLE
Enforce SAFE MODE on rehydrated positions without confidence

### DIFF
--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -132,7 +132,12 @@ namespace GeminiV26.Core.Logging
             else if (ctx.FinalDirection == TradeDirection.Short)
                 pnlPips = (pos.EntryPrice - symbol.Ask) / symbol.PipSize;
 
-            return "[STATE]\n" +
+            string safeModeTrace = ctx.RehydratedWithoutConfidence
+                ? "[CTX][SAFE_MODE] active=true\n"
+                : string.Empty;
+
+            return safeModeTrace +
+                   "[STATE]\n" +
                    $"barsOpen={ctx.BarsSinceEntryM5}\n" +
                    $"pnlPips={pnlPips:0.##}\n" +
                    $"mfeR={ctx.MfeR:0.##}\n" +

--- a/Instruments/AUDNZD/AudNzdExitManager.cs
+++ b/Instruments/AUDNZD/AudNzdExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.AUDNZD
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.AUDNZD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/AUDUSD/AudUsdExitManager.cs
+++ b/Instruments/AUDUSD/AudUsdExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.AUDUSD
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.AUDUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/BTCUSD/BtcUsdExitManager.cs
+++ b/Instruments/BTCUSD/BtcUsdExitManager.cs
@@ -353,7 +353,11 @@ namespace GeminiV26.Instruments.BTCUSD
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                             {
                                 GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -573,13 +577,13 @@ namespace GeminiV26.Instruments.BTCUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/ETHUSD/EthUsdExitManager.cs
+++ b/Instruments/ETHUSD/EthUsdExitManager.cs
@@ -334,7 +334,11 @@ namespace GeminiV26.Instruments.ETHUSD
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -503,13 +507,13 @@ namespace GeminiV26.Instruments.ETHUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/EURJPY/EurJpyExitManager.cs
+++ b/Instruments/EURJPY/EurJpyExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.EURJPY
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.EURJPY
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/EURUSD/EurUsdExitManager.cs
+++ b/Instruments/EURUSD/EurUsdExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.EURUSD
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.EURUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/GBPJPY/GbpJpyExitManager.cs
+++ b/Instruments/GBPJPY/GbpJpyExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.GBPJPY
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.GBPJPY
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/GBPUSD/GbpUsdExitManager.cs
+++ b/Instruments/GBPUSD/GbpUsdExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.GBPUSD
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.GBPUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/GER40/Ger40ExitManager.cs
+++ b/Instruments/GER40/Ger40ExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.GER40
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.GER40
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/NAS100/NasExitManager.cs
+++ b/Instruments/NAS100/NasExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.NAS100
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.NAS100
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/NZDUSD/NzdUsdExitManager.cs
+++ b/Instruments/NZDUSD/NzdUsdExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.NZDUSD
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.NZDUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/US30/Us30ExitManager.cs
+++ b/Instruments/US30/Us30ExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.US30
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.US30
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/USDCAD/UsdCadExitManager.cs
+++ b/Instruments/USDCAD/UsdCadExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.USDCAD
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.USDCAD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/USDCHF/UsdChfExitManager.cs
+++ b/Instruments/USDCHF/UsdChfExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.USDCHF
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.USDCHF
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/USDJPY/UsdJpyExitManager.cs
+++ b/Instruments/USDJPY/UsdJpyExitManager.cs
@@ -307,7 +307,11 @@ namespace GeminiV26.Instruments.USDJPY
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -446,13 +450,13 @@ namespace GeminiV26.Instruments.USDJPY
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return 0.60;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             if (confidence >= 85)
                 return 0.40;

--- a/Instruments/XAUUSD/XauExitManager.cs
+++ b/Instruments/XAUUSD/XauExitManager.cs
@@ -379,7 +379,11 @@ namespace GeminiV26.Instruments.XAUUSD
                             continue;
                         }
 
-                        if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
+                        if (ctx.RehydratedWithoutConfidence)
+                        {
+                            GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={pos.SymbolName} positionId={pos.Id} confidence_exit_disabled=true");
+                        }
+                        else if (_tvm.ShouldEarlyExit(ctx, pos, m5, m15))
                         {
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds($"[EXIT][DECISION]\nreason={ctx.DeadTradeReason}\ndetail=tvm_early_exit", ctx, pos));
                             GlobalLogger.Log(_bot, TradeLogIdentity.WithPositionIds("[EXIT SNAPSHOT]\n" +
@@ -663,13 +667,13 @@ namespace GeminiV26.Instruments.XAUUSD
             if (ctx.Tp1R > 0)
                 return ctx.Tp1R;
 
-            int confidence = ctx.AdjustedRiskConfidence;
-
-            if (confidence <= 0)
+            if (ctx.RehydratedWithoutConfidence)
             {
-                confidence = ctx.FinalConfidence;
-                GlobalLogger.Log(_bot, "[CONF][EXIT_FALLBACK] using FinalConfidence");
+                GlobalLogger.Log(_bot, $"[EXIT][SAFE_MODE] symbol={ctx.Symbol} positionId={ctx.PositionId} profile=tp1_conservative");
+                return _profile.Tp1R_Low;
             }
+
+            int confidence = ctx.AdjustedRiskConfidence;
 
             // Profil bucket
             if (confidence >= 85) return _profile.Tp1R_High;


### PR DESCRIPTION
### Motivation
- Prevent synthetic, default or fallback `EntryScore`/`LogicConfidence` values from influencing risk/exit/TP/trailing logic after a restart when persisted confidence inputs are missing.
- Ensure rehydrated contexts without confidence enter an explicit SAFE MODE that disables confidence-dependent exit decisions and forces the most conservative policies.

### Description
- Emit SAFE MODE trace in lifecycle snapshots by prefixing state logs with `[CTX][SAFE_MODE] active=true` when `PositionContext.RehydratedWithoutConfidence` is true (`Core/Logging/TradeAuditLog.cs`).
- In all instrument `ExitManager`s, bypass TVM early-exit checks when `ctx.RehydratedWithoutConfidence` is true and emit `[EXIT][SAFE_MODE] ... confidence_exit_disabled=true` instead of running confidence-based early-exit (`_tvm.ShouldEarlyExit`).
- In all instrument `ExitManager`s, replace the previous fallback that used `FinalConfidence` for TP1 resolution with an explicit SAFE MODE branch that logs `[EXIT][SAFE_MODE] ... profile=tp1_conservative` and returns the conservative TP1 profile (`0.60` or `_profile.Tp1R_Low` for XAUUSD).
- Applied these changes across 16 instrument exit managers and committed the updates with message `Enforce safe-mode confidence handling for rehydrated exits`.

### Testing
- Ran `git -C /workspace/GeminiV26 diff --check` and it returned `OK` indicating no whitespace/patch issues.
- Verified presence of the TVM SAFE MODE disable marker with a repository-wide search which returned 16 matches for `confidence_exit_disabled=true`.
- Verified presence of the TP1 SAFE MODE marker with a repo-wide search which returned 16 matches for `profile=tp1_conservative`.
- Verified no remaining `[CONF][EXIT_FALLBACK]` usages in instrument `ExitManager`s via `rg` checks which returned zero matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3d07cc5883288b53826f1f243f97)