### PR TITLE
Index_Pullback: narrow post-selection qualification to avoid redundant vetoes

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -3479,6 +3479,15 @@ namespace GeminiV26.Core
             if (ctx == null || eval == null)
                 return false;
 
+            if (eval.Type == EntryType.Index_Pullback)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[ENTRY][INDEX_PB][ACCEPTED] symbol={eval.Symbol ?? ctx.Symbol ?? _bot.SymbolName} dir={eval.Direction} score={eval.Score} trigger={eval.TriggerConfirmed.ToString().ToLowerInvariant()} state={eval.State} reason={eval.Reason ?? "NA"}");
+
+                if (!PassIndexPullbackQualification(ctx, eval))
+                    return false;
+            }
+
             if (eval.Direction == TradeDirection.None)
             {
                 GlobalLogger.Log(_bot, "[FA][INTEGRITY_BLOCK] reason=DIRECTION_NONE");
@@ -3501,6 +3510,69 @@ namespace GeminiV26.Core
             }
 
             GlobalLogger.Log(_bot, "[FINAL][DECISION] decision=ALLOW reason=PASS");
+            return true;
+        }
+
+        private bool PassIndexPullbackQualification(EntryContext ctx, EntryEvaluation eval)
+        {
+            int barsSinceBreak = GetBarsSinceBreak(ctx, eval.Direction);
+            bool hasDirectionalPullback = ctx.HasDirectionalPullback(eval.Direction);
+            bool decelerating = ctx.IsPullbackDecelerating_M5;
+            bool reactionCandle = ctx.HasReactionCandle_M5;
+            double tq = eval.Direction == TradeDirection.Long
+                ? (ctx.TransitionLong?.QualityScore01 ?? ctx.Transition?.QualityScore01 ?? 0.0)
+                : eval.Direction == TradeDirection.Short
+                    ? (ctx.TransitionShort?.QualityScore01 ?? ctx.Transition?.QualityScore01 ?? 0.0)
+                    : (ctx.Transition?.QualityScore01 ?? 0.0);
+            double pullbackDepthR = eval.Direction == TradeDirection.Long
+                ? ctx.PullbackDepthRLong_M5
+                : eval.Direction == TradeDirection.Short
+                    ? ctx.PullbackDepthRShort_M5
+                    : 0.0;
+
+            bool redundantEarlyVeto = ContainsAny(eval.Reason, "EARLY_BREAK", "PULLBACK_TOO_EARLY", "TOO_EARLY");
+            bool redundantDepthVeto = ContainsAny(eval.Reason, "PULLBACK_DEPTH", "TOO_SHALLOW", "PULLBACK_TOO_SHALLOW");
+            bool redundantTransitionVeto = ContainsAny(eval.Reason, "TRANSITION", "COLLAPSE");
+
+            if (barsSinceBreak <= 0 && !decelerating && !reactionCandle)
+            {
+                if (!eval.TriggerConfirmed)
+                {
+                    GlobalLogger.Log(_bot,
+                        $"[ENTRY][INDEX_PB][QUAL_BLOCK] reason=TOO_EARLY barsSinceBreak={barsSinceBreak} trigger={eval.TriggerConfirmed.ToString().ToLowerInvariant()} decelerating={decelerating.ToString().ToLowerInvariant()} reactionCandle={reactionCandle.ToString().ToLowerInvariant()} redundantSecondStage={redundantEarlyVeto.ToString().ToLowerInvariant()}");
+                    return false;
+                }
+
+                int before = eval.Score;
+                eval.Score = Math.Max(0, eval.Score - 4);
+                GlobalLogger.Log(_bot,
+                    $"[ENTRY][INDEX_PB][QUAL_ALLOW] reason=TOO_EARLY_SOFT barsSinceBreak={barsSinceBreak} trigger={eval.TriggerConfirmed.ToString().ToLowerInvariant()} decelerating={decelerating.ToString().ToLowerInvariant()} reactionCandle={reactionCandle.ToString().ToLowerInvariant()} score={before}->{eval.Score} redundantSecondStage={redundantEarlyVeto.ToString().ToLowerInvariant()}");
+            }
+
+            bool collapse = tq < 0.24 && !decelerating && !reactionCandle && !hasDirectionalPullback;
+            if (collapse)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[ENTRY][INDEX_PB][QUAL_BLOCK] reason=TRANSITION_COLLAPSE tq={tq:0.00} hasDirectionalPullback={hasDirectionalPullback.ToString().ToLowerInvariant()} decelerating={decelerating.ToString().ToLowerInvariant()} reactionCandle={reactionCandle.ToString().ToLowerInvariant()} redundantSecondStage={redundantTransitionVeto.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            if (tq < 0.30)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[ENTRY][INDEX_PB][QUAL_ALLOW] reason=TRANSITION_COOLING tq={tq:0.00} hasDirectionalPullback={hasDirectionalPullback.ToString().ToLowerInvariant()} decelerating={decelerating.ToString().ToLowerInvariant()} reactionCandle={reactionCandle.ToString().ToLowerInvariant()} redundantSecondStage={redundantTransitionVeto.ToString().ToLowerInvariant()}");
+            }
+
+            bool shallow = pullbackDepthR > 0 && pullbackDepthR < 0.10 && !decelerating && !reactionCandle && !hasDirectionalPullback;
+            if (shallow && !redundantDepthVeto)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[ENTRY][INDEX_PB][QUAL_BLOCK] reason=PULLBACK_TOO_SHALLOW pullbackDepthR={pullbackDepthR:0.000} hasDirectionalPullback={hasDirectionalPullback.ToString().ToLowerInvariant()} decelerating={decelerating.ToString().ToLowerInvariant()} reactionCandle={reactionCandle.ToString().ToLowerInvariant()} redundantSecondStage={redundantDepthVeto.ToString().ToLowerInvariant()}");
+                return false;
+            }
+
+            GlobalLogger.Log(_bot,
+                $"[ENTRY][INDEX_PB][QUAL_ALLOW] reason=PASS tq={tq:0.00} pullbackDepthR={pullbackDepthR:0.000} barsSinceBreak={barsSinceBreak} hasDirectionalPullback={hasDirectionalPullback.ToString().ToLowerInvariant()} decelerating={decelerating.ToString().ToLowerInvariant()} reactionCandle={reactionCandle.ToString().ToLowerInvariant()} redundantTooEarly={redundantEarlyVeto.ToString().ToLowerInvariant()} redundantTransition={redundantTransitionVeto.ToString().ToLowerInvariant()} redundantShallow={redundantDepthVeto.ToString().ToLowerInvariant()}");
             return true;
         }
 


### PR DESCRIPTION
### Motivation
- Accepted `Index_Pullback` candidates were reaching ACCEPT but later being killed by redundant/over-aggressive post-selection qualification (`TOO_EARLY`, `TRANSITION_COLLAPSE`, `PULLBACK_TOO_SHALLOW`).
- The change addresses only the post-selection qualification path for `Index_Pullback` to let legitimate accepted setups proceed toward execution while preserving anti-bad-trade protections.

### Description
- Added an Index_Pullback-only post-selection gate called from `PassFinalAcceptance` and implemented in a new helper `PassIndexPullbackQualification(...)` (file modified: `Core/TradeCore.cs`).
- TOO_EARLY: hard-block only when truly untriggered and structurally immature (`barsSinceBreak <= 0 && !decelerating && !reactionCandle`); otherwise apply a small soft penalty and allow continuation.
- TRANSITION_COLLAPSE: reserved for genuine collapse (`tq < 0.24 && no deceleration && no reaction && no directional pullback`); mild low-TQ (`tq < 0.30`) is treated as cooling and logged, not a hard kill.
- PULLBACK_TOO_SHALLOW: hard-block only when genuinely shallow and not previously depth-vetoed upstream (detects redundant second-stage veto via reason tokens); avoid double-gating accepted setups.
- Added explicit diagnostic logs for accepted pullbacks and qualification outcomes: `[ENTRY][INDEX_PB][ACCEPTED]`, `[ENTRY][INDEX_PB][QUAL_BLOCK]`, and `[ENTRY][INDEX_PB][QUAL_ALLOW]` with raw values and a `redundantSecondStage` flag.
- Scope kept minimal and local: only `Core/TradeCore.cs` modified; no changes to other entry families, execution, risk, exit, or session subsystems.

### Testing
- Attempted to build: ran `dotnet build -v minimal`, but the environment lacks the SDK (`dotnet: command not found`), so no compiled/test run was performed.
- Code was compiled for syntax locally not possible here; change is small and limited to safe checks and logging, so manual review and a CI build + runtime smoke test are required before production rollout.
- Recommended follow-ups: run full `dotnet build`/unit tests and a short live-capture to confirm accepted `Index_Pullback` flows now reach executor and that the new logs appear as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce65edc7cc8328bc48e5cfa32d1e93)