### PR TITLE
Block entry execution on direction consistency mismatches

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2021,9 +2021,29 @@ namespace GeminiV26.Core
                 return false;
             }
 
+            if (entry.Direction == TradeDirection.None || entryContext.FinalDirection == TradeDirection.None)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[DIR][FATAL_MISMATCH] sym={_bot.SymbolName} reason=direction_none entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
+                return false;
+            }
+
+            if (entryContext.RoutedDirection != TradeDirection.None &&
+                entryContext.RoutedDirection != entryContext.FinalDirection)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[DIR][FATAL_MISMATCH] sym={_bot.SymbolName} reason=routed_final_mismatch routedDir={entryContext.RoutedDirection} finalDir={entryContext.FinalDirection}");
+                GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
+                return false;
+            }
+
             if (entry.Direction != entryContext.FinalDirection)
             {
-                GlobalLogger.Log(_bot, $"[DIR][EXEC_MISMATCH] sym={_bot.SymbolName} entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                GlobalLogger.Log(_bot,
+                    $"[DIR][FATAL_MISMATCH] sym={_bot.SymbolName} reason=entry_final_mismatch entryDir={entry.Direction} finalDir={entryContext.FinalDirection} routedDir={entryContext.RoutedDirection}");
+                GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
+                return false;
             }
 
             return true;


### PR DESCRIPTION
### Motivation
- The pipeline previously logged direction disagreements but allowed execution to continue, which could let internal direction drift reach the executor and place orders despite inconsistent inputs. 
- The system treats `FinalDirection` as the single source of truth (SSOT) for execution and must block when internal routing/entry values contradict it. 
- Enforce a centralized hard-block to prevent silent mismatches from reaching instrument executors. 

### Description
- Hardened `ValidateDirectionConsistency` in `Core/TradeCore.cs` to return `false` (block) and emit `[DIR][FATAL_MISMATCH]` when any of these conditions occur: `entry.Direction == TradeDirection.None` or `entryContext.FinalDirection == TradeDirection.None`; `entryContext.RoutedDirection != TradeDirection.None` and `entryContext.RoutedDirection != entryContext.FinalDirection`; or `entry.Direction != entryContext.FinalDirection`. (See `Core/TradeCore.cs` around the `ValidateDirectionConsistency` method.)
- Replaced prior non-blocking `EXEC_MISMATCH` logging with explicit fatal mismatch logs and immediate block-return from `ValidateDirectionConsistency` so callers stop execution when inconsistency is detected. 
- Noted the relevant related locations where mismatches were previously only logged (audit paths): `Core/Entry/EntryContext.cs` (direction flow fields: `LogicBiasDirection`, `RoutedDirection`, `FinalDirection`) and representative executor mismatch logs such as `Instruments/XAUUSD/XauInstrumentExecutor.cs` (log-only handling before fix). 

### Testing
- Attempted an automated build with `dotnet build -v minimal`, but the environment lacks `dotnet` so the build could not be run (`dotnet: command not found`).
- No automated tests were executed successfully in this environment; the change is limited to `Core/TradeCore.cs` and is designed to be validated by a normal CI build and integration test run that exercise routing → execution paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd454fb5408328a793354499f65d98)