### PR TITLE
Deterministic structure chain (Impulse → Pullback → Flag) for Index entries

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -15,6 +15,24 @@ namespace GeminiV26.Core.Entry
         public bool IsDeadMarketBlocked { get; set; }
     }
 
+    public class StructureContext
+    {
+        public bool HasImpulse;
+        public double ImpulseStrength;
+        public double ImpulseRange;
+        public int ImpulseBars;
+
+        public bool HasPullback;
+        public double PullbackDepth;
+        public int PullbackBars;
+
+        public bool HasFlag;
+        public double FlagCompression;
+        public int FlagBars;
+
+        public TradeDirection StructureDirection;
+    }
+
     public class EntryContext
     {
         // =========================
@@ -30,6 +48,7 @@ namespace GeminiV26.Core.Entry
         }
         public Action<string> Log { get; set; }
         public EntryContextFlags Flags { get; set; } = new EntryContextFlags();
+        public StructureContext Structure = new StructureContext();
         public GeminiV26.Core.Entry.Qualification.EntryState QualificationState { get; set; }
 
         public DateTime LastUpdateUtc { get; set; } = DateTime.UtcNow;

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -834,6 +834,10 @@ namespace GeminiV26.Core.Entry
                 ctx.HasBreakout_M1 &&
                 ctx.BreakoutDirection == ctx.TrendDirection;
 
+            BuildImpulseAnchor(ctx);
+            BuildPullback(ctx);
+            BuildFlag(ctx);
+
             // =================================================
             // HTF BIAS – FINAL DISPATCH (Phase 3.8 FIX)
             // =================================================
@@ -1002,6 +1006,82 @@ namespace GeminiV26.Core.Entry
             }
 
             return new string(buffer, index, buffer.Length - index);
+        }
+
+        private void BuildImpulseAnchor(EntryContext ctx)
+        {
+            if (ctx == null || ctx.M5 == null || ctx.M5.Count < 3 || ctx.AtrM5 <= 0)
+                return;
+
+            int m5Idx = ctx.M5.Count - 2;
+            double body = Math.Abs(ctx.M5.ClosePrices[m5Idx] - ctx.M5.OpenPrices[m5Idx]);
+            double range = Math.Abs(ctx.M5.HighPrices[m5Idx] - ctx.M5.LowPrices[m5Idx]);
+            double move = body / ctx.AtrM5;
+            int bars = ctx.BarsSinceImpulse_M5 <= 0 || ctx.BarsSinceImpulse_M5 >= 999
+                ? 1
+                : ctx.BarsSinceImpulse_M5;
+
+            bool strongMove = move >= 0.6;
+            bool expansion = range >= ctx.AtrM5 * 1.2;
+
+            ctx.Structure.HasImpulse = strongMove && expansion;
+
+            if (!ctx.Structure.HasImpulse)
+                return;
+
+            ctx.Structure.ImpulseStrength = move;
+            ctx.Structure.ImpulseRange = range;
+            ctx.Structure.ImpulseBars = bars;
+            ctx.Structure.StructureDirection = ctx.TrendDirection;
+
+            GlobalLogger.Log(_bot,
+                $"[STRUCTURE][IMPULSE] dir={ctx.Structure.StructureDirection} strength={ctx.Structure.ImpulseStrength:F2} range={ctx.Structure.ImpulseRange:F1}");
+        }
+
+        private void BuildPullback(EntryContext ctx)
+        {
+            if (ctx == null || !ctx.Structure.HasImpulse)
+                return;
+
+            double retrace = ctx.PullbackDepthAtr_M5;
+            int bars = ctx.PullbackBars_M5;
+
+            bool validDepth = retrace >= 0.2 && retrace <= 0.65;
+            bool notTooLong = bars <= 12;
+
+            ctx.Structure.HasPullback = validDepth && notTooLong;
+
+            if (!ctx.Structure.HasPullback)
+                return;
+
+            ctx.Structure.PullbackDepth = retrace;
+            ctx.Structure.PullbackBars = bars;
+
+            GlobalLogger.Log(_bot, $"[STRUCTURE][PULLBACK] depth={retrace:F2} bars={bars}");
+        }
+
+        private void BuildFlag(EntryContext ctx)
+        {
+            if (ctx == null || !ctx.Structure.HasPullback || ctx.AtrM5 <= 0)
+                return;
+
+            int bars = Math.Max(ctx.FlagBarsLong_M5, ctx.FlagBarsShort_M5);
+            double compression = ctx.FlagAtr_M5 > 0
+                ? ctx.FlagAtr_M5 / ctx.AtrM5
+                : 1.0;
+
+            bool tight = compression <= 0.6;
+            bool shortFlag = bars <= 6;
+
+            ctx.Structure.HasFlag = tight && shortFlag;
+
+            if (!ctx.Structure.HasFlag)
+                return;
+
+            ctx.Structure.FlagCompression = compression;
+            ctx.Structure.FlagBars = bars;
+
+            GlobalLogger.Log(_bot, $"[STRUCTURE][FLAG] compression={compression:F2} bars={bars}");
         }
     }
 }

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -1,35 +1,14 @@
-using cAlgo.API;
 using GeminiV26.Core;
 using GeminiV26.Core.Entry;
-using GeminiV26.EntryTypes;
 using GeminiV26.Core.Matrix;
-using GeminiV26.Instruments.INDEX;
+using GeminiV26.EntryTypes;
 using System;
-using System.Collections.Generic;
 
 namespace GeminiV26.EntryTypes.INDEX
 {
     public sealed class Index_FlagEntry : IEntryType
     {
         public EntryType Type => EntryType.Index_Flag;
-
-        private const int DefaultMaxBarsSinceImpulse = 3;
-        private const int DefaultFlagBars = 3;
-
-        private const double DefaultMaxFlagRangeAtr = 1.20;
-        private const double DefaultBreakBufferAtr = 0.08;
-        private const double DefaultMaxDistFromEmaAtr = 0.65;
-
-        private const double MinBreakoutBodyRatio = 0.55;
-        private const double MinBreakoutBarAtr = 0.35;
-
-        private const double MaxOpposingSlopeAtr = 0.45;
-        private const double MaxSameDirSlopeAtr = 0.20;
-
-        private const int BaseScore = 84;
-        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
-
-        private static readonly Dictionary<string, int> _traceInvocationCountByBarDir = new Dictionary<string, int>();
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
@@ -38,668 +17,56 @@ namespace GeminiV26.EntryTypes.INDEX
             if (!matrix.AllowFlag)
                 return Reject(ctx, "SESSION_MATRIX_ALLOWFLAG_DISABLED", 0, TradeDirection.None);
 
-            if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 40)
+            if (ctx == null || !ctx.IsReady)
                 return Reject(ctx, "CTX_NOT_READY", 0, TradeDirection.None);
 
-            if (ctx.LogicBias == TradeDirection.None)
-                return Reject(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
-
-            if (ctx.AtrM5 <= 0)
-                return Reject(ctx, "ATR_NOT_READY", 0, TradeDirection.None);
-
-            var p = IndexInstrumentMatrix.Get(ctx.Symbol);
-            if (p == null)
-                return Reject(ctx, "NO_INDEX_PROFILE", 0, TradeDirection.None);
-
-            int maxBarsSinceImpulse = p.MaxBarsSinceImpulse_M5 > 0 ? p.MaxBarsSinceImpulse_M5 : DefaultMaxBarsSinceImpulse;
-            int flagBars = p.FlagBars > 0 ? p.FlagBars : DefaultFlagBars;
-            double maxFlagRangeAtr = p.MaxFlagAtrMult > 0 ? p.MaxFlagAtrMult : DefaultMaxFlagRangeAtr;
-            double breakoutBufferAtr = p.BreakoutBufferAtr > 0 ? p.BreakoutBufferAtr : DefaultBreakBufferAtr;
-            double maxDistFromEmaAtr = p.MaxEmaDistanceAtr > 0 ? p.MaxEmaDistanceAtr : DefaultMaxDistFromEmaAtr;
-
-            double minAdxTrend = p.MinAdxTrend > 0 ? p.MinAdxTrend : 18.0;
-            minAdxTrend = Math.Max(minAdxTrend, matrix.MinAdx);
-            double chopAdxThreshold = p.ChopAdxThreshold > 0 ? p.ChopAdxThreshold : 17.0;
-            double chopDiDiff = p.ChopDiDiffThreshold > 0 ? p.ChopDiDiffThreshold : 7.0;
-
-            int fatigueThreshold = p.FatigueThreshold > 0 ? p.FatigueThreshold : 3;
-            double fatigueAdxLevel = p.FatigueAdxLevel > 0 ? p.FatigueAdxLevel : 38.0;
-
-            double scoreMultiplier = p.ScoreWeightMultiplier > 0 ? p.ScoreWeightMultiplier : 1.0;
-            bool requireStructure = p.PullbackStyle == IndexPullbackStyle.Structure;
-
-            ctx.Log?.Invoke(
-                $"[IDX_FLAG][PROFILE] sym={ctx.Symbol} norm={p.Symbol} " +
-                $"minAdx={minAdxTrend:F1} chopAdx={chopAdxThreshold:F1} fatigueTh={fatigueThreshold} scoreMult={scoreMultiplier:F2}"
-            );
-
-            bool hasHtfMismatch = ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias;
-
-            if (ctx.LogicBias == TradeDirection.Long)
+            if (!ctx.Structure.HasImpulse)
             {
-                var eval = EvaluateDir(
-                    ctx,
-                    TradeDirection.Long,
-                    flagBars,
-                    maxBarsSinceImpulse,
-                    maxFlagRangeAtr,
-                    breakoutBufferAtr,
-                    maxDistFromEmaAtr,
-                    requireStructure,
-                    minAdxTrend,
-                    chopAdxThreshold,
-                    chopDiDiff,
-                    fatigueThreshold,
-                    fatigueAdxLevel,
-                    scoreMultiplier,
-                    hasHtfMismatch);
-                eval.Score += (int)Math.Round(matrix.EntryScoreModifier);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
-                return EntryDecisionPolicy.Normalize(eval);
-            }
-            else if (ctx.LogicBias == TradeDirection.Short)
-            {
-                var eval = EvaluateDir(
-                    ctx,
-                    TradeDirection.Short,
-                    flagBars,
-                    maxBarsSinceImpulse,
-                    maxFlagRangeAtr,
-                    breakoutBufferAtr,
-                    maxDistFromEmaAtr,
-                    requireStructure,
-                    minAdxTrend,
-                    chopAdxThreshold,
-                    chopDiDiff,
-                    fatigueThreshold,
-                    fatigueAdxLevel,
-                    scoreMultiplier,
-                    hasHtfMismatch);
-                eval.Score += (int)Math.Round(matrix.EntryScoreModifier);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
-                return EntryDecisionPolicy.Normalize(eval);
+                ctx.Log?.Invoke("[ENTRY][FLAG][STRUCTURE_ERROR] violation=no_trade_without_impulse");
+                return Reject(ctx, "no_impulse", 0, TradeDirection.None);
             }
 
-            return Reject(ctx, "NO_LOGIC_BIAS", 0, TradeDirection.None);
-        }
-        private EntryEvaluation EvaluateDir(
-            EntryContext ctx,
-            TradeDirection dir,
-            int flagBars,
-            int maxBarsSinceImpulse,
-            double maxFlagRangeAtr,
-            double breakoutBufferAtr,
-            double maxDistFromEmaAtr,
-            bool requireStructure,
-            double minAdxTrend,
-            double chopAdxThreshold,
-            double chopDiDiff,
-            int fatigueThreshold,
-            double fatigueAdxLevel,
-            double scoreMultiplier,
-            bool hasHtfMismatch)
-        {
-            int score = BaseScore;
-            int setupScore = 0;
-            int penaltyBudget = 0;
-            double triggerScore = 0;
-            const int maxPenalty = 22;
-            bool continuationAuthority = HasContinuationAuthority(ctx, dir);
-            bool sourceHtfAlign = IsAlignedWithAllowedDirection(ctx?.ActiveHtfDirection ?? TradeDirection.None, dir);
-            string sourceHtfState = "N/A";
-
-            ctx.Log?.Invoke(
-                $"[AUDIT][HTF TRACE][SOURCE] symbol={ctx?.Symbol} entryType={Type} candidateDirection={dir} " +
-                $"rawHtfState={sourceHtfState} allowedDirection={ctx?.ActiveHtfDirection ?? TradeDirection.None} " +
-                $"htfAlign={sourceHtfAlign} sourceModule=IndexHtfBiasEngine");
-
-            if (hasHtfMismatch)
+            if (!ctx.Structure.HasPullback)
             {
-                if (continuationAuthority)
-                {
-                    ApplyPenalty(8);
-                    ctx.Log?.Invoke($"[IDX_FLAG][SOFT_PENALTY] reason=HTF_MISMATCH penalty=8 dir={dir}");
-                }
-                else
-                {
-                    ApplyPenalty(12);
-                    ctx.Log?.Invoke($"[IDX_FLAG][SOFT_PENALTY] reason=HTF_MISMATCH_NO_CONTINUATION penalty=12 dir={dir}");
-                }
+                ctx.Log?.Invoke("[ENTRY][FLAG][STRUCTURE_ERROR] violation=no_flag_without_pullback_retrace");
+                return Reject(ctx, "no_pullback", 0, TradeDirection.None);
             }
 
-            void ApplyPenalty(int p)
+            if (!ctx.Structure.HasFlag)
             {
-                if (p <= 0) return;
-                int room = maxPenalty - penaltyBudget;
-                int use = Math.Min(room, p);
-                if (use <= 0) return;
-                score -= use;
-                penaltyBudget += use;
+                ctx.Log?.Invoke("[ENTRY][FLAG][STRUCTURE_ERROR] violation=no_flag_entry_without_compression");
+                return Reject(ctx, "no_flag", 0, TradeDirection.None);
             }
 
-            void ApplyReward(int r)
+            if (ctx.Structure.StructureDirection == TradeDirection.None)
             {
-                if (r > 0) score += r;
+                ctx.Log?.Invoke("[ENTRY][FLAG][STRUCTURE_ERROR] violation=direction_must_come_from_impulse");
+                return Reject(ctx, "structure_direction_missing", 0, TradeDirection.None);
             }
 
-            var bars = ctx.M5;
-            int lastClosed = bars.Count - 2;
-            int breakoutBarIndex = lastClosed;
-            int flagEnd = breakoutBarIndex - 1;
-            int flagStart = flagEnd - flagBars + 1;
-
-            if (flagStart < 3)
-                return Reject(ctx, "NOT_ENOUGH_FLAG_BARS", score, dir);
-
-            var breakoutBar = bars[breakoutBarIndex];
-            double close = breakoutBar.Close;
-            double open = breakoutBar.Open;
-            double high = breakoutBar.High;
-            double low = breakoutBar.Low;
-
-            bool hasImpulse =
-                dir == TradeDirection.Long ? ctx.HasImpulseLong_M5 :
-                dir == TradeDirection.Short ? ctx.HasImpulseShort_M5 :
-                false;
-
-            bool hasPullback =
-                dir == TradeDirection.Long ? ctx.HasPullbackLong_M5 :
-                dir == TradeDirection.Short ? ctx.HasPullbackShort_M5 :
-                false;
-
-            DateTime traceBarTime = bars.OpenTimes[lastClosed];
-            string traceKey = $"{ctx.Symbol}|{traceBarTime:O}|{dir}";
-            int traceCount;
-            lock (_traceInvocationCountByBarDir)
-            {
-                _traceInvocationCountByBarDir.TryGetValue(traceKey, out traceCount);
-                traceCount++;
-                _traceInvocationCountByBarDir[traceKey] = traceCount;
-            }
-
-            ctx.Log?.Invoke(
-                $"[IDX_FLAG][TRACE] evaluator invoked sym={ctx.Symbol} dir={dir} bar={traceBarTime:O} count={traceCount}"
-            );
-
-            ctx.Log?.Invoke(
-                $"[IDX_FLAG][START] sym={ctx.Symbol} dir={dir} " +
-                $"adx={ctx.Adx_M5:F1} atr={ctx.AtrM5:F1} trend={ctx.MarketState?.IsTrend} lowVol={ctx.MarketState?.IsLowVol} " +
-                $"impulse={hasImpulse} bsi={ctx.BarsSinceImpulse_M5}"
-            );
-
-            // =====================================================
-            // HARD CONTEXT GATES
-            // =====================================================
-            if (ctx.MarketState?.IsLowVol == true)
-                return Reject(ctx, "LOW_VOL_ENV", score, dir);
-
-            if (ctx.Adx_M5 >= 15 && ctx.Adx_M5 < minAdxTrend)
-                return Reject(ctx, $"ADX_TOO_LOW({ctx.Adx_M5:F1}<{minAdxTrend:F1})", score, dir);
-
-            bool chopZone =
-                ctx.Adx_M5 >= 15 && ctx.Adx_M5 < chopAdxThreshold &&
-                Math.Abs(ctx.PlusDI_M5 - ctx.MinusDI_M5) < chopDiDiff &&
-                !ctx.IsAtrExpanding_M5;
-                
-            if (chopZone)
-                return Reject(ctx, "CHOP_ZONE", score, dir);
-
-            if (!hasImpulse)
-                return Reject(ctx, "NO_IMPULSE", score, dir);
-
-            if (ctx.BarsSinceImpulse_M5 > maxBarsSinceImpulse)
-                return Reject(ctx, $"STALE_IMPULSE({ctx.BarsSinceImpulse_M5}>{maxBarsSinceImpulse})", score, dir);
-
-            // =====================================================
-            // FATIGUE
-            // =====================================================
-            bool adxExhausted = ctx.Adx_M5 >= fatigueAdxLevel && ctx.AdxSlope_M5 <= 0;
-            bool atrContracting = ctx.AtrSlope_M5 <= 0;
-            bool diConverging = Math.Abs(ctx.PlusDI_M5 - ctx.MinusDI_M5) < chopDiDiff;
-            bool lateImpulse = ctx.BarsSinceImpulse_M5 >= Math.Max(2, maxBarsSinceImpulse);
-
-            int fatigueCount = 0;
-            if (adxExhausted) fatigueCount++;
-            if (atrContracting) fatigueCount++;
-            if (diConverging) fatigueCount++;
-            if (lateImpulse) fatigueCount++;
-
-            if (fatigueCount >= fatigueThreshold)
-            {
-                if (continuationAuthority)
-                {
-                    ApplyPenalty(10);
-                    ctx.Log?.Invoke(
-                        $"[IDX_FLAG][SOFT_PENALTY] reason=IDX_TREND_FATIGUE({fatigueCount}/{fatigueThreshold}) penalty=10 dir={dir}");
-                }
-                else
-                {
-                    return Reject(ctx, $"IDX_TREND_FATIGUE({fatigueCount}/{fatigueThreshold})", score, dir);
-                }
-            }
-
-            // =====================================================
-            // FLAG RANGE
-            // =====================================================
-            double hi = double.MinValue;
-            double lo = double.MaxValue;
-
-            for (int i = flagStart; i <= flagEnd; i++)
-            {
-                hi = Math.Max(hi, bars[i].High);
-                lo = Math.Min(lo, bars[i].Low);
-            }
-
-            bool hasValidRange = hi > lo && hi > 0 && lo > 0;
-
-            if (!hasValidRange)
-                ctx.Log?.Invoke("[FLAG WARN] No valid range → fallback mode");
-
-            double flagRange = hasValidRange ? hi - lo : 0;
-            double flagAtr = hasValidRange && ctx.AtrM5 > 0
-                ? flagRange / ctx.AtrM5
-                : 0;
-
-            ctx.Log?.Invoke(
-                $"[IDX_FLAG][RANGE] dir={dir} flagBars={flagBars} flagATR={flagAtr:F2} maxAllowed={maxFlagRangeAtr:F2} hasRange={hasValidRange}"
-            );
-
-            if (flagAtr > 0)
-            {
-                if (flagAtr > maxFlagRangeAtr)
-                    ApplyPenalty(4);
-
-                if (flagAtr < 0.45)
-                    ApplyReward(2);
-                else if (flagAtr > 1.0)
-                    ApplyPenalty(3);
-            }
-            else
-            {
-                ApplyPenalty(2);
-            }
-
-            // =====================================================
-            // FLAG SLOPE
-            // =====================================================
-            double firstOpen = bars[flagStart].Open;
-            double lastFlagClose = bars[flagEnd].Close;
-            double flagSlopeAtr = ctx.AtrM5 > 0
-                ? (lastFlagClose - firstOpen) / ctx.AtrM5
-                : 0;
-
-            if (hasValidRange)
-            {
-                if (dir == TradeDirection.Long)
-                {
-                    if (flagSlopeAtr > MaxSameDirSlopeAtr)
-                        ApplyPenalty(4);
-
-                    if (flagSlopeAtr < -MaxOpposingSlopeAtr)
-                        ApplyPenalty(4);
-
-                    if (flagSlopeAtr >= -0.25 && flagSlopeAtr <= 0.05)
-                        ApplyReward(3);
-                }
-                else
-                {
-                    if (flagSlopeAtr < -MaxSameDirSlopeAtr)
-                        ApplyPenalty(4);
-
-                    if (flagSlopeAtr > MaxOpposingSlopeAtr)
-                        ApplyPenalty(4);
-
-                    if (flagSlopeAtr >= -0.05 && flagSlopeAtr <= 0.25)
-                        ApplyReward(3);
-                }
-            }
-
-            // =====================================================
-            // EMA BIAS + OVEREXTENSION
-            // =====================================================
-            double distFromEmaAtr = Math.Abs(close - ctx.Ema21_M5) / ctx.AtrM5;
-
-            if (distFromEmaAtr > maxDistFromEmaAtr)
-            {
-                if (continuationAuthority)
-                {
-                    ApplyPenalty(10);
-                    ctx.Log?.Invoke(
-                        $"[IDX_FLAG][SOFT_PENALTY] reason=OVEREXTENDED_EMA({distFromEmaAtr:F2}>{maxDistFromEmaAtr:F2}) penalty=10 dir={dir}");
-                }
-                else
-                {
-                    return Reject(ctx,
-                        $"OVEREXTENDED_EMA({distFromEmaAtr:F2}>{maxDistFromEmaAtr:F2})",
-                        score,
-                        dir);
-                }
-            }
-
-            if (dir == TradeDirection.Long && close < ctx.Ema21_M5)
-                return Reject(ctx, "EMA_BIAS_MISMATCH_LONG", score, dir);
-
-            if (dir == TradeDirection.Short && close > ctx.Ema21_M5)
-                return Reject(ctx, "EMA_BIAS_MISMATCH_SHORT", score, dir);
-
-            // =====================================================
-            // STRUCTURE
-            // =====================================================
-            bool structureOk;
-
-            bool hasFlag =
-                dir == TradeDirection.Long ? ctx.HasFlagLong_M5 :
-                dir == TradeDirection.Short ? ctx.HasFlagShort_M5 :
-                ctx.IsValidFlagStructure_M5;
-
-            if (dir == TradeDirection.Long)
-            {
-                structureOk =
-                    ctx.BrokeLastSwingHigh_M5 ||
-                    (!requireStructure && close > ctx.Ema21_M5);
-            }
-            else
-            {
-                structureOk =
-                    ctx.BrokeLastSwingLow_M5 ||
-                    (!requireStructure && close < ctx.Ema21_M5);
-            }
-
-            if (!structureOk)
-                ApplyPenalty(4);
-
-            if (!hasFlag)
-                ApplyPenalty(2);
-            else
-                ApplyReward(3);
-
-            // =====================================================
-            // BREAKOUT
-            // =====================================================
-            double buffer = ctx.AtrM5 * breakoutBufferAtr;
-            bool bullBreak = hasValidRange && close > hi + buffer;
-            bool bearBreak = hasValidRange && close < lo - buffer;
-
-            bool breakoutSignal =
-                (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir) ||
-                ctx.RangeBreakDirection == dir ||
-                (dir == TradeDirection.Long
-                    ? (ctx.FlagBreakoutUp || ctx.FlagBreakoutUpConfirmed)
-                    : (ctx.FlagBreakoutDown || ctx.FlagBreakoutDownConfirmed));
-
-            bool breakoutConfirmed =
-                (dir == TradeDirection.Long && (bullBreak || breakoutSignal)) ||
-                (dir == TradeDirection.Short && (bearBreak || breakoutSignal));
-
-            bool continuationSignal = breakoutSignal;
-
-            bool hasImpulseSetup =
-                hasImpulse;
-
-            if (!hasImpulseSetup)
-                setupScore -= 40;
-            else
-                setupScore += 15;
-
-            bool hasStructure =
-                hasPullback || hasFlag;
-
-            if (hasStructure)
-                setupScore += 10;
-
-            bool hasContinuation =
-                continuationSignal || breakoutConfirmed;
-
-            if (hasContinuation)
-                setupScore += 20;
-
-            double breakDist = 0;
-
-            if (hasValidRange)
-            {
-                breakDist =
-                    dir == TradeDirection.Long
-                        ? Math.Max(0, close - hi)
-                        : Math.Max(0, lo - close);
-            }
-
-            double follow = ctx.AtrM5 * 0.12;
-            bool followThrough = true;
-
-            if (hasValidRange)
-            {
-                if (dir == TradeDirection.Long && close < hi + follow)
-                    followThrough = false;
-
-                if (dir == TradeDirection.Short && close > lo - follow)
-                    followThrough = false;
-            }
-
-            if (!breakoutConfirmed)
-                ApplyPenalty(8);
-
-            if (!followThrough)
-                ApplyPenalty(6);
-
-            // =====================================================
-            // BREAKOUT BAR QUALITY
-            // =====================================================
-            double barRange = high - low;
-            if (barRange <= 0)
-                return Reject(ctx, "BAD_BAR_RANGE", score, dir);
-
-            double body = Math.Abs(close - open);
-            double bodyRatio = body / barRange;
-            double breakoutBarAtr = barRange / ctx.AtrM5;
-
-            if (bodyRatio < MinBreakoutBodyRatio)
-                ApplyPenalty(6);
-
-            if (breakoutBarAtr < MinBreakoutBarAtr)
-                ApplyPenalty(6);
-
-            if (dir == TradeDirection.Long && close <= open)
-                ApplyPenalty(8);
-
-            if (dir == TradeDirection.Short && close >= open)
-                ApplyPenalty(8);
-
-            // =====================================================
-            // M1 CONFIRMATION
-            // =====================================================
-            bool m1Ok =
-                HasDirectionalM1Trigger(ctx, dir) ||
-                HasDirectionalM1FollowThrough(ctx, dir);
-
-            if (!m1Ok)
-                ApplyPenalty(6);
-            else
-                ApplyReward(5);
-
-            // =====================================================
-            // EXTRA QUALITY
-            // =====================================================
-            if (ctx.IsAtrExpanding_M5)
-                ApplyReward(2);
-            else
-                ApplyPenalty(2);
-
-            if (ctx.MarketState?.IsTrend == true)
-                ApplyReward(2);
-            else
-                ApplyPenalty(3);
-
-            if (dir == TradeDirection.Long)
-            {
-                if (ctx.Ema50_M5 > ctx.Ema200_M5) ApplyReward(2);
-                else ApplyPenalty(4);
-            }
-            else
-            {
-                if (ctx.Ema50_M5 < ctx.Ema200_M5) ApplyReward(2);
-                else ApplyPenalty(4);
-            }
-
-            // HTF = soft only
-            if (ctx.ActiveHtfDirection != TradeDirection.None)
-            {
-                if (ctx.ActiveHtfDirection == dir)
-                    ApplyReward(3);
-                else
-                    ApplyPenalty(ctx.ActiveHtfConfidence >= 0.70 ? 5 : 3);
-            }
-
-            score = (int)Math.Round(score * scoreMultiplier);
-
-            bool missingImpulse =
-                string.Equals(ctx.Transition?.Reason, "MissingImpulse", StringComparison.Ordinal);
-
-            if (missingImpulse)
-            {
-                score = Math.Max(0, score - 6);
-
-                ctx.Log?.Invoke(
-                    "[FLAG][PENALTY] Missing impulse detected → score penalty applied " +
-                    $"symbol={ctx.Symbol} entry={Type} penalty=6 score={score}");
-            }
-
-            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
-            score += setupScore;
-
-            bool breakoutDetected = breakoutConfirmed;
-            bool strongCandle =
-                bodyRatio >= MinBreakoutBodyRatio &&
-                ((dir == TradeDirection.Long && close > open) || (dir == TradeDirection.Short && close < open));
-            followThrough = followThrough && m1Ok;
-
-            if (breakoutDetected)
-                triggerScore += 1;
-
-            if (strongCandle)
-                triggerScore += 1;
-
-            if (followThrough)
-                triggerScore += 2;
-
-            score += (int)Math.Round(triggerScore * 5);
-
-            if (triggerScore == 0)
-                score -= 15;
-
-            bool minimalTrigger = breakoutDetected || strongCandle;
-            if (!minimalTrigger)
-                score -= 10;
-
-            ctx.Log?.Invoke(
-                $"[TRIGGER SCORE] breakout={(breakoutDetected ? 1 : 0)} strong={(strongCandle ? 1 : 0)} follow={(followThrough ? 1 : 0)} total={triggerScore:F0} finalScore={score}");
-
-            if (setupScore <= 0)
-                score = Math.Min(score, MinScore - 10);
-
-            ctx.Log?.Invoke(
-                $"[IDX_FLAG][FINAL] dir={dir} score={score} flagATR={flagAtr:F2} slopeATR={flagSlopeAtr:F2} " +
-                $"emaDistATR={distFromEmaAtr:F2} fatigue={fatigueCount}/{fatigueThreshold} hasRange={hasValidRange}"
-            );
-
-
-            if (score < MinScore)
-                return Reject(ctx, $"LOW_SCORE({score}<{MinScore})", score, dir);
+            var direction = ctx.Structure.StructureDirection;
+            int score = (int)Math.Round(100.0 * (
+                0.4 * ctx.Structure.ImpulseStrength +
+                0.3 * (1.0 - ctx.Structure.PullbackDepth) +
+                0.3 * (1.0 - ctx.Structure.FlagCompression)));
+            score += (int)Math.Round(matrix.EntryScoreModifier);
+            score = Math.Max(0, Math.Min(100, score));
+
+            ctx.Log?.Invoke("[ENTRY][FLAG][STRUCTURE_OK]");
 
             return new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
-                Direction = dir,
+                Direction = direction,
                 Score = score,
                 IsValid = true,
-                Reason =
-                    $"IDX_FLAG_PRO dir={dir} score={score} mult={scoreMultiplier:F2} " +
-                    $"fatigue={fatigueCount}/{fatigueThreshold} flagATR={flagAtr:F2} slopeATR={flagSlopeAtr:F2} " +
-                    $"emaATR={distFromEmaAtr:F2} rangeState={(hasValidRange ? "OK" : "FLAG_RANGE_UNKNOWN")}",
-                HtfTraceSourceStage = "Index_FlagEntry.EvaluateDir",
-                HtfTraceSourceModule = "IndexHtfBiasEngine",
-                HtfTraceSourceState = sourceHtfState,
-                HtfTraceSourceAllowedDirection = ctx?.ActiveHtfDirection ?? TradeDirection.None,
-                HtfTraceSourceAlign = sourceHtfAlign,
-                HtfTraceSourceCandidateDirection = dir
+                Reason = "STRUCTURE_IMPULSE_PULLBACK_FLAG_OK"
             };
         }
 
-        private static bool HasDirectionalM1Trigger(EntryContext ctx, TradeDirection dir)
-        {            
-            if (ctx.M1 == null || ctx.M1.Count < 3)
-                return false;
-
-            int lastClosed = ctx.M1.Count - 2;
-            int prevClosed = ctx.M1.Count - 3;
-
-            var last = ctx.M1[lastClosed];
-            var prev = ctx.M1[prevClosed];
-
-            if (dir == TradeDirection.Long)
-                return last.Close > last.Open && last.Close > prev.High;
-
-            if (dir == TradeDirection.Short)
-                return last.Close < last.Open && last.Close < prev.Low;
-
-            return false;
-        }
-
-        private static bool HasDirectionalM1FollowThrough(EntryContext ctx, TradeDirection dir)
+        private static EntryEvaluation Reject(EntryContext ctx, string reason, int score, TradeDirection dir)
         {
-            if (ctx.M1 == null || ctx.M1.Count < 4)
-                return false;
-
-            int lastClosed = ctx.M1.Count - 2;
-            int prevClosed = ctx.M1.Count - 3;
-
-            var last = ctx.M1[lastClosed];
-            var prev = ctx.M1[prevClosed];
-
-            double range = last.High - last.Low;
-            if (range <= 0) return false;
-
-            double body = Math.Abs(last.Close - last.Open);
-            double ratio = body / range;
-            if (ratio < 0.50) return false;
-
-            if (dir == TradeDirection.Long)
-                return last.Close > prev.High && last.Close > last.Open;
-
-            if (dir == TradeDirection.Short)
-                return last.Close < prev.Low && last.Close < last.Open;
-
-            return false;
-        }
-
-        private static EntryEvaluation Reject(
-            EntryContext ctx,
-            string reason,
-            int score,
-            TradeDirection dir)
-        {
-            bool hasImpulse =
-                dir == TradeDirection.Long ? ctx?.HasImpulseLong_M5 == true :
-                dir == TradeDirection.Short ? ctx?.HasImpulseShort_M5 == true :
-                false;
-
-            ctx.Log?.Invoke(
-                $"[IDX_FLAG][REJECT] {reason} | score={Math.Max(0, score)} | dir={dir} | " +
-                $"ADX={ctx?.Adx_M5:F1} Impulse={hasImpulse} ATR={ctx?.AtrM5:F1}"
-            );
-
-            bool sourceHtfAlign = IsAlignedWithAllowedDirection(ctx?.ActiveHtfDirection ?? TradeDirection.None, dir);
-            string sourceHtfState = "N/A";
-
-            if (!string.IsNullOrWhiteSpace(reason) && reason.Contains("HTF_MISMATCH"))
-            {
-                ctx?.Log?.Invoke(
-                    $"[AUDIT][HTF TRACE][REJECT] symbol={ctx?.Symbol} entryType={EntryType.Index_Flag} candidateDirection={dir} " +
-                    $"rejectReason={reason} currentHtfState={sourceHtfState} " +
-                    $"currentAllowedDirection={ctx?.ActiveHtfDirection ?? TradeDirection.None} " +
-                    $"currentHtfAlign={sourceHtfAlign} module=Index_FlagEntry");
-            }
-
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
@@ -707,48 +74,8 @@ namespace GeminiV26.EntryTypes.INDEX
                 Direction = dir,
                 IsValid = false,
                 Score = Math.Max(0, score),
-                Reason = reason,
-                HtfTraceSourceStage = "Index_FlagEntry.EvaluateDir",
-                HtfTraceSourceModule = "IndexHtfBiasEngine",
-                HtfTraceSourceState = sourceHtfState,
-                HtfTraceSourceAllowedDirection = ctx?.ActiveHtfDirection ?? TradeDirection.None,
-                HtfTraceSourceAlign = sourceHtfAlign,
-                HtfTraceSourceCandidateDirection = dir
+                Reason = reason
             };
         }
-
-        private static bool IsAlignedWithAllowedDirection(TradeDirection allowedDirection, TradeDirection candidateDirection)
-        {
-            if (candidateDirection == TradeDirection.None)
-                return false;
-
-            return allowedDirection == TradeDirection.None || allowedDirection == candidateDirection;
-        }
-
-        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
-        {
-            return EntryDirectionQuality.Apply(
-                ctx,
-                direction,
-                score,
-                new DirectionQualityRequest
-                {
-                    TypeTag = "Index_FlagEntry",
-                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
-                });
-        }
-
-        private static bool HasContinuationAuthority(EntryContext ctx, TradeDirection dir)
-        {
-            if (ctx == null || dir == TradeDirection.None)
-                return false;
-
-            return
-                ctx.TrendDirection == dir &&
-                ctx.HasImpulse_M5 &&
-                ctx.IsAtrExpanding_M5 &&
-                ctx.MarketState?.IsTrend == true;
-        }
-
     }
 }

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -1,8 +1,7 @@
-using GeminiV26.Core.Entry;
-using GeminiV26.EntryTypes;
 using GeminiV26.Core;
+using GeminiV26.Core.Entry;
 using GeminiV26.Core.Matrix;
-using GeminiV26.Instruments.INDEX;
+using GeminiV26.EntryTypes;
 using System;
 
 namespace GeminiV26.EntryTypes.INDEX
@@ -11,12 +10,6 @@ namespace GeminiV26.EntryTypes.INDEX
     {
         public EntryType Type => EntryType.Index_Pullback;
 
-        private const int BaseScore = 60;
-        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
-
-        private const double MaxPullbackDepthAtr = 0.9;
-        private const int MaxPullbackBars = 5;
-
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             DirectionDebug.LogOnce(ctx);
@@ -24,327 +17,46 @@ namespace GeminiV26.EntryTypes.INDEX
             if (!matrix.AllowPullback)
                 return Reject(ctx, TradeDirection.None, 0, "SESSION_MATRIX_ALLOWPULLBACK_DISABLED");
 
-            if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 10)
+            if (ctx == null || !ctx.IsReady)
                 return Reject(ctx, TradeDirection.None, 0, "CTX_NOT_READY");
 
-            if (ctx.LogicBias == TradeDirection.None)
-                return Reject(ctx, TradeDirection.None, 0, "NO_LOGIC_BIAS");
-
-            var p = IndexInstrumentMatrix.Get(ctx.Symbol);
-            if (p == null)
-                return Reject(ctx, TradeDirection.None, 0, "NO_INDEX_PROFILE");
-
-            bool hasHtfMismatch = ctx.ResolveAssetHtfConfidence01() >= 0.6 && ctx.ResolveAssetHtfAllowedDirection() != TradeDirection.None && ctx.ResolveAssetHtfAllowedDirection() != ctx.LogicBias;
-
-            if (ctx.LogicBias == TradeDirection.Long)
+            if (!ctx.Structure.HasImpulse)
             {
-                var eval = EvaluateSide(ctx, p, matrix, TradeDirection.Long, hasHtfMismatch);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
-                return EntryDecisionPolicy.Normalize(eval);
-            }
-            else if (ctx.LogicBias == TradeDirection.Short)
-            {
-                var eval = EvaluateSide(ctx, p, matrix, TradeDirection.Short, hasHtfMismatch);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
-                return EntryDecisionPolicy.Normalize(eval);
+                ctx.Log?.Invoke("[ENTRY][PULLBACK][STRUCTURE_ERROR] violation=no_trade_without_impulse");
+                return Reject(ctx, TradeDirection.None, 0, "no_impulse");
             }
 
-            return Reject(ctx, TradeDirection.None, 0, "NO_LOGIC_BIAS");
-        }
-        private EntryEvaluation EvaluateSide(
-            EntryContext ctx,
-            dynamic p,
-            SessionMatrixConfig matrix,
-            TradeDirection dir,
-            bool hasHtfMismatch)
-        {
-            // =============================
-            // MATRIX DRIVEN THRESHOLDS
-            // =============================
-            int setupScore = 0;
-            double minAdxTrend = p.MinAdxTrend > 0 ? p.MinAdxTrend : 20;
-            minAdxTrend = Math.Max(minAdxTrend, matrix.MinAdx);
-            int maxBarsSinceImpulse = p.MaxBarsSinceImpulse_M5 > 0 ? p.MaxBarsSinceImpulse_M5 : 4;
-            double minAtrPoints = p.MinAtrPoints > 0 ? p.MinAtrPoints : 0;
-
-            double maxPullbackDepthAtr =
-                p.PullbackStyle == IndexPullbackStyle.Shallow ? 0.7 :
-                p.PullbackStyle == IndexPullbackStyle.Structure ? 1.0 :
-                MaxPullbackDepthAtr;
-
-            int maxPullbackBars =
-                p.PullbackStyle == IndexPullbackStyle.Shallow ? 3 :
-                p.PullbackStyle == IndexPullbackStyle.Structure ? 6 :
-                MaxPullbackBars;
-
-            int score = BaseScore;
-            bool continuationAuthority = HasContinuationAuthority(ctx, dir);
-
-            if (hasHtfMismatch)
+            if (!ctx.Structure.HasPullback)
             {
-                if (continuationAuthority)
-                {
-                    score -= 8;
-                    ctx.Log?.Invoke($"[IDX_PULLBACK][SOFT_PENALTY] reason=HTF_MISMATCH penalty=8 dir={dir} score={score}");
-                }
-                else
-                {
-                    score -= 12;
-                    ctx.Log?.Invoke($"[IDX_PULLBACK][SOFT_PENALTY] reason=HTF_MISMATCH_NO_CONTINUATION penalty=12 dir={dir} score={score}");
-                }
+                ctx.Log?.Invoke("[ENTRY][PULLBACK][STRUCTURE_ERROR] violation=no_pullback_entry_without_retrace");
+                return Reject(ctx, TradeDirection.None, 0, "no_pullback");
             }
 
-            var bars = ctx.M5;
-            int lastClosed = bars.Count - 2;
-
-            bool hasImpulse =
-                dir == TradeDirection.Long ? ctx.HasImpulseLong_M5 :
-                dir == TradeDirection.Short ? ctx.HasImpulseShort_M5 :
-                false;
-
-            double pullbackDepthAtr =
-                dir == TradeDirection.Long ? ctx.PullbackDepthRLong_M5 :
-                dir == TradeDirection.Short ? ctx.PullbackDepthRShort_M5 :
-                ctx.PullbackDepthAtr_M5;
-
-            bool hasFlag =
-                dir == TradeDirection.Long ? ctx.HasFlagLong_M5 :
-                dir == TradeDirection.Short ? ctx.HasFlagShort_M5 :
-                ctx.IsValidFlagStructure_M5;
-
-            bool lastBarInDir =
-                (dir == TradeDirection.Long && bars[lastClosed].Close > bars[lastClosed].Open) ||
-                (dir == TradeDirection.Short && bars[lastClosed].Close < bars[lastClosed].Open);
-
-            bool m1TriggerInDir = HasDirectionalM1Trigger(ctx, dir);
-            bool continuationSignal = m1TriggerInDir;
-            bool breakoutConfirmed = m1TriggerInDir;
-
-            bool hasImpulseSetup = ctx.HasImpulse_M5;
-
-            if (!hasImpulseSetup)
-                setupScore -= 40;
-            else
-                setupScore += 15;
-
-            bool hasStructure =
-                (dir == TradeDirection.Long ? ctx.HasPullbackLong_M5 : ctx.HasPullbackShort_M5) ||
-                hasFlag;
-
-            if (hasStructure)
-                setupScore += 10;
-
-            bool hasContinuation =
-                continuationSignal || breakoutConfirmed;
-
-            if (hasContinuation)
-                setupScore += 20;
-
-            // =====================================================
-            // CHOP SOFT (matrix ADX)
-            // =====================================================
-            bool chopZone =
-                ctx.Adx_M5 < minAdxTrend &&
-                Math.Abs(ctx.PlusDI_M5 - ctx.MinusDI_M5) < 7 &&
-                !ctx.IsAtrExpanding_M5;
-
-            if (chopZone)
-                score -= 8;
-
-            // =====================================================
-            // ATR sanity (matrix driven)
-            // =====================================================
-            if (minAtrPoints > 0 && ctx.AtrM5 < minAtrPoints)
-                score -= 6;
-
-            // =====================================================
-            // TREND FATIGUE → SOFT
-            // =====================================================
-            bool adxExhausted =
-                ctx.Adx_M5 > 45 &&
-                ctx.AdxSlope_M5 <= 0;
-
-            bool atrContracting =
-                ctx.AtrSlope_M5 <= 0;
-
-            bool diConverging =
-                Math.Abs(ctx.PlusDI_M5 - ctx.MinusDI_M5) < 7;
-
-            bool impulseStale =
-                !hasImpulse ||
-                ctx.BarsSinceImpulse_M5 > maxBarsSinceImpulse;
-
-            int fatigueCount = 0;
-            if (adxExhausted) fatigueCount++;
-            if (atrContracting) fatigueCount++;
-            if (diConverging) fatigueCount++;
-            if (impulseStale) fatigueCount++;
-
-            bool trendFatigue = fatigueCount >= 3;
-
-            if (trendFatigue)
-                score -= 12;
-
-            // =====================================================
-            // PULLBACK STRUCTURAL GATES
-            // =====================================================
-
-            if (ctx.IsAtrExpanding_M5 && pullbackDepthAtr > 0.6)
-                score -= 6;
-
-            if (pullbackDepthAtr > 0.5)
+            if (ctx.Structure.StructureDirection == TradeDirection.None)
             {
-                int compressionBars = Math.Max(0, Math.Min(ctx.PullbackBars_M5, 10));
-                int compressionStart = Math.Max(0, lastClosed - compressionBars + 1);
-
-                double compressionHigh = double.MinValue;
-                double compressionLow = double.MaxValue;
-
-                for (int i = compressionStart; i <= lastClosed; i++)
-                {
-                    compressionHigh = Math.Max(compressionHigh, bars[i].High);
-                    compressionLow = Math.Min(compressionLow, bars[i].Low);
-                }
-
-                double compressionRange = compressionHigh - compressionLow;
-                double atr = Math.Max(0, ctx.AtrM5);
-
-                bool compressionDetected =
-                    compressionBars >= 3 &&
-                    compressionBars <= 10 &&
-                    compressionRange <= atr * 0.6;
-
-                if (!compressionDetected)
-                {
-                    ctx.Log?.Invoke($"[PB] dir={dir} rejected: deep pullback without compression");
-                    score -= 10;
-                }
-
-                TradeDirection impulseDirection =
-                    ctx.ImpulseDirection != TradeDirection.None ? ctx.ImpulseDirection : dir;
-
-                bool breakoutAligned =
-                    (impulseDirection == TradeDirection.Long && bars[lastClosed].Close > compressionHigh) ||
-                    (impulseDirection == TradeDirection.Short && bars[lastClosed].Close < compressionLow);
-
-                if (!breakoutAligned)
-                {
-                    ctx.Log?.Invoke($"[PB] dir={dir} rejected: breakout against impulse");
-                    score -= 10;
-                }
-
-                ctx.Log?.Invoke($"[PB] dir={dir} DeepPullbackContinuation accepted");
+                ctx.Log?.Invoke("[ENTRY][PULLBACK][STRUCTURE_ERROR] violation=direction_must_come_from_impulse");
+                return Reject(ctx, TradeDirection.None, 0, "structure_direction_missing");
             }
 
-            if (pullbackDepthAtr <= 0 ||
-                pullbackDepthAtr > maxPullbackDepthAtr)
-            {
-                if (continuationAuthority)
-                {
-                    score -= 12;
-                    ctx.Log?.Invoke(
-                        $"[IDX_PULLBACK][SOFT_PENALTY] reason=PULLBACK_DEPTH_INVALID penalty=12 dir={dir} pbATR={pullbackDepthAtr:F2} score={score}");
-                }
-                else
-                {
-                    return Reject(ctx, dir, score, "PULLBACK_DEPTH_INVALID");
-                }
-            }
-
-            if (ctx.PullbackBars_M5 > maxPullbackBars)
-                return Reject(ctx, dir, score, "PULLBACK_BARS_TOO_LONG");
-
-            if (!ctx.HasReactionCandle_M5)
-                score -= 8;
-
-            if (!lastBarInDir)
-                score -= 10;
-
-            double distFromEma =
-                Math.Abs(ctx.M5.Last(1).Close - ctx.Ema21_M5);
-
-            if (distFromEma > ctx.AtrM5 * 1.2)
-                score -= 8;
-
-            // =====================================================
-            // CONTEXT BONUSES
-            // =====================================================
-
-            if (m1TriggerInDir)
-                score += 10;
-
-            if (ctx.MarketState?.IsTrend == true)
-                score += 6;
-
-            if (hasImpulse &&
-                ctx.BarsSinceImpulse_M5 <= 2 &&
-                pullbackDepthAtr < 0.6)
-            {
-                score += 8;
-            }
-
-            if (ctx.IsPullbackDecelerating_M5)
-                score += 5;
-
-            // =====================================================
-            // VOL REGIME SOFT
-            // =====================================================
-            if (ctx.MarketState?.IsLowVol == true)
-                score -= 12;
-
-            // =====================================================
-            // FLAG PRIORITY
-            // =====================================================
-            if (hasFlag &&
-                m1TriggerInDir)
-                score -= 12;
-
-            // =====================================================
-            // FINAL SCORE GATE
-            // =====================================================
-            bool breakoutDetected = breakoutConfirmed || ctx.RangeBreakDirection == dir;
-            bool strongCandle = lastBarInDir;
-            bool followThrough = continuationSignal || ctx.HasReactionCandle_M5;
-            score = TriggerScoreModel.Apply(ctx, $"IDX_PULLBACK_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_PULLBACK_TRIGGER");
-
-            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
-            score += setupScore;
-
-            if (setupScore <= 0)
-                score = Math.Min(score, MinScore - 10);
-
+            var direction = ctx.Structure.StructureDirection;
+            int score = (int)Math.Round(100.0 * (
+                0.5 * ctx.Structure.ImpulseStrength +
+                0.5 * (1.0 - ctx.Structure.PullbackDepth)));
             score += (int)Math.Round(matrix.EntryScoreModifier);
+            score = Math.Max(0, Math.Min(100, score));
 
-            if (score < MinScore)
-            {
-                GlobalLogger.Log(this, 
-                    $"[IDX_PULLBACK][REJECT] LOW_SCORE({score}) | " +
-                    $"dir={dir} | pbATR={pullbackDepthAtr:F2} | " +
-                    $"pbBars={ctx.PullbackBars_M5} | fatigue={trendFatigue} | " +
-                    $"ADX={ctx.Adx_M5:F1}"
-                );
-                return Reject(ctx, dir, score, "LOW_SCORE");
-            }
-
-            GlobalLogger.Log(this, 
-                $"[IDX_PULLBACK][PASS] dir={dir} score={score} | " +
-                $"pbATR={pullbackDepthAtr:F2} | pbBars={ctx.PullbackBars_M5} | " +
-                $"fatigue={trendFatigue} | ADX={ctx.Adx_M5:F1}"
-            );
+            ctx.Log?.Invoke("[ENTRY][PULLBACK][STRUCTURE_OK]");
 
             return new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
-                Direction = dir,
+                Direction = direction,
                 Score = score,
                 IsValid = true,
-                Reason =
-                    $"IDX_PULLBACK_4.1 dir={dir} score={score} " +
-                    $"pbATR={pullbackDepthAtr:F2} pbBars={ctx.PullbackBars_M5} fatigue={trendFatigue}"
+                Reason = "STRUCTURE_IMPULSE_PULLBACK_OK"
             };
         }
-
 
         private static EntryEvaluation Reject(EntryContext ctx, TradeDirection dir, int score, string reason)
         {
@@ -358,51 +70,5 @@ namespace GeminiV26.EntryTypes.INDEX
                 Reason = reason
             };
         }
-
-        private static bool HasDirectionalM1Trigger(EntryContext ctx, TradeDirection dir)
-        {
-            if (ctx == null || ctx.M1 == null || ctx.M1.Count < 3)
-                return false;
-
-            int lastClosed = ctx.M1.Count - 2;
-            int prevClosed = ctx.M1.Count - 3;
-
-            var last = ctx.M1[lastClosed];
-            var prev = ctx.M1[prevClosed];
-
-            if (dir == TradeDirection.Long)
-                return last.Close > last.Open && last.Close > prev.High;
-
-            if (dir == TradeDirection.Short)
-                return last.Close < last.Open && last.Close < prev.Low;
-
-            return false;
-        }
-
-        private static bool HasContinuationAuthority(EntryContext ctx, TradeDirection dir)
-        {
-            if (ctx == null || dir == TradeDirection.None)
-                return false;
-
-            return
-                ctx.TrendDirection == dir &&
-                ctx.HasImpulse_M5 &&
-                ctx.IsAtrExpanding_M5 &&
-                ctx.MarketState?.IsTrend == true;
-        }
-
-        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
-        {
-            return EntryDirectionQuality.Apply(
-                ctx,
-                direction,
-                score,
-                new DirectionQualityRequest
-                {
-                    TypeTag = "Index_PullbackEntry",
-                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
-                });
-        }
-
     }
 }


### PR DESCRIPTION
### Motivation
- Introduce a deterministic structure model (Impulse → Pullback → Flag) so index entry decisions are based on a single, explicit `StructureContext` instead of scattered heuristics.
- Enforce invariants: no trade without impulse, no pullback entry without retrace, no flag entry without compression, and direction must come only from the impulse anchor.
- Scope is limited to context construction and index entry evaluation to avoid changes to risk, exit, or execution logic. 

### Description
- Added a new `StructureContext` class and attached it to `EntryContext` as `Structure` carrying `HasImpulse`, `ImpulseStrength`, `ImpulseRange`, `ImpulseBars`, `HasPullback`, `PullbackDepth`, `PullbackBars`, `HasFlag`, `FlagCompression`, `FlagBars`, and `StructureDirection`.
- Extended `EntryContextBuilder` with a deterministic pipeline invoking `BuildImpulseAnchor(ctx)`, `BuildPullback(ctx)`, and `BuildFlag(ctx)` during context creation, and implemented these methods with the specified thresholds (`move >= 0.6`, `range >= ATR*1.2`, pullback retrace in `[0.2,0.65]`, pullback bars `<= 12`, flag compression `<= 0.6`, flag bars `<= 6`).
- Replaced the previous Index entry evaluators with structure-gated implementations: `Index_PullbackEntry` now requires `Structure.HasImpulse` and `Structure.HasPullback`, sets `Direction = Structure.StructureDirection`, and computes `Score = 0.5*ImpulseStrength + 0.5*(1-PullbackDepth)` (scaled to 0–100); `Index_FlagEntry` requires impulse+pullback+flag, uses `Direction = Structure.StructureDirection`, and computes `Score = 0.4*ImpulseStrength + 0.3*(1-PullbackDepth) + 0.3*(1-FlagCompression)` (scaled to 0–100).
- Added explicit structure-violation logging for the hard guarantees (e.g. `"[ENTRY][PULLBACK][STRUCTURE_ERROR] violation=no_trade_without_impulse"`) and ensured no direction fallbacks are used. 

### Testing
- Attempted an automated build with `dotnet build -v minimal`, but the environment lacked the `dotnet` tool so compilation could not be executed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce3ac62b9c8328aad5f9201f8af193)