### PR TITLE
Widen FX/INDEX flag recognition with guarded soft-gate logic

### DIFF
--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -23,41 +23,86 @@ namespace GeminiV26.EntryTypes.FX
             var direction = ctx.Structure?.StructureDirection ?? TradeDirection.None;
             bool breakoutUp = ctx.Structure?.FlagBreakoutUp == true;
             bool breakoutDown = ctx.Structure?.FlagBreakoutDown == true;
+            bool alignedBreakout = direction == TradeDirection.Long ? breakoutUp : breakoutDown;
+            bool opposingBreakout = direction == TradeDirection.Long ? breakoutDown : breakoutUp;
+            bool hasContinuationSignal = ctx.Structure?.ContinuationEarlySignal == true || ctx.Structure?.ContinuationConfirmedSignal == true;
+            int barsSinceImpulse = ctx.GetBarsSinceImpulse(direction);
+            bool hasRecentDirectionalImpulse = direction != TradeDirection.None && barsSinceImpulse >= 0 && barsSinceImpulse <= 12;
 
             ctx.Log?.Invoke(
                 $"[FX][FLAG_CHECK] impulse={hasImpulse.ToString().ToLowerInvariant()} pullback={hasPullback.ToString().ToLowerInvariant()} flag={hasFlag.ToString().ToLowerInvariant()} direction={direction} breakout_up={breakoutUp.ToString().ToLowerInvariant()} breakout_down={breakoutDown.ToString().ToLowerInvariant()}");
 
-            if (!hasImpulse)
+            if (direction != TradeDirection.Long && direction != TradeDirection.Short)
+                return Block(ctx, "NO_DIRECTION");
+
+            bool localAuthority =
+                hasPullback &&
+                hasFlag &&
+                hasContinuationSignal &&
+                (alignedBreakout || !opposingBreakout);
+
+            if (!hasImpulse && !hasRecentDirectionalImpulse)
                 return Block(ctx, "NO_IMPULSE");
 
             if (!hasPullback)
                 return Block(ctx, "NO_PULLBACK");
 
             if (!hasFlag)
-                return Block(ctx, "NO_FLAG");
+                return Block(ctx, "INVALID_FLAG");
 
-            if (direction == TradeDirection.None)
-                return Block(ctx, "NO_DIRECTION");
+            if (!alignedBreakout && !hasContinuationSignal)
+                return Block(ctx, "INVALID_FLAG");
 
-            if (direction == TradeDirection.Long && !breakoutUp)
-                return Block(ctx, "NO_BREAKOUT_UP");
-
-            if (direction == TradeDirection.Short && !breakoutDown)
-                return Block(ctx, "NO_BREAKOUT_DOWN");
-
-            if ((direction == TradeDirection.Long && breakoutDown) || (direction == TradeDirection.Short && breakoutUp))
+            if (opposingBreakout)
                 return Block(ctx, "DIRECTION_MISMATCH");
 
-            ctx.Log?.Invoke($"[FX][FLAG_ENTRY] direction={direction}");
+            var timing = ContinuationTimingGate.Evaluate(ctx, direction, Type.ToString());
+            if (!timing.IsAllowed && timing.Reason == "TIMING_SIDE_INACTIVE" && !localAuthority)
+                return Block(ctx, "TIMING_SIDE_INACTIVE");
+
+            int score = 70;
+            if (hasRecentDirectionalImpulse && !hasImpulse)
+            {
+                score -= 6;
+                ctx.Log?.Invoke($"[ENTRY][FX_FLAG][PASS] reason=RECENT_IMPULSE_FALLBACK barsSinceImpulse={barsSinceImpulse}");
+            }
+
+            if (!timing.IsAllowed && timing.Reason == "TIMING_SIDE_INACTIVE" && localAuthority)
+            {
+                score -= 8;
+                ctx.Log?.Invoke($"[ENTRY][FX_FLAG][PASS] reason=TIMING_SIDE_INACTIVE_LOCAL_AUTHORITY direction={direction}");
+            }
+            else
+            {
+                score += timing.ScoreAdjustment;
+            }
+
+            var htfDir = ctx.ResolveAssetHtfAllowedDirection();
+            bool htfMismatch =
+                htfDir != TradeDirection.None &&
+                direction != TradeDirection.None &&
+                htfDir != direction;
+
+            if (htfMismatch && !localAuthority)
+                return Block(ctx, "HTF_MISMATCH");
+
+            if (htfMismatch)
+            {
+                score -= 10;
+                ctx.Log?.Invoke($"[ENTRY][FX_FLAG][PASS] reason=HTF_MISMATCH_LOCAL_AUTHORITY htf={htfDir} dir={direction}");
+            }
+
+            score = score < 0 ? 0 : (score > 100 ? 100 : score);
+            ctx.Log?.Invoke($"[ENTRY][FX_FLAG][RECOGNIZED] direction={direction} score={score} localAuthority={localAuthority.ToString().ToLowerInvariant()}");
 
             var eval = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
                 Direction = direction,
-                Score = 70,
+                Score = score,
                 IsValid = true,
-                TriggerConfirmed = true,
+                TriggerConfirmed = alignedBreakout,
                 Reason = "FX_FLAG_STRUCTURE_CONFIRMED"
             };
 
@@ -79,7 +124,7 @@ namespace GeminiV26.EntryTypes.FX
 
         private EntryEvaluation Block(EntryContext ctx, string reason)
         {
-            ctx.Log?.Invoke($"[FX][ENTRY_BLOCK] reason={reason}");
+            ctx.Log?.Invoke($"[ENTRY][FX_FLAG][BLOCK] reason={reason}");
             return Invalid(ctx, TradeDirection.None, reason);
         }
 

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -20,51 +20,78 @@ namespace GeminiV26.EntryTypes.INDEX
             if (ctx == null || !ctx.IsReady)
                 return Reject(ctx, "CTX_NOT_READY", 0, TradeDirection.None);
 
-            if (!ctx.Structure.HasImpulse)
+            var direction = ctx.Structure.StructureDirection;
+            if (direction == TradeDirection.None)
             {
-                ctx.Log?.Invoke("[ENTRY][FLAG][STRUCTURE_ERROR] violation=no_trade_without_impulse");
-                return Reject(ctx, "no_impulse", 0, TradeDirection.None);
+                ctx.Log?.Invoke("[ENTRY][INDEX_FLAG][BLOCK] reason=NO_DIRECTION");
+                return Reject(ctx, "NO_DIRECTION", 0, TradeDirection.None);
+            }
+
+            int barsSinceImpulse = ctx.GetBarsSinceImpulse(direction);
+            bool recentDirectionalImpulse = barsSinceImpulse >= 0 && barsSinceImpulse <= 14;
+            bool hasImpulse = ctx.Structure.HasImpulse || recentDirectionalImpulse;
+            if (!hasImpulse)
+            {
+                ctx.Log?.Invoke("[ENTRY][INDEX_FLAG][BLOCK] reason=NO_IMPULSE");
+                return Reject(ctx, "NO_IMPULSE", 0, TradeDirection.None);
             }
 
             if (!ctx.Structure.HasPullback)
             {
-                ctx.Log?.Invoke("[ENTRY][FLAG][STRUCTURE_ERROR] violation=no_flag_without_pullback_retrace");
-                return Reject(ctx, "no_pullback", 0, TradeDirection.None);
+                ctx.Log?.Invoke("[ENTRY][INDEX_FLAG][BLOCK] reason=NO_PULLBACK");
+                return Reject(ctx, "NO_PULLBACK", 0, TradeDirection.None);
             }
 
-            if (!ctx.Structure.HasFlag)
+            bool hasFlag = ctx.Structure.HasFlag;
+            bool weakButUsableFlag =
+                ctx.Structure.FlagBars >= 2 &&
+                ctx.Structure.PullbackDepth <= 0.72 &&
+                ctx.Structure.FlagCompression <= 0.80;
+            if (!hasFlag && !weakButUsableFlag)
             {
-                ctx.Log?.Invoke("[ENTRY][FLAG][STRUCTURE_ERROR] violation=no_flag_entry_without_compression");
-                return Reject(ctx, "no_flag", 0, TradeDirection.None);
-            }
-
-            if (ctx.Structure.StructureDirection == TradeDirection.None)
-            {
-                ctx.Log?.Invoke("[ENTRY][FLAG][STRUCTURE_ERROR] violation=direction_must_come_from_impulse");
-                return Reject(ctx, "structure_direction_missing", 0, TradeDirection.None);
+                ctx.Log?.Invoke($"[ENTRY][INDEX_FLAG][BLOCK] reason=INVALID_FLAG flagBars={ctx.Structure.FlagBars} pullbackDepth={ctx.Structure.PullbackDepth:0.00} compression={ctx.Structure.FlagCompression:0.00}");
+                return Reject(ctx, "INVALID_FLAG", 0, TradeDirection.None);
             }
 
             bool validBreakout =
-                (ctx.Structure.StructureDirection == TradeDirection.Long && ctx.Structure.FlagBreakoutUp) ||
-                (ctx.Structure.StructureDirection == TradeDirection.Short && ctx.Structure.FlagBreakoutDown);
+                (direction == TradeDirection.Long && ctx.Structure.FlagBreakoutUp) ||
+                (direction == TradeDirection.Short && ctx.Structure.FlagBreakoutDown);
+            bool hasContinuationSignal = ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal;
 
-            if (!validBreakout)
+            bool momentumOk =
+                ctx.IsAtrExpanding_M5 ||
+                ctx.Adx_M5 >= 17.5 ||
+                hasContinuationSignal ||
+                validBreakout;
+            if (!momentumOk)
             {
-                ctx.Log?.Invoke("[ENTRY][FLAG][WAIT_BREAKOUT]");
-                return Reject(ctx, "no_breakout", 0, TradeDirection.None);
+                ctx.Log?.Invoke($"[ENTRY][INDEX_FLAG][BLOCK] reason=NO_MOMENTUM adx={ctx.Adx_M5:0.0} atrExp={ctx.IsAtrExpanding_M5.ToString().ToLowerInvariant()}");
+                return Reject(ctx, "NO_MOMENTUM", 0, TradeDirection.None);
             }
 
-            var direction = ctx.Structure.StructureDirection;
+            if (!validBreakout && !hasContinuationSignal)
+            {
+                ctx.Log?.Invoke("[ENTRY][INDEX_FLAG][BLOCK] reason=INVALID_FLAG");
+                return Reject(ctx, "INVALID_FLAG", 0, TradeDirection.None);
+            }
+
             double score01 =
                 0.5 * ctx.Structure.ImpulseStrength +
                 0.3 * (1.0 - ctx.Structure.PullbackDepth) +
                 0.2 * (1.0 - ctx.Structure.FlagCompression);
 
             int score = (int)Math.Round(100.0 * score01);
+            if (recentDirectionalImpulse && !ctx.Structure.HasImpulse)
+                score -= 8;
+            if (!validBreakout && hasContinuationSignal)
+                score -= 6;
+            if (!ctx.IsAtrExpanding_M5 && ctx.Adx_M5 < 20.0)
+                score -= 5;
+
             score += (int)Math.Round(matrix.EntryScoreModifier);
             score = Math.Max(0, Math.Min(100, score));
 
-            ctx.Log?.Invoke("[ENTRY][FLAG][BREAKOUT_CONFIRMED]");
+            ctx.Log?.Invoke($"[ENTRY][INDEX_FLAG][RECOGNIZED] direction={direction} score={score} breakout={validBreakout.ToString().ToLowerInvariant()} continuation={hasContinuationSignal.ToString().ToLowerInvariant()}");
 
             return new EntryEvaluation
             {
@@ -73,6 +100,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 Direction = direction,
                 Score = score,
                 IsValid = true,
+                TriggerConfirmed = validBreakout,
                 Reason = "STRUCTURE_IMPULSE_PULLBACK_FLAG_OK"
             };
         }


### PR DESCRIPTION
### Motivation
- Runtime audit showed `FX_FlagContinuation` and `Index_Flag` were frequently hard-blocking valid continuation setups due to strict gates (`NO_IMPULSE`, `INVALID_FLAG`, `HTF_MISMATCH`, `TIMING_SIDE_INACTIVE`, `NO_MOMENTUM`).
- The goal is to widen recognition so structurally-valid flags are recognized more often while preserving structure-first discipline and avoiding reckless entry frequency.

### Description
- `FX_FlagContinuationEntry` changes: accept a recent directional impulse fallback via `GetBarsSinceImpulse(direction) <= 12`, introduce `localAuthority` (pullback + flag + continuation signal + directional integrity) to allow controlled passes when timing/HTF are slightly off, integrate `ContinuationTimingGate` with a local-authority pass-with-penalty path for `TIMING_SIDE_INACTIVE`, convert unconditional HTF kills into conditional soft-penalties unless `localAuthority` is absent, adjust scoring/penalties and set `TriggerConfirmed` only when the breakout is aligned, and add explicit logs `[ENTRY][FX_FLAG][RECOGNIZED]` and `[ENTRY][FX_FLAG][BLOCK]` for every pass/block branch.
- `Index_FlagEntry` changes: accept recent directional impulse context (`<= 14` bars) rather than requiring immediate `HasImpulse`, allow a `weakButUsableFlag` (e.g. `FlagBars >= 2` with bounded depth/compression) rather than requiring textbook geometry, relax momentum gating to accept `IsAtrExpanding_M5` or `Adx_M5` or continuation signal or valid breakout and otherwise block as `NO_MOMENTUM`, apply modest score penalties on softened paths and mark `TriggerConfirmed` only when a real breakout exists, and add explicit logs `[ENTRY][INDEX_FLAG][RECOGNIZED]` and `[ENTRY][INDEX_FLAG][BLOCK]`.
- Scope was intentionally narrow and limited to `EntryTypes/FX/FX_FlagContinuationEntry.cs` and `EntryTypes/INDEX/Index_FlagEntry.cs`, with no changes to risk, exit, analytics, session architecture, or broad `TradeCore` flow.

### Testing
- Attempted an automated build with `dotnet build -v minimal`, but the environment lacks the SDK and the command failed with `/bin/bash: dotnet: command not found`, so no compile or unit-test run was performed.
- No other automated tests were executed in this environment; changes are intentionally small and structured to be low-risk but should be validated with a full CI build and short backtest/run verifying candidate rates and winner conversion quality before rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce60fe5d9483289bf558249bedcf78)