### PR TITLE
Enforce FinalDirection as SSOT in ValidateDirectionConsistency

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2016,15 +2016,15 @@ namespace GeminiV26.Core
         {
             if (entryContext == null || entry == null)
             {
-                GlobalLogger.Log(_bot, $"[DIR][FATAL_MISMATCH] sym={_bot.SymbolName} reason=null_context_or_entry");
+                GlobalLogger.Log(_bot, $"[DIR][FATAL_MISMATCH] type=null_context_or_entry sym={_bot.SymbolName}");
                 GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
                 return false;
             }
 
-            if (entry.Direction == TradeDirection.None || entryContext.FinalDirection == TradeDirection.None)
+            if (entryContext.FinalDirection == TradeDirection.None)
             {
                 GlobalLogger.Log(_bot,
-                    $"[DIR][FATAL_MISMATCH] sym={_bot.SymbolName} reason=direction_none entryDir={entry.Direction} finalDir={entryContext.FinalDirection}");
+                    $"[DIR][FATAL_MISMATCH] type=final_none sym={_bot.SymbolName}");
                 GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
                 return false;
             }
@@ -2033,7 +2033,7 @@ namespace GeminiV26.Core
                 entryContext.RoutedDirection != entryContext.FinalDirection)
             {
                 GlobalLogger.Log(_bot,
-                    $"[DIR][FATAL_MISMATCH] sym={_bot.SymbolName} reason=routed_final_mismatch routedDir={entryContext.RoutedDirection} finalDir={entryContext.FinalDirection}");
+                    $"[DIR][FATAL_MISMATCH] type=routed_vs_final sym={_bot.SymbolName} routed={entryContext.RoutedDirection} final={entryContext.FinalDirection}");
                 GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
                 return false;
             }
@@ -2041,9 +2041,7 @@ namespace GeminiV26.Core
             if (entry.Direction != entryContext.FinalDirection)
             {
                 GlobalLogger.Log(_bot,
-                    $"[DIR][FATAL_MISMATCH] sym={_bot.SymbolName} reason=entry_final_mismatch entryDir={entry.Direction} finalDir={entryContext.FinalDirection} routedDir={entryContext.RoutedDirection}");
-                GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
-                return false;
+                    $"[DIR][ENTRY_MISMATCH] entry={entry.Direction.ToString().ToUpperInvariant()} final={entryContext.FinalDirection.ToString().ToUpperInvariant()} sym={_bot.SymbolName}");
             }
 
             return true;


### PR DESCRIPTION
### Motivation
- Ensure `FinalDirection` is the single source of truth for execution direction and remove false hard-blocks caused by candidate direction differences.  
- Prevent direction drift and preserve deterministic execution while keeping routing and HTF logic untouched.  
- Limit the change strictly to direction validation to avoid touching HTF, `EntryLogic`, or executor behavior.

### Description
- Updated `ValidateDirectionConsistency` in `Core/TradeCore.cs` to hard-block only when `entryContext`/`entry` is null or `entryContext.FinalDirection == TradeDirection.None`, and to log a `[DIR][FATAL_MISMATCH] type=final_none` message for the latter.  
- Added a hard block when `entryContext.RoutedDirection` exists and conflicts with `FinalDirection`, emitting `[DIR][FATAL_MISMATCH] type=routed_vs_final`.  
- Replaced the previous hard block for `entry.Direction != FinalDirection` with a non-blocking audit log `[DIR][ENTRY_MISMATCH] entry=... final=...` and allowed the method to return `true`.  
- Normalized the null-context fatal log to use `type=null_context_or_entry` and preserved the existing blocking behavior on fatal conditions.

### Testing
- Verified the code diff with `git diff -- Core/TradeCore.cs` and confirmed the intended changes were present.  
- Searched for the new log patterns using `rg -n "\[DIR\]\[(FATAL_MISMATCH|ENTRY_MISMATCH)\]" Core/TradeCore.cs` and confirmed the expected log entries exist.  
- Inspected the modified method lines with `nl -ba Core/TradeCore.cs | sed -n '2008,2052p'` to confirm the soft vs hard validation behavior and that the method returns `true` for entry mismatches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd46a4af808328a5a371b4d5841885)