### PR TITLE
FX: Structure-driven continuation entries (Impulse & Flag)

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -23,10 +23,13 @@ namespace GeminiV26.Core.Entry
         public int ImpulseBars;
 
         public bool HasPullback;
+        public bool HasMicroPullback;
         public double PullbackDepth;
         public int PullbackBars;
         public bool PullbackEarlySignal;
         public bool PullbackConfirmedSignal;
+        public bool ContinuationEarlySignal;
+        public bool ContinuationConfirmedSignal;
         public double PullbackLow;
         public double PullbackHigh;
 

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -842,6 +842,7 @@ namespace GeminiV26.Core.Entry
             DetectPullbackEarly(ctx);
             DetectPullbackConfirmed(ctx);
             DetectFlagBreakout(ctx);
+            MapStructureContinuationSignals(ctx);
 
             // =================================================
             // HTF BIAS – FINAL DISPATCH (Phase 3.8 FIX)
@@ -1059,6 +1060,7 @@ namespace GeminiV26.Core.Entry
             if (!ctx.Structure.HasPullback)
                 return;
 
+            ctx.Structure.HasMicroPullback = retrace >= 0.15 && retrace <= 0.45 && bars <= 6;
             ctx.Structure.PullbackDepth = retrace;
             ctx.Structure.PullbackBars = bars;
             ctx.Structure.PullbackLow = GetPullbackLow(ctx);
@@ -1158,6 +1160,7 @@ namespace GeminiV26.Core.Entry
                 price < previousLow;
 
             ctx.Structure.PullbackEarlySignal = earlyLong || earlyShort;
+            ctx.Structure.ContinuationEarlySignal = ctx.Structure.PullbackEarlySignal;
 
             if (ctx.Structure.PullbackEarlySignal)
                 GlobalLogger.Log(_bot, $"[STRUCTURE][PULLBACK_EARLY] dir={(earlyLong ? "LONG" : "SHORT")}");
@@ -1168,6 +1171,7 @@ namespace GeminiV26.Core.Entry
             if (weakMove)
             {
                 ctx.Structure.PullbackEarlySignal = false;
+                ctx.Structure.ContinuationEarlySignal = false;
                 GlobalLogger.Log(_bot, "[STRUCTURE][PULLBACK_EARLY_WEAK]");
             }
         }
@@ -1189,6 +1193,7 @@ namespace GeminiV26.Core.Entry
                 price < ctx.Structure.PullbackLow;
 
             ctx.Structure.PullbackConfirmedSignal = confirmedLong || confirmedShort;
+            ctx.Structure.ContinuationConfirmedSignal = ctx.Structure.PullbackConfirmedSignal;
 
             if (ctx.Structure.PullbackConfirmedSignal)
                 GlobalLogger.Log(_bot, $"[STRUCTURE][PULLBACK_CONFIRMED] dir={(confirmedLong ? "LONG" : "SHORT")}");
@@ -1199,6 +1204,15 @@ namespace GeminiV26.Core.Entry
 
             if (invalidTiming)
                 GlobalLogger.Log(_bot, "[ERROR][PULLBACK_TIMING_INVALID]");
+        }
+
+        private void MapStructureContinuationSignals(EntryContext ctx)
+        {
+            if (ctx == null)
+                return;
+
+            ctx.Structure.ContinuationEarlySignal = ctx.Structure.PullbackEarlySignal;
+            ctx.Structure.ContinuationConfirmedSignal = ctx.Structure.PullbackConfirmedSignal;
         }
 
         private static double GetPullbackLow(EntryContext ctx)

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -1,6 +1,6 @@
+using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.EntryTypes;
-using GeminiV26.Core;
 using GeminiV26.Instruments.FX;
 
 namespace GeminiV26.EntryTypes.FX
@@ -9,188 +9,89 @@ namespace GeminiV26.EntryTypes.FX
     {
         public EntryType Type => EntryType.FX_FlagContinuation;
 
-        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;
-        private const double MinPullbackAtr = 0.15;
-        private const double MaxPullbackAtr = 0.60;
-
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             FxDirectionValidation.LogDirectionDebug(ctx);
             if (ctx == null || !ctx.IsReady)
-                return Invalid(ctx, "CTX_NOT_READY");
+                return Invalid(ctx, TradeDirection.None, "CTX_NOT_READY");
 
-            if (ctx.LogicBias == TradeDirection.None)
-                return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
+            LogStructure(ctx);
 
-            FxDirectionValidation.GetLowConfidenceHtfConflictPenalty(ctx);
+            bool hasImpulse = ctx.Structure?.HasImpulse == true;
+            bool hasPullback = ctx.Structure?.HasPullback == true;
+            bool hasFlag = ctx.Structure?.HasFlag == true;
+            var direction = ctx.Structure?.StructureDirection ?? TradeDirection.None;
+            bool breakoutUp = ctx.Structure?.FlagBreakoutUp == true;
+            bool breakoutDown = ctx.Structure?.FlagBreakoutDown == true;
 
-            if (ctx.LogicBias == TradeDirection.Long)
-            {
-                var eval = EvaluateSide(TradeDirection.Long, ctx);
-                FxDirectionValidation.ApplyLowConfidenceHtfConflictSoftPenalty(ctx, eval);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
-                return EntryDecisionPolicy.Normalize(eval);
-            }
-            else if (ctx.LogicBias == TradeDirection.Short)
-            {
-                var eval = EvaluateSide(TradeDirection.Short, ctx);
-                FxDirectionValidation.ApplyLowConfidenceHtfConflictSoftPenalty(ctx, eval);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
-                return EntryDecisionPolicy.Normalize(eval);
-            }
+            ctx.Log?.Invoke(
+                $"[FX][FLAG_CHECK] impulse={hasImpulse.ToString().ToLowerInvariant()} pullback={hasPullback.ToString().ToLowerInvariant()} flag={hasFlag.ToString().ToLowerInvariant()} direction={direction} breakout_up={breakoutUp.ToString().ToLowerInvariant()} breakout_down={breakoutDown.ToString().ToLowerInvariant()}");
 
-            return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
-        }
+            if (!hasImpulse)
+                return Block(ctx, "NO_IMPULSE");
 
-        private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)
-        {
-            int setupScore = 0;
-            int minScore = MinScore;
+            if (!hasPullback)
+                return Block(ctx, "NO_PULLBACK");
 
-            var timing = ContinuationTimingGate.Evaluate(ctx, dir, Type.ToString());
-            if (!timing.IsAllowed)
-                return Invalid(ctx, dir, timing.Reason, 0);
+            if (!hasFlag)
+                return Block(ctx, "NO_FLAG");
 
-            bool hasImpulse =
-                dir == TradeDirection.Long ? ctx.HasImpulseLong_M5 : ctx.HasImpulseShort_M5;
+            if (direction == TradeDirection.None)
+                return Block(ctx, "NO_DIRECTION");
 
-            double pullbackDepthAtr =
-                dir == TradeDirection.Long ? ctx.PullbackDepthRLong_M5 : ctx.PullbackDepthRShort_M5;
+            if (direction == TradeDirection.Long && !breakoutUp)
+                return Block(ctx, "NO_BREAKOUT_UP");
 
-            bool isValidFlagStructure =
-                dir == TradeDirection.Long ? ctx.HasFlagLong_M5 : ctx.HasFlagShort_M5;
+            if (direction == TradeDirection.Short && !breakoutDown)
+                return Block(ctx, "NO_BREAKOUT_DOWN");
 
-            bool hasValidImpulse =
-                hasImpulse ||
-                (ctx.IsAtrExpanding_M5 && !ctx.IsRange_M5);
+            if ((direction == TradeDirection.Long && breakoutDown) || (direction == TradeDirection.Short && breakoutUp))
+                return Block(ctx, "DIRECTION_MISMATCH");
 
-            if (!hasValidImpulse)
-                return Invalid(ctx, dir, "NO_IMPULSE", 49);
+            ctx.Log?.Invoke($"[FX][FLAG_ENTRY] direction={direction}");
 
-            if (!isValidFlagStructure)
-                return Invalid(ctx, dir, "INVALID_FLAG", 50);
-
-            if (pullbackDepthAtr < MinPullbackAtr)
-                return Invalid(ctx, dir, "PB_TOO_SHALLOW", 50);
-
-            // =========================
-            // SESSION-AWARE PULLBACK DEPTH
-            // =========================
-            double maxPb = MaxPullbackAtr;
-
-            if (ctx.Session.ToString() == "NewYork")
-                maxPb = 0.75;
-
-            int score = 48;
-
-            if (pullbackDepthAtr > maxPb)
-                return Invalid(ctx, dir, "PB_TOO_DEEP", 49);
-
-            if (!ctx.IsPullbackDecelerating_M5)
-                return Invalid(ctx, dir, "NO_DECELERATION", 51);
-
-            if (!ctx.HasReactionCandle_M5)
-                return Invalid(ctx, dir, "NO_REACTION", 50);
-
-            // ✅ FIX: side-aware M1 confirmation
-            bool m1Confirm =
-                ctx.M1FlagBreakTrigger ||
-                (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir);
-
-            bool continuationSignal = m1Confirm;
-
-            bool hasStructure =
-                pullbackDepthAtr >= MinPullbackAtr;
-
-            if (!hasStructure)
-                setupScore -= 35;
-            else
-                setupScore += 15;
-
-            bool hasContinuation =
-                continuationSignal;
-
-            if (hasContinuation)
-                setupScore += 20;
-
-            if (timing.RequireStrongStructure && !hasStructure)
-                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_STRUCTURE", 0);
-
-            if (timing.RequireStrongTrigger && !m1Confirm)
-                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_TRIGGER", 0);
-
-            // ✅ FIX: side-aware score boost
-            if (ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir)
-                score += 10;
-
-            int lastClosed = ctx.M5.Count - 2;
-            var bar = ctx.M5[lastClosed];
-            bool breakoutDetected = m1Confirm || ctx.RangeBreakDirection == dir;
-            bool strongCandle =
-                (dir == TradeDirection.Long && bar.Close > bar.Open) ||
-                (dir == TradeDirection.Short && bar.Close < bar.Open);
-            bool followThrough = continuationSignal || ctx.LastClosedBarInTrendDirection;
-
-            if (ctx.IsRange_M5)
-                score -= 10;
-
-            score = TriggerScoreModel.Apply(ctx, $"FX_FLAG_CONT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_M1_CONFIRM");
-
-
-            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
-            score += timing.ScoreAdjustment;
-            minScore += timing.MinScoreAdjustment;
-            score += setupScore;
-
-            if (setupScore <= 0)
-                score = System.Math.Min(score, minScore - 10);
-
-            if (score < minScore)
-                return Invalid(ctx, dir, "LOW_SCORE", score);
-
-            return new EntryEvaluation
+            var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
-                Direction = dir,
-                Score = score,
+                Direction = direction,
+                Score = 70,
                 IsValid = true,
-                Reason = $"FX_FLAG_CONT score={score} pbATR={pullbackDepthAtr:F2}"
+                TriggerConfirmed = true,
+                Reason = "FX_FLAG_STRUCTURE_CONFIRMED"
             };
+
+            EntryDirectionQuality.LogDecision(
+                ctx,
+                Type.ToString(),
+                direction == TradeDirection.Long ? eval : null,
+                direction == TradeDirection.Short ? eval : null,
+                eval.Direction);
+
+            return EntryDecisionPolicy.Normalize(eval);
         }
 
-        private EntryEvaluation Invalid(EntryContext ctx, string reason)
-            => new()
-            {
-                Symbol = ctx?.Symbol,
-                Type = Type,
-                IsValid = false,
-                Reason = reason
-            };
+        private void LogStructure(EntryContext ctx)
+        {
+            ctx.Log?.Invoke(
+                $"[FX][STRUCTURE] impulse={(ctx.Structure?.HasImpulse == true).ToString().ToLowerInvariant()} pullback={(ctx.Structure?.HasPullback == true).ToString().ToLowerInvariant()} micro_pullback={(ctx.Structure?.HasMicroPullback == true).ToString().ToLowerInvariant()} flag={(ctx.Structure?.HasFlag == true).ToString().ToLowerInvariant()} direction={ctx.Structure?.StructureDirection ?? TradeDirection.None}");
+        }
 
-        private EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason, int score)
+        private EntryEvaluation Block(EntryContext ctx, string reason)
+        {
+            ctx.Log?.Invoke($"[FX][ENTRY_BLOCK] reason={reason}");
+            return Invalid(ctx, TradeDirection.None, reason);
+        }
+
+        private EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason)
             => new()
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
                 Direction = dir,
-                Score = score,
+                Score = 0,
                 IsValid = false,
                 Reason = reason
             };
-
-        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
-        {
-            return EntryDirectionQuality.Apply(
-                ctx,
-                direction,
-                score,
-                new DirectionQualityRequest
-                {
-                    TypeTag = "FX_FlagContinuationEntry",
-                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
-                });
-        }
-
     }
 }

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -1,217 +1,92 @@
+using GeminiV26.Core;
 using GeminiV26.Core.Entry;
 using GeminiV26.EntryTypes;
-using GeminiV26.Core;
 using GeminiV26.Instruments.FX;
 
 namespace GeminiV26.EntryTypes.FX
 {
-    /// <summary>
-    /// FX Impulse Continuation Entry
-    /// Phase 3.7.x – tightened to avoid late / top impulse entries
-    /// </summary>
     public class FX_ImpulseContinuationEntry : IEntryType
     {
         public EntryType Type => EntryType.FX_ImpulseContinuation;
 
-        private const double MinSlope = 0.00015;
-
-        // ===== Patch knobs (FX-safe) =====
-        private const int MinScore = EntryDecisionPolicy.MinScoreThreshold;                 // was 45
-        private const double MinPullbackAtr = 0.15;      // avoid top-tick entries
-        private const double MaxPullbackAtr = 1.0;       // already present logic
-
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             FxDirectionValidation.LogDirectionDebug(ctx);
-            if (!ctx.IsReady)
-                return Invalid(ctx, "CTX_NOT_READY");
+            if (ctx == null || !ctx.IsReady)
+                return Invalid(ctx, TradeDirection.None, "CTX_NOT_READY");
 
-            if (ctx.LogicBias == TradeDirection.None)
-                return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
+            LogStructure(ctx);
 
-            FxDirectionValidation.GetLowConfidenceHtfConflictPenalty(ctx);
+            var structureDirection = ctx.Structure?.StructureDirection ?? TradeDirection.None;
+            if (structureDirection != TradeDirection.Long && structureDirection != TradeDirection.Short)
+                return Block(ctx, "NO_DIRECTION");
 
-            if (ctx.LogicBias == TradeDirection.Long)
-            {
-                var eval = EvaluateSide(TradeDirection.Long, ctx);
-                FxDirectionValidation.ApplyLowConfidenceHtfConflictSoftPenalty(ctx, eval);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), eval, null, eval.Direction);
-                return EntryDecisionPolicy.Normalize(eval);
-            }
-            else if (ctx.LogicBias == TradeDirection.Short)
-            {
-                var eval = EvaluateSide(TradeDirection.Short, ctx);
-                FxDirectionValidation.ApplyLowConfidenceHtfConflictSoftPenalty(ctx, eval);
-                EntryDirectionQuality.LogDecision(ctx, Type.ToString(), null, eval, eval.Direction);
-                return EntryDecisionPolicy.Normalize(eval);
-            }
+            bool hasImpulse = ctx.Structure?.HasImpulse == true;
+            bool hasPullback = ctx.Structure?.HasPullback == true;
+            bool hasMicroPullback = ctx.Structure?.HasMicroPullback == true;
+            bool early = ctx.Structure?.ContinuationEarlySignal == true;
+            bool confirmed = ctx.Structure?.ContinuationConfirmedSignal == true;
 
-            return Invalid(ctx, TradeDirection.None, "NO_LOGIC_BIAS", 0);
-        }
-
-        private EntryEvaluation EvaluateSide(TradeDirection dir, EntryContext ctx)
-        {
-            int setupScore = 0;
-            int minScore = MinScore;
-
-            var timing = ContinuationTimingGate.Evaluate(ctx, dir, Type.ToString());
-            if (!timing.IsAllowed)
-                return Invalid(ctx, dir, timing.Reason, 0);
-
-            bool hasImpulse =
-                dir == TradeDirection.Long ? ctx.HasImpulseLong_M5 : ctx.HasImpulseShort_M5;
-
-            double pullbackDepthR =
-                dir == TradeDirection.Long ? ctx.PullbackDepthRLong_M5 : ctx.PullbackDepthRShort_M5;
-
-            // =====================================================
-            // TREND DIRECTION — PULLBACK LOGIKA (SZENT)
-            // =====================================================
-            bool up =
-                ctx.Ema21Slope_M15 > MinSlope &&
-                ctx.Ema21Slope_M5 > MinSlope;
-
-            bool down =
-                ctx.Ema21Slope_M15 < -MinSlope &&
-                ctx.Ema21Slope_M5 < -MinSlope;
-
-            if (!up && !down)
-            {
-                return new EntryEvaluation
-                {
-                    Symbol = ctx.Symbol,
-                    Type = Type,
-                    Direction = TradeDirection.None,
-                    Score = 0,
-                    IsValid = false,
-                    Reason = "NoTrend;"
-                };
-            }
-
-            if (dir == TradeDirection.Long && !up)
-                return Invalid(ctx, dir, "NoTrend", 0);
-
-            if (dir == TradeDirection.Short && !down)
-                return Invalid(ctx, dir, "NoTrend", 0);
-
-            // =====================================================
-            // IMPULSE CONDITIONS (REAL CONTEXT FIELDS)
-            // =====================================================
-            if (ctx.Adx_M5 >= 15 && ctx.Adx_M5 < 22)
-                return Invalid(ctx, dir, "WeakTrend", 50);
+            ctx.Log?.Invoke(
+                $"[FX][IMPULSE_CHECK] impulse={hasImpulse.ToString().ToLowerInvariant()} micro_pullback={hasMicroPullback.ToString().ToLowerInvariant()} direction={structureDirection} early={early.ToString().ToLowerInvariant()} confirmed={confirmed.ToString().ToLowerInvariant()}");
 
             if (!hasImpulse)
-                return Invalid(ctx, dir, "NoImpulse", 50);
+                return Block(ctx, "NO_IMPULSE");
 
-            if (pullbackDepthR > MaxPullbackAtr)
-                return Invalid(ctx, dir, "TooDeepPullback", 49);
+            if (!hasPullback)
+                return Block(ctx, "NO_PULLBACK");
 
-            if (pullbackDepthR < MinPullbackAtr)
-                return Invalid(ctx, dir, "NoMeaningfulPullback", 50);
+            if (!hasMicroPullback)
+                return Block(ctx, "NO_MICRO_PULLBACK");
 
-            // ATR expanding = kifulladó impulse chase FX-en
-            if (ctx.IsAtrExpanding_M5)
-                return Invalid(ctx, dir, "VolExpanding", 51);
+            if (!early && !confirmed)
+                return Block(ctx, "NO_CONTINUATION_SIGNAL");
 
-            bool continuationSignal =
-                ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir;
+            string entryType = confirmed ? "CONFIRMED" : "EARLY";
+            ctx.Log?.Invoke($"[FX][IMPULSE_ENTRY] type={entryType} direction={structureDirection}");
 
-            bool hasStructure =
-                pullbackDepthR >= MinPullbackAtr;
-
-            if (!hasStructure)
-                setupScore -= 35;
-            else
-                setupScore += 15;
-
-            bool hasContinuation =
-                continuationSignal;
-
-            if (hasContinuation)
-                setupScore += 20;
-
-            if (timing.RequireStrongStructure && !hasStructure)
-                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_STRUCTURE", 0);
-
-            if (timing.RequireStrongTrigger && !continuationSignal)
-                return Invalid(ctx, dir, "TIMING_LATE_NEEDS_STRONG_TRIGGER", 0);
-
-            int score = 30;
-
-            if (continuationSignal)
-                score += 15;
-
-            if (ctx.IsRange_M5)
-                score -= 10;
-
-            int lastClosed = ctx.M5.Count - 2;
-            var bar = ctx.M5[lastClosed];
-            bool breakoutDetected = continuationSignal || ctx.RangeBreakDirection == dir;
-            bool strongCandle =
-                (dir == TradeDirection.Long && bar.Close > bar.Open) ||
-                (dir == TradeDirection.Short && bar.Close < bar.Open);
-            bool followThrough = continuationSignal || (ctx.LastClosedBarInTrendDirection && ctx.HasReactionCandle_M5);
-
-            score = TriggerScoreModel.Apply(ctx, $"FX_IMPULSE_CONT_{dir}", score, breakoutDetected, strongCandle, followThrough, "NO_CONTINUATION_SIGNAL");
-
-
-            score = ApplyMandatoryEntryAdjustments(ctx, dir, score, true);
-            score += timing.ScoreAdjustment;
-            minScore += timing.MinScoreAdjustment;
-            score += setupScore;
-
-            if (setupScore <= 0)
-                score = System.Math.Min(score, minScore - 10);
-
-            // =====================================================
-            // SCORE → DIRECTION
-            // =====================================================
-            return new EntryEvaluation
+            var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
-                Direction = dir,
-                Score = score,
+                Direction = structureDirection,
+                Score = confirmed ? 70 : 60,
                 IsValid = true,
-                Reason =
-                    $"FX_CONT score={score} " +
-                    $"pbR={pullbackDepthR:F2} " +
-                    $"m1={(ctx.HasBreakout_M1 && ctx.BreakoutDirection == dir)}"
+                TriggerConfirmed = confirmed,
+                Reason = $"FX_IMPULSE_STRUCTURE_{entryType}"
             };
+
+            EntryDirectionQuality.LogDecision(
+                ctx,
+                Type.ToString(),
+                structureDirection == TradeDirection.Long ? eval : null,
+                structureDirection == TradeDirection.Short ? eval : null,
+                eval.Direction);
+
+            return EntryDecisionPolicy.Normalize(eval);
         }
 
-        private EntryEvaluation Invalid(EntryContext ctx, string reason)
-            => new()
-            {
-                Symbol = ctx?.Symbol,
-                Type = Type,
-                IsValid = false,
-                Reason = reason
-            };
+        private void LogStructure(EntryContext ctx)
+        {
+            ctx.Log?.Invoke(
+                $"[FX][STRUCTURE] impulse={(ctx.Structure?.HasImpulse == true).ToString().ToLowerInvariant()} pullback={(ctx.Structure?.HasPullback == true).ToString().ToLowerInvariant()} micro_pullback={(ctx.Structure?.HasMicroPullback == true).ToString().ToLowerInvariant()} flag={(ctx.Structure?.HasFlag == true).ToString().ToLowerInvariant()} direction={ctx.Structure?.StructureDirection ?? TradeDirection.None}");
+        }
 
-        private EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason, int score)
+        private EntryEvaluation Block(EntryContext ctx, string reason)
+        {
+            ctx.Log?.Invoke($"[FX][ENTRY_BLOCK] reason={reason}");
+            return Invalid(ctx, TradeDirection.None, reason);
+        }
+
+        private EntryEvaluation Invalid(EntryContext ctx, TradeDirection dir, string reason)
             => new()
             {
                 Symbol = ctx?.Symbol,
                 Type = Type,
                 Direction = dir,
-                Score = score,
+                Score = 0,
                 IsValid = false,
                 Reason = reason
             };
-
-        private static int ApplyMandatoryEntryAdjustments(EntryContext ctx, TradeDirection direction, int score, bool applyTrendRegimePenalty)
-        {
-            return EntryDirectionQuality.Apply(
-                ctx,
-                direction,
-                score,
-                new DirectionQualityRequest
-                {
-                    TypeTag = "FX_ImpulseContinuationEntry",
-                    ApplyTrendRegimePenalty = applyTrendRegimePenalty
-                });
-        }
-
     }
 }


### PR DESCRIPTION
### Motivation

- Move FX entry decisioning to a deterministic, structure-first model that enforces Impulse → Pullback → Continuation and Impulse → Pullback → Flag → Breakout flows and eliminates score-rescue, mixed triggers and direction overrides.
- Provide minimal StructureContext wiring so FX entry types can rely on a single source of truth for `HasImpulse`, `HasPullback`, `HasMicroPullback`, `HasFlag`, `StructureDirection`, `FlagBreakoutUp/Down` and continuation signals.

### Description

- Added structure fields `HasMicroPullback`, `ContinuationEarlySignal`, and `ContinuationConfirmedSignal` to `StructureContext` in `Core/Entry/EntryContext.cs` and mapped/mirrored these from pullback detection in `Core/Entry/EntryContextBuilder.cs` (including `MapStructureContinuationSignals`).
- Rewrote `EntryTypes/FX/FX_ImpulseContinuationEntry.cs` to a structure-driven gate that requires `HasImpulse && HasPullback && HasMicroPullback && (ContinuationEarlySignal || ContinuationConfirmedSignal)` and uses `StructureDirection` for direction with deterministic scores and logs; legacy score/rescue/mixed-trigger logic was removed.
- Rewrote `EntryTypes/FX/FX_FlagContinuationEntry.cs` to a structure-driven gate that requires `HasImpulse && HasPullback && HasFlag` and a direction-matching flag breakout (`FlagBreakoutUp`/`FlagBreakoutDown`), with deterministic outcome and logs; legacy heuristics and score-forcing were removed.
- Added the required debug/log messages across the new logic: `"[FX][STRUCTURE]"`, `"[FX][IMPULSE_CHECK]"`, `"[FX][IMPULSE_ENTRY]"`, `"[FX][FLAG_CHECK]"`, `"[FX][FLAG_ENTRY]"`, and unified hard blocks via `"[FX][ENTRY_BLOCK]"`.

### Testing

- Verified presence of new fields and log tokens with pattern searches using `rg` for `HasMicroPullback`, `ContinuationEarlySignal`, `ContinuationConfirmedSignal` and the new `"[FX]"` log tokens, and confirmed matches in the modified files.
- Ran repository inspection commands (`rg`, `sed`) to validate the inserted mapping and logging locations and ensured the new entry types return deterministic `EntryEvaluation` objects.
- No full build or unit test run was executed because no solution/project files (`*.sln`/`*.csproj`) were found at the repository root in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce456acd4c832888a3a7480a573292)