### PR TITLE
Standardize direction consistency mismatch logs

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -2024,7 +2024,7 @@ namespace GeminiV26.Core
             if (entryContext.FinalDirection == TradeDirection.None)
             {
                 GlobalLogger.Log(_bot,
-                    $"[DIR][FATAL_MISMATCH] type=final_none sym={_bot.SymbolName}");
+                    $"[DIR][FATAL_MISMATCH] type=final_none entry={entry.Direction} routed={entryContext.RoutedDirection} final={entryContext.FinalDirection} sym={_bot.SymbolName}");
                 GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
                 return false;
             }
@@ -2033,7 +2033,7 @@ namespace GeminiV26.Core
                 entryContext.RoutedDirection != entryContext.FinalDirection)
             {
                 GlobalLogger.Log(_bot,
-                    $"[DIR][FATAL_MISMATCH] type=routed_vs_final sym={_bot.SymbolName} routed={entryContext.RoutedDirection} final={entryContext.FinalDirection}");
+                    $"[DIR][FATAL_MISMATCH] type=routed_vs_final entry={entry.Direction} routed={entryContext.RoutedDirection} final={entryContext.FinalDirection} sym={_bot.SymbolName}");
                 GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
                 return false;
             }
@@ -2041,7 +2041,7 @@ namespace GeminiV26.Core
             if (entry.Direction != entryContext.FinalDirection)
             {
                 GlobalLogger.Log(_bot,
-                    $"[DIR][ENTRY_MISMATCH] entry={entry.Direction.ToString().ToUpperInvariant()} final={entryContext.FinalDirection.ToString().ToUpperInvariant()} sym={_bot.SymbolName}");
+                    $"[DIR][ENTRY_MISMATCH] entry={entry.Direction} routed={entryContext.RoutedDirection} final={entryContext.FinalDirection} sym={_bot.SymbolName}");
             }
 
             return true;


### PR DESCRIPTION
### Motivation
- Improve direction-related auditability and debugging by adding full direction context (`entry`, `routed`, `final`) to all direction mismatch logs in the direction consistency check.

### Description
- Updated `ValidateDirectionConsistency` in `Core/TradeCore.cs` to include `entry`, `routed`, and `final` fields in the `[DIR][FATAL_MISMATCH] type=final_none` log without changing control flow.
- Updated the `[DIR][FATAL_MISMATCH] type=routed_vs_final` log to also include `entry` while preserving the existing routed/final context and return paths.
- Expanded the `[DIR][ENTRY_MISMATCH]` log to include `routed` in addition to `entry` and `final`, keeping all logic and behavior unchanged.

### Testing
- Ran `git -C /workspace/GeminiV26 diff -- Core/TradeCore.cs` to verify the file delta and it completed successfully.
- Ran `git -C /workspace/GeminiV26 status --short` to confirm the working tree status and it completed successfully.
- Printed the modified region with `nl -ba /workspace/GeminiV26/Core/TradeCore.cs | sed -n '2016,2050p'` to validate the final log strings and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd47cc4fa88328b372ede2e7fd54c6)