### PR TITLE
Add deterministic flag-breakout trigger for Index_Flag entries

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -29,6 +29,10 @@ namespace GeminiV26.Core.Entry
         public bool HasFlag;
         public double FlagCompression;
         public int FlagBars;
+        public double FlagHigh;
+        public double FlagLow;
+        public bool FlagBreakoutUp;
+        public bool FlagBreakoutDown;
 
         public TradeDirection StructureDirection;
     }

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -837,6 +837,7 @@ namespace GeminiV26.Core.Entry
             BuildImpulseAnchor(ctx);
             BuildPullback(ctx);
             BuildFlag(ctx);
+            DetectFlagBreakout(ctx);
 
             // =================================================
             // HTF BIAS – FINAL DISPATCH (Phase 3.8 FIX)
@@ -1080,8 +1081,54 @@ namespace GeminiV26.Core.Entry
 
             ctx.Structure.FlagCompression = compression;
             ctx.Structure.FlagBars = bars;
+            ctx.Structure.FlagHigh = ctx.FlagHigh;
+            ctx.Structure.FlagLow = ctx.FlagLow;
 
             GlobalLogger.Log(_bot, $"[STRUCTURE][FLAG] compression={compression:F2} bars={bars}");
+            GlobalLogger.Log(_bot, $"[STRUCTURE][FLAG_RANGE] high={ctx.Structure.FlagHigh:F5} low={ctx.Structure.FlagLow:F5}");
+        }
+
+        private void DetectFlagBreakout(EntryContext ctx)
+        {
+            if (ctx == null || !ctx.Structure.HasFlag || ctx.M1 == null || ctx.M1.Count < 2)
+                return;
+
+            int m1Idx = ctx.M1.Count - 2;
+            double price = ctx.M1.ClosePrices[m1Idx];
+
+            bool breakoutUp = price > ctx.Structure.FlagHigh;
+            bool breakoutDown = price < ctx.Structure.FlagLow;
+
+            ctx.Structure.FlagBreakoutUp = breakoutUp;
+            ctx.Structure.FlagBreakoutDown = breakoutDown;
+
+            if (breakoutUp || breakoutDown)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCTURE][FLAG_BREAKOUT] dir={(breakoutUp ? "UP" : "DOWN")} price={price:F5}");
+            }
+
+            if (ctx.AtrM5 > 0)
+            {
+                double breakoutRef = breakoutUp ? ctx.Structure.FlagHigh : ctx.Structure.FlagLow;
+                double breakoutStrength = Math.Abs(price - breakoutRef) / ctx.AtrM5;
+                bool weakBreakout = breakoutStrength < 0.1;
+
+                if (weakBreakout)
+                {
+                    ctx.Structure.FlagBreakoutUp = false;
+                    ctx.Structure.FlagBreakoutDown = false;
+                    GlobalLogger.Log(_bot, "[STRUCTURE][FLAG_BREAKOUT_WEAK]");
+                }
+            }
+
+            bool invalidBreakout =
+                (ctx.Structure.FlagBreakoutUp && ctx.Structure.StructureDirection != TradeDirection.Long) ||
+                (ctx.Structure.FlagBreakoutDown && ctx.Structure.StructureDirection != TradeDirection.Short) ||
+                (ctx.Structure.FlagBreakoutUp && ctx.Structure.FlagBreakoutDown);
+
+            if (invalidBreakout)
+                GlobalLogger.Log(_bot, "[ERROR][FLAG_BREAKOUT_INVALID]");
         }
     }
 }

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -44,15 +44,27 @@ namespace GeminiV26.EntryTypes.INDEX
                 return Reject(ctx, "structure_direction_missing", 0, TradeDirection.None);
             }
 
+            bool validBreakout =
+                (ctx.Structure.StructureDirection == TradeDirection.Long && ctx.Structure.FlagBreakoutUp) ||
+                (ctx.Structure.StructureDirection == TradeDirection.Short && ctx.Structure.FlagBreakoutDown);
+
+            if (!validBreakout)
+            {
+                ctx.Log?.Invoke("[ENTRY][FLAG][WAIT_BREAKOUT]");
+                return Reject(ctx, "no_breakout", 0, TradeDirection.None);
+            }
+
             var direction = ctx.Structure.StructureDirection;
-            int score = (int)Math.Round(100.0 * (
-                0.4 * ctx.Structure.ImpulseStrength +
+            double score01 =
+                0.5 * ctx.Structure.ImpulseStrength +
                 0.3 * (1.0 - ctx.Structure.PullbackDepth) +
-                0.3 * (1.0 - ctx.Structure.FlagCompression)));
+                0.2 * (1.0 - ctx.Structure.FlagCompression);
+
+            int score = (int)Math.Round(100.0 * score01);
             score += (int)Math.Round(matrix.EntryScoreModifier);
             score = Math.Max(0, Math.Min(100, score));
 
-            ctx.Log?.Invoke("[ENTRY][FLAG][STRUCTURE_OK]");
+            ctx.Log?.Invoke("[ENTRY][FLAG][BREAKOUT_CONFIRMED]");
 
             return new EntryEvaluation
             {


### PR DESCRIPTION
### Motivation
- Ensure flag-based entries happen only on an immediate, deterministic breakout of the detected flag range and not while price remains inside the flag consolidation.
- Filter minimal fake breakouts using ATR-normalized strength and guarantee breakout direction matches the impulse direction.

### Description
- Extended `StructureContext` with `FlagHigh`, `FlagLow`, `FlagBreakoutUp` and `FlagBreakoutDown` so structure-level logic can publish and consume flag range and breakout state.
- Updated `BuildFlag` (in `EntryContextBuilder`) to copy `ctx.FlagHigh/FlagLow` into `ctx.Structure` and emit `[STRUCTURE][FLAG_RANGE]` logging.
- Added `DetectFlagBreakout(EntryContext ctx)` and wired it into the pipeline immediately after `BuildFlag(ctx)`; it checks the latest M1 close against the flag range, sets breakout flags, logs breakouts, and applies a minimal anti-fake filter using ATR-normalized breakout strength (< 0.1).
- Added invalid-state logging `[ERROR][FLAG_BREAKOUT_INVALID]` when breakout state is inconsistent with structure direction or both sides report breakout.
- Modified `EntryTypes/INDEX/Index_FlagEntry` to reject entries until a valid, structure-aligned breakout exists (returns `no_breakout` and logs `[ENTRY][FLAG][WAIT_BREAKOUT]`), and to log `[ENTRY][FLAG][BREAKOUT_CONFIRMED]` when passing; scoring formula adjusted to the requested 0.5/0.3/0.2 weighting.
- No changes were made to risk, SL/TP, execution modules, StructureContext core logic, or unrelated modules per constraints.

### Testing
- Performed repository-level validations and inspections including `rg` lookups and `sed` file previews to verify the changelist and locations, and `git diff` to confirm the exact diffs; these commands completed successfully.
- Committed the changes (`git commit`) and confirmed the commit `34af0d4` was created successfully.
- No build, unit or runtime integration tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce3c4db128832899f7dcaf575b0a07)