### PR TITLE
Phase 1 safe‑mode: register only Index_Flag/Index_Pullback and add execution debug log

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -328,16 +328,16 @@ namespace GeminiV26.Core
             {
                 _entryTypes = new List<IEntryType>
                 {
-                    new XAU_FlagEntry(),
-                    new XAU_PullbackEntry()
+                    // Phase 1 safe-mode runtime registration:
+                    // Metal entry types remain parked / non-executable.
                 };
             }
             else if (_instrumentClass == InstrumentClass.FX)
             {
                 _entryTypes = new List<IEntryType>
                 {
-                new FX_FlagContinuationEntry(),
-                new FX_ImpulseContinuationEntry(),   // ← ide
+                    // Phase 1 safe-mode runtime registration:
+                    // FX entry types remain disabled / non-executable.
                 };
             }
             else if (_instrumentClass == InstrumentClass.INDEX)
@@ -345,7 +345,6 @@ namespace GeminiV26.Core
                 _entryTypes = new List<IEntryType>
                 {
                     new Index_PullbackEntry(),
-                    new Index_BreakoutEntry(),
                     new Index_FlagEntry()
                 };
             }

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -330,6 +330,7 @@ namespace GeminiV26.Core
             }
 
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[ACCEPT] type={winner.Type} dir={winner.Direction} score={winner.Score} reason={winner.Reason}", entryContext));
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[ENTRY][ACTIVE_SET] type={winner.Type}", entryContext));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[ENTRY][WINNER] symbol={winner.Symbol ?? entryContext?.Symbol ?? _bot.SymbolName} entryType={winner.Type} pipelineId={entryContext?.TempId} dir={winner.Direction} score={winner.Score} valid={winner.IsValid} reason={winner.Reason}", entryContext));
             return winner;
         }


### PR DESCRIPTION
### Motivation

- Restore trading in a controlled, minimal way by reactivating only the safest INDEX EntryTypes (`Index_Flag` and `Index_Pullback`) while keeping all other families parked.
- Reduce runtime noise and eliminate accidental execution reach of higher‑risk or legacy EntryTypes (notably `Index_Breakout`) during Phase 1.
- Add lightweight observability so the runtime selection can be audited and verified that only the allowed EntryTypes execute.

### Description

- Restricted runtime registration in `Core/TradeCore.cs` so INDEX now registers only `Index_PullbackEntry` and `Index_FlagEntry`, and `Index_BreakoutEntry` was removed from the INDEX `_entryTypes` list. 
- Parked non‑INDEX families by leaving FX and METAL `_entryTypes` lists empty in `Core/TradeCore.cs`, preserving their code but removing runtime reach for this phase. 
- Added a temporary debug log in `Core/TradeRouter.cs` inside `SelectEntry` to emit `"[ENTRY][ACTIVE_SET] type={winner.Type}"` immediately after acceptance to verify which EntryType is chosen for execution. 
- Changes are limited to runtime registration and logging only; no EntryType logic, scoring, thresholds, FA, RiskSizer, ExitManager, state machine, or execution flow was modified.

### Testing

- Attempted automated build with `dotnet build -v minimal`, but it could not run in this environment (`/bin/bash: dotnet: command not found`), so no compile/test run was performed here. 
- Static validation performed: source edits verified via diffs and file inspection showing the new registration lists and added log line (no runtime tests executed in this environment). 
- Recommend running CI/build (`dotnet build` and unit/integration tests) in the target build environment to confirm compilation and behavior before rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce340c4c648328b7e5f978ea5cf1cc)