### PR TITLE
Add deterministic pullback entry timing signals for Index_Pullback

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -25,6 +25,10 @@ namespace GeminiV26.Core.Entry
         public bool HasPullback;
         public double PullbackDepth;
         public int PullbackBars;
+        public bool PullbackEarlySignal;
+        public bool PullbackConfirmedSignal;
+        public double PullbackLow;
+        public double PullbackHigh;
 
         public bool HasFlag;
         public double FlagCompression;
@@ -97,6 +101,7 @@ namespace GeminiV26.Core.Entry
         // ATR
         // =========================
         public double AtrM5;
+        public double AtrM1;
         public double AtrM15;
 
         public double AtrSlope_M5;

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -121,10 +121,12 @@ namespace GeminiV26.Core.Entry
             // ATR (M5 + M15)
             // =====================================================
 
+            var atr_m1 = _bot.Indicators.AverageTrueRange(ctx.M1, 14, MovingAverageType.Simple);
             var atr_m5 = _bot.Indicators.AverageTrueRange(ctx.M5, 14, MovingAverageType.Simple);
             var atr_m15 = _bot.Indicators.AverageTrueRange(ctx.M15, 14, MovingAverageType.Simple);
 
             // aktuális index
+            ctx.AtrM1 = atr_m1.Result[m1Idx];
             ctx.AtrM5 = atr_m5.Result[m5Idx];
             ctx.AtrM15 = atr_m15.Result.LastValue;
 
@@ -837,6 +839,8 @@ namespace GeminiV26.Core.Entry
             BuildImpulseAnchor(ctx);
             BuildPullback(ctx);
             BuildFlag(ctx);
+            DetectPullbackEarly(ctx);
+            DetectPullbackConfirmed(ctx);
             DetectFlagBreakout(ctx);
 
             // =================================================
@@ -1057,8 +1061,11 @@ namespace GeminiV26.Core.Entry
 
             ctx.Structure.PullbackDepth = retrace;
             ctx.Structure.PullbackBars = bars;
+            ctx.Structure.PullbackLow = GetPullbackLow(ctx);
+            ctx.Structure.PullbackHigh = GetPullbackHigh(ctx);
 
             GlobalLogger.Log(_bot, $"[STRUCTURE][PULLBACK] depth={retrace:F2} bars={bars}");
+            GlobalLogger.Log(_bot, $"[STRUCTURE][PULLBACK_RANGE] low={ctx.Structure.PullbackLow:F5} high={ctx.Structure.PullbackHigh:F5}");
         }
 
         private void BuildFlag(EntryContext ctx)
@@ -1129,6 +1136,101 @@ namespace GeminiV26.Core.Entry
 
             if (invalidBreakout)
                 GlobalLogger.Log(_bot, "[ERROR][FLAG_BREAKOUT_INVALID]");
+        }
+
+        private void DetectPullbackEarly(EntryContext ctx)
+        {
+            if (ctx == null || !ctx.Structure.HasPullback || ctx.M1 == null || ctx.M1.Count < 3)
+                return;
+
+            int m1Idx = ctx.M1.Count - 2;
+            double price = ctx.M1.ClosePrices[m1Idx];
+            double previousHigh = ctx.M1.HighPrices[m1Idx - 1];
+            double previousLow = ctx.M1.LowPrices[m1Idx - 1];
+            double previousClose = ctx.M1.ClosePrices[m1Idx - 1];
+
+            bool earlyLong =
+                ctx.Structure.StructureDirection == TradeDirection.Long &&
+                price > previousHigh;
+
+            bool earlyShort =
+                ctx.Structure.StructureDirection == TradeDirection.Short &&
+                price < previousLow;
+
+            ctx.Structure.PullbackEarlySignal = earlyLong || earlyShort;
+
+            if (ctx.Structure.PullbackEarlySignal)
+                GlobalLogger.Log(_bot, $"[STRUCTURE][PULLBACK_EARLY] dir={(earlyLong ? "LONG" : "SHORT")}");
+
+            double moveSize = Math.Abs(price - previousClose);
+            bool weakMove = ctx.AtrM1 > 0 && moveSize < ctx.AtrM1 * 0.05;
+
+            if (weakMove)
+            {
+                ctx.Structure.PullbackEarlySignal = false;
+                GlobalLogger.Log(_bot, "[STRUCTURE][PULLBACK_EARLY_WEAK]");
+            }
+        }
+
+        private void DetectPullbackConfirmed(EntryContext ctx)
+        {
+            if (ctx == null || !ctx.Structure.HasPullback || ctx.M1 == null || ctx.M1.Count < 2)
+                return;
+
+            int m1Idx = ctx.M1.Count - 2;
+            double price = ctx.M1.ClosePrices[m1Idx];
+
+            bool confirmedLong =
+                ctx.Structure.StructureDirection == TradeDirection.Long &&
+                price > ctx.Structure.PullbackHigh;
+
+            bool confirmedShort =
+                ctx.Structure.StructureDirection == TradeDirection.Short &&
+                price < ctx.Structure.PullbackLow;
+
+            ctx.Structure.PullbackConfirmedSignal = confirmedLong || confirmedShort;
+
+            if (ctx.Structure.PullbackConfirmedSignal)
+                GlobalLogger.Log(_bot, $"[STRUCTURE][PULLBACK_CONFIRMED] dir={(confirmedLong ? "LONG" : "SHORT")}");
+
+            bool invalidTiming =
+                (ctx.Structure.PullbackEarlySignal || ctx.Structure.PullbackConfirmedSignal) &&
+                ctx.Structure.StructureDirection == TradeDirection.None;
+
+            if (invalidTiming)
+                GlobalLogger.Log(_bot, "[ERROR][PULLBACK_TIMING_INVALID]");
+        }
+
+        private static double GetPullbackLow(EntryContext ctx)
+        {
+            if (ctx?.M1 == null || ctx.M1.Count < 3)
+                return 0;
+
+            int m1Idx = ctx.M1.Count - 2;
+            int window = Math.Max(2, Math.Min(m1Idx + 1, Math.Max(2, ctx.PullbackBars_M5 * 5)));
+            int start = Math.Max(0, m1Idx - window + 1);
+            double low = double.MaxValue;
+
+            for (int i = start; i <= m1Idx; i++)
+                low = Math.Min(low, ctx.M1.LowPrices[i]);
+
+            return low == double.MaxValue ? 0 : low;
+        }
+
+        private static double GetPullbackHigh(EntryContext ctx)
+        {
+            if (ctx?.M1 == null || ctx.M1.Count < 3)
+                return 0;
+
+            int m1Idx = ctx.M1.Count - 2;
+            int window = Math.Max(2, Math.Min(m1Idx + 1, Math.Max(2, ctx.PullbackBars_M5 * 5)));
+            int start = Math.Max(0, m1Idx - window + 1);
+            double high = double.MinValue;
+
+            for (int i = start; i <= m1Idx; i++)
+                high = Math.Max(high, ctx.M1.HighPrices[i]);
+
+            return high == double.MinValue ? 0 : high;
         }
     }
 }

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -32,20 +32,34 @@ namespace GeminiV26.EntryTypes.INDEX
                 return Reject(ctx, TradeDirection.None, 0, "no_pullback");
             }
 
+            bool useEarly = ctx.Structure.PullbackEarlySignal;
+            bool useConfirmed = ctx.Structure.PullbackConfirmedSignal;
+
+            if (!useEarly && !useConfirmed)
+            {
+                ctx.Log?.Invoke("[ENTRY][PULLBACK][WAIT_SIGNAL]");
+                return Reject(ctx, TradeDirection.None, 0, "no_signal");
+            }
+
             if (ctx.Structure.StructureDirection == TradeDirection.None)
             {
                 ctx.Log?.Invoke("[ENTRY][PULLBACK][STRUCTURE_ERROR] violation=direction_must_come_from_impulse");
                 return Reject(ctx, TradeDirection.None, 0, "structure_direction_missing");
             }
 
+            bool isConfirmedEntry = useConfirmed;
+
             var direction = ctx.Structure.StructureDirection;
+            double timingScore = isConfirmedEntry ? 1.0 : 0.7;
             int score = (int)Math.Round(100.0 * (
-                0.5 * ctx.Structure.ImpulseStrength +
-                0.5 * (1.0 - ctx.Structure.PullbackDepth)));
+                0.4 * ctx.Structure.ImpulseStrength +
+                0.4 * (1.0 - ctx.Structure.PullbackDepth) +
+                0.2 * timingScore));
             score += (int)Math.Round(matrix.EntryScoreModifier);
             score = Math.Max(0, Math.Min(100, score));
 
             ctx.Log?.Invoke("[ENTRY][PULLBACK][STRUCTURE_OK]");
+            ctx.Log?.Invoke($"[ENTRY][PULLBACK][SIGNAL] type={(isConfirmedEntry ? "CONFIRMED" : "EARLY")}");
 
             return new EntryEvaluation
             {


### PR DESCRIPTION
### Motivation
- Provide deterministic, structure-only pullback entry timing for index pullbacks by distinguishing immediate EARLY (micro reversal) and CONFIRMED (range breakout) entry opportunities without introducing RSI/EMA or other heuristic triggers.
- Ensure timing decisions remain strictly derived from impulse/structure state and are observable via explicit signals and logs.

### Description
- Extended `StructureContext` with `PullbackEarlySignal`, `PullbackConfirmedSignal`, `PullbackLow`, and `PullbackHigh`, and added `AtrM1` to `EntryContext` for a minimal anti-fake filter (`Core/Entry/EntryContext.cs`).
- In `EntryContextBuilder` computed `AtrM1`, populated `Structure.PullbackLow`/`PullbackHigh` inside `BuildPullback`, and added `DetectPullbackEarly` (micro break detection + weak-move anti-fake) and `DetectPullbackConfirmed` (pullback-range breakout) which are invoked in the main build pipeline after `BuildImpulseAnchor`, `BuildPullback`, and `BuildFlag` (`Core/Entry/EntryContextBuilder.cs`).
- Implemented safe range calculation helpers `GetPullbackLow`/`GetPullbackHigh` used to compute the M1-range for confirmed breakout checks (`Core/Entry/EntryContextBuilder.cs`).
- Modified `Index_PullbackEntry` to require either an early or confirmed signal before accepting an entry, lock direction from `StructureDirection`, apply timing-aware scoring weights (`0.4/0.4/0.2` for impulse/pullback/timing), and log the selected timing type (`EntryTypes/INDEX/Index_PullbackEntry.cs`).
- Added logging markers for observability including `[STRUCTURE][PULLBACK_RANGE]`, `[STRUCTURE][PULLBACK_EARLY]`, `[STRUCTURE][PULLBACK_EARLY_WEAK]`, `[STRUCTURE][PULLBACK_CONFIRMED]`, `[ENTRY][PULLBACK][WAIT_SIGNAL]`, and `[ERROR][PULLBACK_TIMING_INVALID]` to surface timing integrity issues.

### Testing
- Ran targeted static inspections and source scans with `rg` to confirm new symbols and log tokens are present and referenced, which succeeded.
- Verified diffs and modified files with `git diff` and repository status checks, and created a commit containing the changes, which succeeded.
- Attempted a build/project discovery (`rg --files -g '*.sln' -g '*.csproj'`) but no solution/project files were present in the workspace, so a compile/test run could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce3da688d883289e408d9fb2b11e3b)