### PR TITLE
docs: add EntryType runtime audit note (2026-04-02)

### DIFF
--- a/Documentation/AUDIT_ENTRYTYPE_RUNTIME_2026-04-02.md
+++ b/Documentation/AUDIT_ENTRYTYPE_RUNTIME_2026-04-02.md
@@ -1,0 +1,19 @@
+# EntryType Runtime Audit Notes (2026-04-02)
+
+This file records that a static runtime-reach + gating audit was performed for the active EntryType system after XAU/BTC/ETH rewrites.
+
+Primary audited files:
+- `Core/TradeCore.cs`
+- `Core/TradeRouter.cs`
+- `Core/Entry/EntryRouter.cs`
+- `Core/Entry/EntryContextBuilder.cs`
+- Active `EntryTypes/*` for FX/INDEX/METAL/CRYPTO
+
+Key finding snapshot:
+- Runtime active registration set is reduced to 8 executable families (FX:2, INDEX:2, METAL:2, CRYPTO:2 symbol-specific wrappers).
+- `XAU_Impulse` remains globally hard-skipped in `EntryRouter`.
+- Legacy `TC_* / BR_* / TR_*` types remain compiled but are not runtime-registered in current `TradeCore` setup.
+- Selection is `IsValid && TriggerConfirmed` executable-only in `TradeRouter`, with score rank + deterministic type tie-break.
+- Final acceptance still has hard vetoes: direction none, restart hard protection, overextended.
+- Confidence pipeline formula remains `0.7*EntryScore + 0.3*LogicConfidence`, but computed in `TradeCore` entry path rather than `PositionContext.ComputeFinalConfidence()` at selection point.
+


### PR DESCRIPTION
### Motivation
- Add an in-repo, auditable snapshot of the EntryType runtime-reach and gating audit performed after the XAU/BTC/ETH entry rewrites to preserve findings and reduce knowledge drift (`Documentation/AUDIT_ENTRYTYPE_RUNTIME_2026-04-02.md`).

### Description
- New documentation file `Documentation/AUDIT_ENTRYTYPE_RUNTIME_2026-04-02.md` added containing the static/runtime-reach audit summary, active registration footprint, router/TradeCore selection observations, HTF/confidence notes, and key findings after the recent entry rewrites; no production code was modified.

### Testing
- Performed repository inspection and static verification commands used during the audit: `rg` searches, `nl` file inspections (multiple `Core/*` and `EntryTypes/*` files), `find`, and `git status`; these completed successfully and the new doc was staged and committed with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce509caa648328a520dc574fe4098c)