### PR TITLE
FinalAcceptance: make timing penalty soft-first and add final decision logging

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -3517,16 +3517,21 @@ namespace GeminiV26.Core
             bool overextended = ctx.MemoryAssessment?.IsOverextendedMove ?? false;
             bool exhausted = ctx.MemoryAssessment?.IsExhaustedContinuation ?? false;
             const int timingBlockThreshold = -20;
+            const int severeTimingBlockThreshold = -35;
+            bool weakSetup = !eval.HasStrongTrigger && !eval.HasStrongStructure;
 
             double timingMultiplier = 1.0 + (recommendedTimingPenalty / 100.0);
             timingMultiplier = Math.Max(0.5, Math.Min(1.0, timingMultiplier));
             double adjustedConfidence = ctx.LogicBiasConfidence * timingMultiplier;
+            int finalScore = PositionContext.ClampRiskConfidence(eval.Score + recommendedTimingPenalty);
+            GlobalLogger.Log(_bot, $"[FINAL][STATE] score={eval.Score:0.##} timingPenalty={recommendedTimingPenalty} statePenalty=0 finalScore={finalScore}");
 
             GlobalLogger.Log(_bot, $"[MEM] penalty={recommendedTimingPenalty} source={(ctx.MemoryAssessment != null ? "assessment" : "fallback")}");
 
             bool timingOverride = false;
             string timingOverrideReason = "none";
             bool timingBlocked = recommendedTimingPenalty <= timingBlockThreshold;
+            string timingDecisionReason = "pass";
 
             if (eval.Score >= 70 && recommendedTimingPenalty > timingBlockThreshold)
             {
@@ -3541,6 +3546,24 @@ namespace GeminiV26.Core
                 timingBlocked = false;
             }
 
+            if (timingBlocked)
+            {
+                if (recommendedTimingPenalty <= severeTimingBlockThreshold)
+                {
+                    timingDecisionReason = "TIMING_EXTREME";
+                }
+                else if (weakSetup && finalScore < EntryDecisionPolicy.MinScoreThreshold)
+                {
+                    timingDecisionReason = "TIMING_WEAK_COMBINED";
+                }
+                else
+                {
+                    timingBlocked = false;
+                    timingOverride = true;
+                    timingOverrideReason = "timing_soft_only";
+                }
+            }
+
             string timingDecision = timingBlocked ? "block" : "allow";
             GlobalLogger.Log(_bot, $"[TIMING DECISION] symbol={ctx.Symbol ?? _bot.SymbolName} score={eval.Score:0.##} penalty={recommendedTimingPenalty} threshold={timingBlockThreshold} override={timingOverride.ToString().ToLowerInvariant()} overextended={overextended.ToString().ToLowerInvariant()} exhausted={exhausted.ToString().ToLowerInvariant()} finalDecision={timingDecision} reason={timingOverrideReason} adjustedConfidence={adjustedConfidence:0.##}");
 
@@ -3552,6 +3575,7 @@ namespace GeminiV26.Core
                     ctx.LastLoggedStateFingerprint = timingFingerprint;
                     GlobalLogger.Log(_bot, $"[TIMING BLOCK] stage=final_acceptance symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} score={eval.Score:0.##} confidence={ctx.LogicBiasConfidence:0.##} adjustedConfidence={adjustedConfidence:0.##} penalty={recommendedTimingPenalty} triggerLateScore={triggerLateScore:0.###} overextended={overextended.ToString().ToLowerInvariant()} exhausted={exhausted.ToString().ToLowerInvariant()} threshold={timingBlockThreshold}");
                 }
+                GlobalLogger.Log(_bot, $"[FINAL][DECISION] decision=BLOCK reason={timingDecisionReason}");
                 return false;
             }
 
@@ -3560,6 +3584,7 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(
                     "[RESTART BLOCK] HARD phase requires higher confidence",
                     ctx));
+                GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=BLOCK reason=RESTART");
                 return false;
             }
 
@@ -3585,6 +3610,7 @@ namespace GeminiV26.Core
                     GlobalLogger.Log(_bot,
                         $"[XAU FILTER] symbol=XAUUSD entryType={eval.Type} scoreBefore={scoreBeforeXauCounterFilter} scoreAfter={scoreAfterXauCounterFilter} " +
                         $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} timingPenalty={recommendedTimingPenalty} isCounterHTF={isCounterHTF.ToString().ToLowerInvariant()} decision=block reason={reason}");
+                    GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=BLOCK reason=HTF");
                     return false;
                 }
 
@@ -3594,6 +3620,7 @@ namespace GeminiV26.Core
                     GlobalLogger.Log(_bot,
                         $"[XAU FILTER] symbol=XAUUSD entryType={eval.Type} scoreBefore={scoreBeforeXauCounterFilter} scoreAfter={scoreAfterXauCounterFilter} " +
                         $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} timingPenalty={recommendedTimingPenalty} isCounterHTF={isCounterHTF.ToString().ToLowerInvariant()} decision=block reason={reason}");
+                    GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=BLOCK reason=TIMING");
                     return false;
                 }
 
@@ -3603,6 +3630,7 @@ namespace GeminiV26.Core
                     GlobalLogger.Log(_bot,
                         $"[XAU FILTER] symbol=XAUUSD entryType={eval.Type} scoreBefore={scoreBeforeXauCounterFilter} scoreAfter={scoreAfterXauCounterFilter} " +
                         $"htfDirection={htfDirection} candidateDirection={candidateDirection} structureAligned={structureAligned.ToString().ToLowerInvariant()} timingPenalty={recommendedTimingPenalty} isCounterHTF={isCounterHTF.ToString().ToLowerInvariant()} decision=block reason={reason}");
+                    GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=BLOCK reason=STRUCTURE");
                     return false;
                 }
 
@@ -3617,10 +3645,10 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(
                     $"[FINAL][REJECT][OVEREXT] {symbol} {eval.Type} {eval.Direction} score={eval.Score} trend={ctx.TrendDirection} conf={ctx.LogicBiasConfidence}",
                     ctx));
+                GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=BLOCK reason=STRUCTURE");
                 return false;
             }
 
-            bool weakSetup = !eval.HasStrongTrigger && !eval.HasStrongStructure;
             bool lateContinuationInDirection =
                 (isLong && ctx.HasLateContinuationLong) ||
                 (isShort && ctx.HasLateContinuationShort);
@@ -3632,6 +3660,7 @@ namespace GeminiV26.Core
                     GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(
                         $"[FINAL][REJECT][LATE] {symbol} {eval.Type} {eval.Direction} score={eval.Score} trend={ctx.TrendDirection} conf={ctx.LogicBiasConfidence}",
                         ctx));
+                    GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=BLOCK reason=COMBINED");
                     return false;
                 }
             }
@@ -3645,6 +3674,7 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(
                     $"[FINAL][REJECT][TREND] {symbol} {eval.Type} {eval.Direction} score={eval.Score} trend={ctx.TrendDirection} conf={ctx.LogicBiasConfidence}",
                     ctx));
+                GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=BLOCK reason=HTF");
                 return false;
             }
 
@@ -3655,9 +3685,11 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(
                     $"[FINAL][REJECT][WEAK] {symbol} {eval.Type} {eval.Direction} score={eval.Score} trend={ctx.TrendDirection} conf={ctx.LogicBiasConfidence}",
                     ctx));
+                GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=BLOCK reason=STRUCTURE");
                 return false;
             }
 
+            GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=ALLOW reason=PASS");
             GlobalLogger.Log(_bot, $"[ENTRY][FINAL][PASS] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} positionId=0 pipelineId={(ctx?.TempId ?? "NA")} score={eval.Score:0.##} penalty={recommendedTimingPenalty}");
             GlobalLogger.Log(_bot, $"[ENTRY][READY] symbol={ctx.Symbol ?? _bot.SymbolName} entryType={eval.Type} pipelineId={(ctx?.TempId ?? "NA")} side={eval.Direction}");
             return true;


### PR DESCRIPTION
### Motivation
- FinalAcceptance (`PassFinalAcceptance`) was observed killing otherwise-valid winners because timing penalty (`RecommendedTimingPenalty`) acted as a standalone hard block at `<= -20`.  This late-stage kill bypassed entry/router/TradeCore validation.
- Timing penalty is produced globally by memory and can be large (runtime data showed values down to -118), so an unconditional timing block risks suppressing valid trades.
- The change preserves protective behavior for extreme timing while making non-extreme timing behave as a soft risk modifier at the final acceptance layer and improving observability for diagnostics.

### Description
- Modified `PassFinalAcceptance` in `Core/TradeCore.cs` to introduce `severeTimingBlockThreshold = -35` and compute `finalScore = ClampRiskConfidence(eval.Score + recommendedTimingPenalty)` for combined checks.
- Timing gating is now soft-first: non-extreme timing (`<= -20` but `> -35`) will only hard-block when combined with a `weakSetup` and `finalScore < EntryDecisionPolicy.MinScoreThreshold`; otherwise timing becomes a soft modifier (`timing_soft_only`) and the candidate is allowed to proceed.
- Added standardized diagnostics: a `[FINAL][STATE] score=... timingPenalty=... statePenalty=... finalScore=...` log at entrance and `[FINAL][DECISION] decision=ALLOW/BLOCK reason=...` logs on all final-block/allow exits; explicit decision reasons were added to existing HTF/STRUCTURE/TIMING branches.
- Changes are minimal and localized to the FinalAcceptance decision logic; no architecture/refactor, no routing/TQ modifications, and no instrument-specific logic changes were made.

### Testing
- Ran a runtime log analysis script (`python` inline) that scanned `Logs/Logs/Runtime/*/runtime_*.log` to compute timing penalty distribution (global min/max/avg/median) and per-symbol statistics; the script executed successfully and confirmed penalty range and instrument outliers.
- Performed static code inspection commands (`rg`, `sed`, `nl`) to locate `PassFinalAcceptance` and verify the inserted logic and new logging; diffs and file excerpts were inspected successfully.
- Attempted to run a build but no solution/project files (`.sln`/`.csproj`) were present in the environment, so a full compile/run test was not executed. The changes are intentionally small and localized to a single method to minimize runtime risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4adc684c8328b9df49e30b2d0264)