### PR TITLE
Remove dead TradeCore symbol-routing fields and unused IsIndexSymbol helper

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -258,11 +258,6 @@ namespace GeminiV26.Core
         private IndexMarketStateDetector _indexMarketStateDetector;
         private IndexHtfBiasEngine _indexBias;
 
-        private bool isFxSymbol;
-        private bool isCryptoSymbol;
-        private bool isMetalSymbol;
-        private bool isIndexSymbol;
-
         private GlobalSessionGate _globalSessionGate;
         private SessionMatrix _sessionMatrix;
         private readonly GeminiRiskConfig _riskConfig;
@@ -4401,14 +4396,6 @@ namespace GeminiV26.Core
         {
             return SymbolRouting.ResolveInstrumentClass(symbol).ToString();
         }
-
-        private static bool IsIndexSymbol(string symbol)
-        {
-            return IsNasSymbol(symbol)
-                || IsUs30(symbol)
-                || IsGer40(symbol);
-        }
-
 
         private bool IsSymbol(string canonical)
         {


### PR DESCRIPTION
### Motivation
- Remove unreachable/dead instrument-routing code in `TradeCore` that is shadowed by method-local variables and unused helper functions to reduce clutter and maintenance surface.

### Description
- Deleted four unused class-level boolean fields: `isFxSymbol`, `isCryptoSymbol`, `isMetalSymbol`, and `isIndexSymbol` from `Core/TradeCore.cs` because method-local variables in `OnBar()` shadowed them and there were no reads of the fields.
- Removed the unused helper `private static bool IsIndexSymbol(string symbol)` from `Core/TradeCore.cs` because it had no call sites and represented dead path logic.
- Change is deletion-only and preserves runtime behavior; no refactor or logic changes were introduced.

### Testing
- Ran repository searches to validate removals: `rg -n "\bisFxSymbol\b|\bisCryptoSymbol\b|\bisMetalSymbol\b|\bisIndexSymbol\b|IsIndexSymbol\(" Core/TradeCore.cs` which returned no remaining usages of the removed members (success).
- Reviewed the resulting diff (`git diff -- Core/TradeCore.cs`) to confirm the patch is deletion-only (success).
- Attempted `dotnet build -v minimal` in this environment but the command failed due to `dotnet` not being available, so a full compile was not executed (build not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4872f27883289683f7279eb2b279)