### PR TITLE
Add legacy AdjustedRiskConfidence alias to EntryContext

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -353,6 +353,13 @@ namespace GeminiV26.Core.Entry
         [Obsolete("LEGACY – use LogicBiasConfidence")]
         public int LogicConfidence => LogicBiasConfidence;
 
+        [Obsolete("LEGACY – use RiskConfidence")]
+        public int AdjustedRiskConfidence
+        {
+            get => RiskConfidence;
+            set => RiskConfidence = value;
+        }
+
         [Obsolete("LEGACY – use ActiveHtfDirection")]
         public TradeDirection HtfDirection => ActiveHtfDirection;
 


### PR DESCRIPTION
### Motivation
- Fix a compile-time break where call sites still reference `EntryContext.AdjustedRiskConfidence` while keeping the current confidence logic and modifications intact.

### Description
- Add an `[Obsolete("LEGACY – use RiskConfidence")]` `AdjustedRiskConfidence` property to `Core/Entry/EntryContext.cs` that `get`/`set`s the existing `RiskConfidence` field as a backward-compatible alias.

### Testing
- Ran `rg -n "AdjustedRiskConfidence" Core/Entry/EntryContext.cs`, checked `git status --short`, and committed the change; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd44767f848328942a759828159823)