### PR TITLE
Register FX entries in TradeCore and add router/execution traces

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -336,9 +336,11 @@ namespace GeminiV26.Core
             {
                 _entryTypes = new List<IEntryType>
                 {
-                    // Phase 1 safe-mode runtime registration:
-                    // FX entry types remain disabled / non-executable.
+                    new FX_FlagContinuationEntry(),
+                    new FX_ImpulseContinuationEntry()
                 };
+
+                _bot.Print($"[ENTRY][REGISTER][FX] count={_entryTypes.Count}");
             }
             else if (_instrumentClass == InstrumentClass.INDEX)
             {
@@ -360,6 +362,12 @@ namespace GeminiV26.Core
                 };
             }
         
+
+            if (_entryTypes == null || _entryTypes.Count == 0)
+            {
+                _bot.Print("[ENTRY][FATAL] No entries registered → abort");
+                return;
+            }
 
             _entryRouter = new EntryRouter(_entryTypes);
             _transitionDetector = new TransitionDetector();
@@ -1177,6 +1185,7 @@ namespace GeminiV26.Core
             _ctx.DirectionDebugLogged = false;
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[PIPE][ENTRY_ROUTER_PASS] pass={_entryRouterPassCounter} symbol={_bot.SymbolName} bar={_bot.Server.Time:O}", _ctx));
             GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[ENTRY START] symbol={_bot.SymbolName} bias={_ctx.LogicBias}", _ctx));
+            _bot.Print($"[ROUTER][START] entries={_entryTypes.Count}");
 
             var signals = _entryRouter.Evaluate(new[] { _ctx });
 
@@ -1607,6 +1616,14 @@ namespace GeminiV26.Core
 
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][EXEC_PRE] sym={_bot.SymbolName} finalCtxDir={_ctx.FinalDirection}", _ctx));
                 GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][EXEC_CONFIRMED] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}", _ctx));
+
+                if (_ctx.FinalDirection == TradeDirection.None)
+                {
+                    _bot.Print("[EXECUTION][BLOCK] FinalDirection NONE");
+                    return;
+                }
+
+                _bot.Print($"[EXECUTION][DISPATCH] symbol={_bot.SymbolName} direction={_ctx.FinalDirection}");
 
                 if (!HasDirectionTraceCompleteness(_ctx))
                     GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DIR][TRACE_INCOMPLETE] sym={_bot.SymbolName} finalDir={_ctx.FinalDirection}", _ctx));


### PR DESCRIPTION
### Motivation
- Enable FX runtime entry types so FX entry evaluation can reach the router and executor pipeline. 
- Add lightweight runtime traces and a safety guard so runtime behavior is observable and the core aborts early if no entries are registered.

### Description
- Register `FX_FlagContinuationEntry` and `FX_ImpulseContinuationEntry` in the FX safe-mode block inside `Core/TradeCore.cs` and emit `[ENTRY][REGISTER][FX] count=...` when created.
- Add a fatal guard `if (_entryTypes == null || _entryTypes.Count == 0) { _bot.Print("[ENTRY][FATAL] No entries registered → abort"); return; }` immediately before `new EntryRouter(_entryTypes);`.
- Emit a router-start trace with `_bot.Print($"[ROUTER][START] entries={_entryTypes.Count}");` immediately before calling `_entryRouter.Evaluate(new[] { _ctx });`.
- Insert an execution-level safety check and dispatch trace that prints `[EXECUTION][BLOCK] FinalDirection NONE` when `_ctx.FinalDirection == TradeDirection.None` and prints `[EXECUTION][DISPATCH] symbol=... direction=...` immediately before dispatching to instrument executors.

### Testing
- Attempted build validation with `dotnet build`, but the environment does not have `dotnet` installed so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce490e3d38832898300db5fb209869)