### PR TITLE
Relax crypto flag/pullback gating to improve BTC/ETH candidate survival

### DIFF
--- a/EntryTypes/CRYPTO/CryptoFlagEntryBase.cs
+++ b/EntryTypes/CRYPTO/CryptoFlagEntryBase.cs
@@ -13,39 +13,53 @@ namespace GeminiV26.EntryTypes.Crypto
         protected abstract int MaxBarsSinceImpulse { get; }
         protected abstract int MaxLateBreakoutBars { get; }
         protected abstract double MinImpulseStrength { get; }
+        protected virtual int MaxImpulseMemoryBars => MaxBarsSinceImpulse + 2;
+        protected virtual int MaxBreakoutPersistenceBars => MaxLateBreakoutBars + 1;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             DirectionDebug.LogOnce(ctx);
 
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 20)
-                return Reject(ctx, TradeDirection.None, "CTX_NOT_READY", "[ENTRY][CRYPTO_FLAG][BLOCK_CTX]");
+                return Reject(ctx, TradeDirection.None, "CTX_NOT_READY");
 
             TradeDirection dir = ResolveDirection(ctx);
             if (dir == TradeDirection.None)
-                return Reject(ctx, TradeDirection.None, "NO_VALID_DIRECTION", "[DIR][CRYPTO_ENTRY][INVALID_NONE]");
+                return Reject(ctx, TradeDirection.None, "NO_VALID_DIRECTION");
 
             if (!ctx.Structure.HasImpulse || !ctx.Structure.HasFlag)
-                return Reject(ctx, dir, "NO_FLAG_STRUCTURE", "[ENTRY][CRYPTO_FLAG][BLOCK_STRUCTURE]");
+                return Reject(ctx, dir, "INVALID_STRUCTURE");
 
             int barsSinceImpulse = dir == TradeDirection.Long ? ctx.BarsSinceImpulseLong : ctx.BarsSinceImpulseShort;
-            if (barsSinceImpulse < 0 || barsSinceImpulse > MaxBarsSinceImpulse)
-                return Reject(ctx, dir, "LATE_FLAG", "[ENTRY][CRYPTO_FLAG][LATE_BLOCK]");
+            if (barsSinceImpulse < 0)
+                return Reject(ctx, dir, "NO_RECENT_IMPULSE");
+
+            if (barsSinceImpulse > MaxImpulseMemoryBars)
+                return Reject(ctx, dir, "LATE_FLAG");
 
             bool breakoutConfirmed = dir == TradeDirection.Long
                 ? (ctx.FlagBreakoutUpConfirmed || ctx.Structure.FlagBreakoutUp)
                 : (ctx.FlagBreakoutDownConfirmed || ctx.Structure.FlagBreakoutDown);
 
             int breakoutBarsSince = dir == TradeDirection.Long ? ctx.BreakoutUpBarsSince : ctx.BreakoutDownBarsSince;
+            bool continuationSignal = ctx.Structure.ContinuationConfirmedSignal || ctx.RangeBreakDirection == dir;
+            bool hasTrendFollowThrough = ctx.LastClosedBarInTrendDirection || ctx.HasReactionCandle_M5 || ctx.M1TriggerInTrendDirection;
 
             bool persistenceOk =
-                breakoutConfirmed &&
-                breakoutBarsSince <= MaxLateBreakoutBars &&
-                ctx.LastClosedBarInTrendDirection &&
-                (ctx.HasReactionCandle_M5 || ctx.M1TriggerInTrendDirection);
+                ((breakoutConfirmed && breakoutBarsSince <= MaxBreakoutPersistenceBars) ||
+                 (continuationSignal && breakoutBarsSince <= MaxLateBreakoutBars)) &&
+                hasTrendFollowThrough;
 
             if (!persistenceOk)
-                return Reject(ctx, dir, "BREAKOUT_NOT_PERSISTENT", "[ENTRY][CRYPTO_FLAG][LATE_BLOCK]");
+                return Reject(ctx, dir, "LATE_FLAG");
+
+            bool structureValid =
+                ctx.Structure.FlagCompression <= 0.62 ||
+                ctx.Structure.ContinuationConfirmedSignal ||
+                ctx.M1TriggerInTrendDirection ||
+                ctx.HasReactionCandle_M5;
+            if (!structureValid)
+                return Reject(ctx, dir, "INVALID_STRUCTURE");
 
             bool fakeBreak =
                 ctx.RangeFakeoutBars_M1 <= 2 ||
@@ -53,9 +67,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 (ctx.Structure.ImpulseStrength < MinImpulseStrength && !ctx.M1TriggerInTrendDirection);
 
             if (fakeBreak)
-                return Reject(ctx, dir, "FAKE_BREAKOUT", "[ENTRY][CRYPTO_FLAG][FAKEBREAK_BLOCK]");
-
-            ctx.Log?.Invoke("[ENTRY][CRYPTO_FLAG][PERSISTENCE_OK]");
+                return Reject(ctx, dir, "FAKE_BREAKOUT");
 
             int score = 62;
             if (ctx.Structure.ImpulseStrength >= 0.6)
@@ -66,7 +78,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 score += 8;
             score = Math.Max(0, Math.Min(100, score));
 
-            return new EntryEvaluation
+            var evaluation = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
@@ -75,6 +87,8 @@ namespace GeminiV26.EntryTypes.Crypto
                 Score = score,
                 Reason = $"{SymbolTag}_FLAG_STRUCTURE_FIRST_OK"
             };
+            ctx.Log?.Invoke($"[ENTRY][CRYPTO_FLAG][RECOGNIZED] symbol={ctx.Symbol} dir={dir} reason={evaluation.Reason} barsSinceImpulse={barsSinceImpulse} breakoutBarsSince={breakoutBarsSince} impulseStrength={ctx.Structure.ImpulseStrength:0.00} compression={ctx.Structure.FlagCompression:0.00}");
+            return evaluation;
         }
 
         private TradeDirection ResolveDirection(EntryContext ctx)
@@ -100,9 +114,9 @@ namespace GeminiV26.EntryTypes.Crypto
             return inputLogic;
         }
 
-        protected EntryEvaluation Reject(EntryContext ctx, TradeDirection dir, string reason, string log)
+        protected EntryEvaluation Reject(EntryContext ctx, TradeDirection dir, string reason)
         {
-            ctx?.Log?.Invoke(log);
+            ctx?.Log?.Invoke($"[ENTRY][CRYPTO_FLAG][BLOCK] symbol={ctx?.Symbol} dir={dir} reason={reason}");
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,

--- a/EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs
+++ b/EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs
@@ -12,40 +12,58 @@ namespace GeminiV26.EntryTypes.Crypto
         protected abstract string SymbolTag { get; }
         protected abstract int MaxBarsSinceImpulse { get; }
         protected abstract double MaxPullbackDepth { get; }
+        protected virtual double MinFuelAtr => 0.30;
+        protected virtual double MinFuelImpulseStrength => 0.34;
 
         public EntryEvaluation Evaluate(EntryContext ctx)
         {
             DirectionDebug.LogOnce(ctx);
 
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < 20)
-                return Reject(ctx, TradeDirection.None, "CTX_NOT_READY", "[ENTRY][CRYPTO_PB][BLOCK_CTX]");
+                return Reject(ctx, TradeDirection.None, "CTX_NOT_READY");
 
             TradeDirection dir = ResolveDirection(ctx);
             if (dir == TradeDirection.None)
-                return Reject(ctx, TradeDirection.None, "NO_VALID_DIRECTION", "[DIR][CRYPTO_ENTRY][INVALID_NONE]");
+                return Reject(ctx, TradeDirection.None, "NO_VALID_DIRECTION");
 
             if (!ctx.Structure.HasImpulse || !ctx.Structure.HasPullback)
-                return Reject(ctx, dir, "NO_PULLBACK_STRUCTURE", "[ENTRY][CRYPTO_PB][BLOCK_STRUCTURE]");
+                return Reject(ctx, dir, "NO_PULLBACK_STRUCTURE");
 
             int attempts = dir == TradeDirection.Long ? ctx.ContinuationAttemptCountLong : ctx.ContinuationAttemptCountShort;
             if (attempts > 0)
-                return Reject(ctx, dir, "REFIRE_BLOCK", "[ENTRY][CRYPTO_PB][REFIRE_BLOCK]");
+                return Reject(ctx, dir, "REFIRE_BLOCK");
 
             int barsSinceImpulse = dir == TradeDirection.Long ? ctx.BarsSinceImpulseLong : ctx.BarsSinceImpulseShort;
             if (barsSinceImpulse < 0 || barsSinceImpulse > MaxBarsSinceImpulse)
-                return Reject(ctx, dir, "STALE_PULLBACK", "[ENTRY][CRYPTO_PB][BLOCK_STALE]");
+                return Reject(ctx, dir, "STALE_PULLBACK");
 
-            bool unstableTransition = ctx.IsTransition_M5 && (!ctx.IsVolatilityAcceptable_Crypto || !ctx.IsAtrExpanding_M5);
+            TradeDirection impulseDirection = ctx.ImpulseDirection == TradeDirection.None ? dir : ctx.ImpulseDirection;
+            bool immediateCounter = barsSinceImpulse <= 0 && impulseDirection != dir;
+            if (immediateCounter)
+                return Reject(ctx, dir, "IMPULSE_LOCK_IMMEDIATE_COUNTER");
+
+            double fuelAtr = Math.Max(0.0, ctx.TotalMoveSinceBreakAtr);
+            bool hasFuel =
+                fuelAtr >= MinFuelAtr ||
+                ctx.Structure.ImpulseStrength >= MinFuelImpulseStrength ||
+                (ctx.IsAtrExpanding_M5 && ctx.Structure.ContinuationConfirmedSignal);
+            if (!hasFuel)
+                return Reject(ctx, dir, "CRYPTO_PULLBACK_NO_FUEL");
+
+            bool unstableTransition = ctx.IsTransition_M5 && !ctx.IsVolatilityAcceptable_Crypto && !ctx.IsAtrExpanding_M5;
             if (unstableTransition)
-                return Reject(ctx, dir, "VOL_TRANSITION_BLOCK", "[ENTRY][CRYPTO_PB][VOL_TRANSITION_BLOCK]");
+                return Reject(ctx, dir, "VOL_TRANSITION_BLOCK");
 
+            int maturitySignals = 0;
+            if (ctx.IsPullbackDecelerating_M5) maturitySignals++;
+            if (ctx.HasReactionCandle_M5) maturitySignals++;
+            if (ctx.LastClosedBarInTrendDirection) maturitySignals++;
             bool pullbackComplete =
                 ctx.Structure.PullbackConfirmedSignal ||
-                (ctx.IsPullbackDecelerating_M5 && ctx.HasReactionCandle_M5 && ctx.LastClosedBarInTrendDirection);
+                maturitySignals >= 2 ||
+                (barsSinceImpulse >= 3 && maturitySignals >= 1);
             if (!pullbackComplete)
-                return Reject(ctx, dir, "PULLBACK_NOT_COMPLETE", "[ENTRY][CRYPTO_PB][BLOCK_INCOMPLETE]");
-
-            ctx.Log?.Invoke("[ENTRY][CRYPTO_PB][COMPLETE_OK]");
+                return Reject(ctx, dir, "PULLBACK_NOT_MATURE");
 
             bool directionalBreak =
                 (dir == TradeDirection.Long && (ctx.Structure.FlagBreakoutUp || ctx.FlagBreakoutUpConfirmed || ctx.RangeBreakDirection == TradeDirection.Long)) ||
@@ -53,19 +71,19 @@ namespace GeminiV26.EntryTypes.Crypto
                 ctx.Structure.ContinuationConfirmedSignal;
 
             if (!directionalBreak)
-                return Reject(ctx, dir, "NO_DIRECTIONAL_CONTINUATION_BREAK", "[ENTRY][CRYPTO_PB][BLOCK_DIR_BREAK]");
-
-            ctx.Log?.Invoke("[ENTRY][CRYPTO_PB][DIR_BREAK_OK]");
+                return Reject(ctx, dir, "NO_DIRECTIONAL_CONTINUATION_BREAK");
 
             bool stackedOverlap =
                 ctx.Structure.PullbackConfirmedSignal &&
                 ctx.Structure.ContinuationConfirmedSignal &&
-                (ctx.RangeBreakDirection == dir);
+                (ctx.RangeBreakDirection == dir) &&
+                !ctx.M1TriggerInTrendDirection &&
+                !ctx.LastClosedBarInTrendDirection;
             if (stackedOverlap)
-                return Reject(ctx, dir, "OVERLAP_STACK_BLOCK", "[ENTRY][CRYPTO_PB][BLOCK_OVERLAP]");
+                return Reject(ctx, dir, "OVERLAP_STACK_BLOCK");
 
             if (ctx.Structure.PullbackDepth <= 0 || ctx.Structure.PullbackDepth > MaxPullbackDepth)
-                return Reject(ctx, dir, "PULLBACK_DEPTH_INVALID", "[ENTRY][CRYPTO_PB][BLOCK_DEPTH]");
+                return Reject(ctx, dir, "PULLBACK_DEPTH_INVALID");
 
             int score = 64;
             if (ctx.Structure.PullbackConfirmedSignal)
@@ -76,7 +94,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 score += 6;
             score = Math.Max(0, Math.Min(100, score));
 
-            return new EntryEvaluation
+            var evaluation = new EntryEvaluation
             {
                 Symbol = ctx.Symbol,
                 Type = Type,
@@ -85,6 +103,8 @@ namespace GeminiV26.EntryTypes.Crypto
                 Score = score,
                 Reason = $"{SymbolTag}_PULLBACK_STRUCTURE_FIRST_OK"
             };
+            ctx.Log?.Invoke($"[ENTRY][CRYPTO_PB][RECOGNIZED] symbol={ctx.Symbol} dir={dir} reason={evaluation.Reason} barsSinceImpulse={barsSinceImpulse} fuelAtr={fuelAtr:0.00} impulseStrength={ctx.Structure.ImpulseStrength:0.00} maturitySignals={maturitySignals} pullbackDepth={ctx.Structure.PullbackDepth:0.00}");
+            return evaluation;
         }
 
         private TradeDirection ResolveDirection(EntryContext ctx)
@@ -110,9 +130,9 @@ namespace GeminiV26.EntryTypes.Crypto
             return inputLogic;
         }
 
-        protected EntryEvaluation Reject(EntryContext ctx, TradeDirection dir, string reason, string log)
+        protected EntryEvaluation Reject(EntryContext ctx, TradeDirection dir, string reason)
         {
-            ctx?.Log?.Invoke(log);
+            ctx?.Log?.Invoke($"[ENTRY][CRYPTO_PB][BLOCK] symbol={ctx?.Symbol} dir={dir} reason={reason}");
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,


### PR DESCRIPTION
### Motivation
- Runtime audits showed BTC/ETH flag and pullback candidates were being over-filtered at evaluation with reasons like `LATE_FLAG`, `INVALID_STRUCTURE`, `NO_RECENT_IMPULSE`, `CRYPTO_PULLBACK_NO_FUEL` and maturity/lock gates causing most candidates to be blocked. 
- The goal was to relax evaluate-stage gates just enough so real crypto continuations survive, while preserving anti-fake-break, anti-refire, and immediate-counter protections. 
- Changes must stay narrowly scoped to base crypto flag/pullback logic and avoid broad architecture refactors or turning crypto entries into loose score-based spam. 

### Description
- Relaxed base flag logic in `EntryTypes/CRYPTO/CryptoFlagEntryBase.cs` by adding modest impulse-memory/persistence slack (`MaxImpulseMemoryBars`, `MaxBreakoutPersistenceBars`), splitting stale diagnostics into `NO_RECENT_IMPULSE` vs `LATE_FLAG`, permitting continuation-confirmed paths with bounded breakout age, and softening structure acceptance while keeping fake-break protections; added `[ENTRY][CRYPTO_FLAG][RECOGNIZED]` and unified block logs under `[ENTRY][CRYPTO_FLAG][BLOCK]`. 
- Relaxed base pullback logic in `EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs` by introducing a modest multi-path fuel check (`MinFuelAtr`, `MinFuelImpulseStrength`) and an explicit immediate-counter lock only for true immediate opposite attempts, tightening transition blocking to require both low crypto volatility and non-expanding ATR, and changing maturity to allow 2-of-3 signals (or 1 signal once slightly older); added `[ENTRY][CRYPTO_PB][RECOGNIZED]` and unified block logs under `[ENTRY][CRYPTO_PB][BLOCK]`. 
- Kept one-attempt-per-impulse/refire protection, overlap/volatility safety, and fake-break protections intact but scoped to avoid suppressing legitimate candidates. 
- No BTC/ETH-specific files were modified; symbol-specific thresholds remain available for later tuning if needed. 

### Testing
- Attempted to run `dotnet build`, which failed in this environment with `dotnet: command not found`, so a full compile/test run was not performed. 
- No automated unit or integration tests were executed in this environment; recommend running a full `dotnet build` and the existing test suite in CI and monitoring runtime audit logs for changes in reason distributions (notably `LATE_FLAG`, `INVALID_STRUCTURE`, `NO_RECENT_IMPULSE`, `CRYPTO_PULLBACK_NO_FUEL`, and `PULLBACK_NOT_MATURE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce641e5dc88328bcf0198622a46dcf)