### PR TITLE
Use ContinuationFreshnessScore in ContinuationPolicy

### DIFF
--- a/Core/Entry/Qualification/ContinuationPolicy.cs
+++ b/Core/Entry/Qualification/ContinuationPolicy.cs
@@ -173,16 +173,16 @@ namespace GeminiV26.Core.Entry.Qualification
 
                 if (memory.MoveAgeBars > 20)
                 {
-                    bool hardStale = memory.MoveAgeBars > 30 || memory.Freshness <= 0.20;
+                    bool hardStale = memory.MoveAgeBars > 30 || memory.ContinuationFreshnessScore <= 0.20;
                     if (hardStale)
                     {
                         Log(ctx, "[ENTRY][TIMING_STALE_BLOCK]",
-                            $"age={memory.MoveAgeBars} freshness={memory.Freshness:0.00} reason=expired_move_phase");
+                            $"age={memory.MoveAgeBars} freshness={memory.ContinuationFreshnessScore:0.00} reason=expired_move_phase");
                         return EntryDecision.Block("TOO_LATE_STALE");
                     }
 
                     Log(ctx, "[ENTRY][TIMING_LATE_SOFT]",
-                        $"age={memory.MoveAgeBars} freshness={memory.Freshness:0.00} penalty=applied");
+                        $"age={memory.MoveAgeBars} freshness={memory.ContinuationFreshnessScore:0.00} penalty=applied");
                     return EntryDecision.Penalize(0.15, "TOO_LATE_SOFT");
                 }
             }


### PR DESCRIPTION
### Motivation
- The continuation qualification referenced a non-existent `Freshness` property on `SymbolMemoryState`, which would cause compilation/runtime errors and is inconsistent with the current memory model.

### Description
- Replaced `memory.Freshness` with `memory.ContinuationFreshnessScore` in the stale-timing checks and updated the two related log messages and the `hardStale` condition in `Core/Entry/Qualification/ContinuationPolicy.cs` (three small edits).

### Testing
- Attempted to run `dotnet build -v minimal` as an automated validation step, but it failed in this environment because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd623498c48328ab707fc6e8a14ee6)