### PR TITLE
Make PassFinalAcceptance an integrity-only gate

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -3456,20 +3456,10 @@ namespace GeminiV26.Core
                 return false;
             }
 
-            if (BotRestartState.IsHardProtectionPhase && eval.Score < 60)
+            if (BotRestartState.IsHardProtectionPhase)
             {
                 GlobalLogger.Log(_bot, "[FA][INTEGRITY_BLOCK] reason=RESTART_HARD_PROTECTION");
                 GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=BLOCK reason=RESTART");
-                return false;
-            }
-
-            bool timingStaleOrExpired =
-                ctx.MemoryContinuationWindow == ContinuationWindowState.Unknown ||
-                ctx.MemoryContinuationWindow == ContinuationWindowState.Exhausted;
-            if (timingStaleOrExpired)
-            {
-                GlobalLogger.Log(_bot, "[FA][INTEGRITY_BLOCK] reason=TIMING_STALE_OR_EXPIRED");
-                GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=BLOCK reason=TIMING");
                 return false;
             }
 


### PR DESCRIPTION
### Motivation
- Final acceptance currently mixes timing and quality heuristics into the integrity gate, causing false blocks and violating separation of concerns.  
- Specifically, `ctx.MemoryContinuationWindow` and `eval.Score < 60` allow entry-type/timing and quality logic into FinalAcceptance.  
- The goal is to ensure `PassFinalAcceptance(...)` is a PURE integrity gate that only blocks on explicit integrity signals.

### Description
- Removed the timing-based block that inspected `ctx.MemoryContinuationWindow == ContinuationWindowState.Unknown || ContinuationWindowState.Exhausted` and its associated logging.  
- Removed the quality threshold `eval.Score < 60` from the restart protection check.  
- Replaced restart protection check with an unconditional block `if (BotRestartState.IsHardProtectionPhase)` preserving the `RESTART_HARD_PROTECTION` integrity log.  
- Preserved only integrity-oriented checks in `PassFinalAcceptance(...)`: null guards, `eval.Direction == TradeDirection.None`, `BotRestartState.IsHardProtectionPhase`, and `ctx.IsOverextendedLong || ctx.IsOverextendedShort`, plus the mandated logging lines.

### Testing
- Ran automated static verification to confirm forbidden tokens were removed using `rg` and inspected the updated function with `sed`; both checks succeeded.  
- Verified the file diff via `git diff` and committed the change; commit succeeded.  
- No unit/integration tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce2c65002083288b6b17706748d6c0)