### PR TITLE
Stabilize crypto eval direction, ETH direct registration, and canonical reject codes

### DIFF
--- a/Core/RuntimeSymbolResolver.cs
+++ b/Core/RuntimeSymbolResolver.cs
@@ -71,7 +71,7 @@ namespace GeminiV26.Core
 
             if (!IsGeminiSupportedCanonical(canonical))
             {
-                GlobalLogger.Log(_bot, $"[RESOLVER][SKIP] reason=unsupported_canonical canonical={canonical}");
+                GlobalLogger.Log(_bot, $"[RESOLVER][SKIP][CODE=SYMBOL_UNSUPPORTED] detail=unsupported_canonical canonical={canonical}");
                 _cycleCache[requested] = null;
                 return false;
             }

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -330,20 +330,22 @@ namespace GeminiV26.Core
                         new BTC_PullbackEntry()
                     };
 
-                    _bot.Print($"[ENTRY][REGISTER][CRYPTO][BTC] raw={rawSymbol} resolved={resolvedSymbol} count={_entryTypes.Count}");
+                    _bot.Print($"[ENTRY][REGISTER][CRYPTO][BTC] raw={rawSymbol} normalized={resolvedSymbol} resolvedClass={nameof(InstrumentClass.CRYPTO)} entryTypes={string.Join(",", _entryTypes.Select(x => x.GetType().Name))} count={_entryTypes.Count}");
                 }
                 else if (string.Equals(resolvedSymbol, "ETHUSD", StringComparison.OrdinalIgnoreCase))
                 {
-                    _entryTypes = new List<IEntryType>();
-                    TryAddCryptoEntryType(_entryTypes, "GeminiV26.EntryTypes.Crypto.ETH_FlagEntry");
-                    TryAddCryptoEntryType(_entryTypes, "GeminiV26.EntryTypes.Crypto.ETH_PullbackEntry");
+                    _entryTypes = new List<IEntryType>
+                    {
+                        new ETH_FlagEntry(),
+                        new ETH_PullbackEntry()
+                    };
 
-                    _bot.Print($"[ENTRY][REGISTER][CRYPTO][ETH] raw={rawSymbol} resolved={resolvedSymbol} count={_entryTypes.Count}");
+                    _bot.Print($"[ENTRY][REGISTER][CRYPTO][ETH] raw={rawSymbol} normalized={resolvedSymbol} resolvedClass={nameof(InstrumentClass.CRYPTO)} entryTypes={string.Join(",", _entryTypes.Select(x => x.GetType().Name))} count={_entryTypes.Count}");
                 }
                 else
                 {
                     _entryTypes = new List<IEntryType>();
-                    _bot.Print($"[ENTRY][REGISTER][CRYPTO][UNSUPPORTED] raw={rawSymbol} resolved={resolvedSymbol} count={_entryTypes.Count}");
+                    _bot.Print($"[ENTRY][REGISTER][CRYPTO][UNSUPPORTED] raw={rawSymbol} normalized={resolvedSymbol} resolvedClass={nameof(InstrumentClass.UNKNOWN)} entryTypes=none count={_entryTypes.Count}");
                 }
             }
 
@@ -1449,7 +1451,7 @@ namespace GeminiV26.Core
 
                 if (selected == null)
                 {
-                    GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[DECISION][REJECT_FINAL] reason=NO_SELECTED_ENTRY", _ctx));
+                    LogFinalReject("ROUTER_NO_CANDIDATE", "no_selected_entry", _ctx);
                     if (isFxSymbol)
                     {
                         fxValidFinalCount = symbolSignals.Count(x => IsFxCandidate(x) && x != null && x.IsValid);
@@ -1458,7 +1460,7 @@ namespace GeminiV26.Core
                     }
                     GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId(
                         $"[ENTRY_TRACE][FINAL] symbol={_bot.SymbolName} entryType=None stage=FINAL candidateDirection={TradeDirection.None} score=NA classification=HTF_NO_DIRECTION " +
-                        $"finalCandidateDirection={TradeDirection.None} finalScore=NA blocked=true finalReason=NO_SELECTED_ENTRY",
+                        $"finalCandidateDirection={TradeDirection.None} finalScore=NA blocked=true finalReason=ROUTER_NO_CANDIDATE",
                         _ctx));
                     GlobalLogger.Log(_bot, "BLOCK: entry gate");
                     GlobalLogger.Log(_bot, "[TC] NO SELECTED ENTRY (all invalid)");
@@ -1655,7 +1657,7 @@ namespace GeminiV26.Core
 
                 if (_ctx.FinalDirection == TradeDirection.None)
                 {
-                    GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[EXEC][ABORT] reason=FINAL_DIRECTION_NONE", _ctx));
+                    GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[EXEC][ABORT][CODE=FINAL_DIRECTION_NONE] detail=final_direction_none", _ctx));
                     _bot.Print("[EXECUTION][BLOCK] FinalDirection NONE");
                     return;
                 }
@@ -1676,7 +1678,7 @@ namespace GeminiV26.Core
                 var currentEquity = _bot.Account.Equity;
                 if (!_globalRiskGuard.CanTrade(currentEquity, utcNowRisk))
                 {
-                    GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[EXEC][ABORT] reason=RISK_GUARD", _ctx));
+                    GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[EXEC][ABORT][CODE=EXEC_RISK_GUARD_BLOCK] detail=risk_guard", _ctx));
                     GlobalLogger.Log(_bot, "[RISK][DD_BLOCK] Daily DD limit reached");
                     return;
                 }
@@ -1994,7 +1996,7 @@ namespace GeminiV26.Core
         {
             if (entryContext == null || entry == null)
             {
-                GlobalLogger.Log(_bot, "[DECISION][REJECT_FINAL] reason=DIRECTION_CONSISTENCY_NULL");
+                LogFinalReject("CONTEXT_NOT_READY", "direction_consistency_null");
                 GlobalLogger.Log(_bot, $"[DIR][FATAL_MISMATCH] type=null_context_or_entry sym={_bot.SymbolName}");
                 GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
                 return false;
@@ -2002,7 +2004,7 @@ namespace GeminiV26.Core
 
             if (entryContext.FinalDirection == TradeDirection.None)
             {
-                GlobalLogger.Log(_bot, "[DECISION][REJECT_FINAL] reason=DIRECTION_CONSISTENCY_FINAL_NONE");
+                LogFinalReject("FINAL_DIRECTION_NONE", "direction_consistency_final_none");
                 GlobalLogger.Log(_bot,
                     $"[DIR][FATAL_MISMATCH] type=final_none entry={entry.Direction} routed={entryContext.RoutedDirection} final={entryContext.FinalDirection} sym={_bot.SymbolName}");
                 GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
@@ -2012,7 +2014,7 @@ namespace GeminiV26.Core
             if (entryContext.RoutedDirection != TradeDirection.None &&
                 entryContext.RoutedDirection != entryContext.FinalDirection)
             {
-                GlobalLogger.Log(_bot, "[DECISION][REJECT_FINAL] reason=DIRECTION_CONSISTENCY_ROUTED_MISMATCH");
+                LogFinalReject("FINAL_ROUTED_MISMATCH", "direction_consistency_routed_mismatch");
                 GlobalLogger.Log(_bot,
                     $"[DIR][FATAL_MISMATCH] type=routed_vs_final entry={entry.Direction} routed={entryContext.RoutedDirection} final={entryContext.FinalDirection} sym={_bot.SymbolName}");
                 GlobalLogger.Log(_bot, "[TC] ENTRY BLOCKED: direction consistency check failed");
@@ -3493,37 +3495,11 @@ namespace GeminiV26.Core
             }
         }
 
-        private void TryAddCryptoEntryType(List<IEntryType> target, string typeName)
-        {
-            Type resolvedType =
-                Type.GetType(typeName) ??
-                Type.GetType($"{typeName}, GeminiV26") ??
-                AppDomain.CurrentDomain
-                    .GetAssemblies()
-                    .Select(a => a.GetType(typeName))
-                    .FirstOrDefault(t => t != null);
-
-            if (resolvedType == null)
-            {
-                _bot?.Print($"[ENTRY][REGISTER][CRYPTO][MISSING] type={typeName}");
-                return;
-            }
-
-            if (!typeof(IEntryType).IsAssignableFrom(resolvedType))
-            {
-                _bot?.Print($"[ENTRY][REGISTER][CRYPTO][INVALID] type={typeName} reason=NotIEntryType");
-                return;
-            }
-
-            if (Activator.CreateInstance(resolvedType) is IEntryType entry)
-                target.Add(entry);
-        }
-
         private bool PassFinalAcceptance(EntryContext ctx, EntryEvaluation eval)
         {
             if (ctx == null || eval == null)
             {
-                GlobalLogger.Log(_bot, "[DECISION][REJECT_FINAL] reason=NULL_CONTEXT_OR_EVAL");
+                LogFinalReject("CONTEXT_NOT_READY", "null_context_or_eval");
                 return false;
             }
 
@@ -3535,19 +3511,19 @@ namespace GeminiV26.Core
 
             if (eval.Direction == TradeDirection.None)
             {
-                GlobalLogger.Log(_bot, "[DECISION][REJECT_FINAL] reason=DIRECTION_NONE");
+                LogFinalReject("CONTEXT_DIRECTION_NONE", "direction_none");
                 return false;
             }
 
             if (BotRestartState.IsHardProtectionPhase)
             {
-                GlobalLogger.Log(_bot, "[DECISION][REJECT_FINAL] reason=RESTART_HARD_PROTECTION");
+                LogFinalReject("QUAL_RESTART_HARD_PROTECTION", "restart_hard_protection");
                 return false;
             }
 
             if (ctx.IsOverextendedLong || ctx.IsOverextendedShort)
             {
-                GlobalLogger.Log(_bot, "[DECISION][REJECT_FINAL] reason=OVEREXTENDED");
+                LogFinalReject("FINAL_OVEREXTENDED", "overextended");
                 return false;
             }
 
@@ -3581,11 +3557,16 @@ namespace GeminiV26.Core
             {
                 GlobalLogger.Log(_bot,
                     $"[ENTRY][INDEX_PB][POST_ACCEPT_INTEGRITY_BLOCK] reason=DIRECTION_NONE barsSinceBreak={barsSinceBreak} tq={tq:0.00} pullbackDepthR={pullbackDepthR:0.000}");
-                GlobalLogger.Log(_bot, "[DECISION][REJECT_FINAL] reason=INDEX_PB_POST_ACCEPT_INTEGRITY_BLOCK");
+                LogFinalReject("QUAL_INDEX_PB_POST_ACCEPT_INTEGRITY", "index_pb_post_accept_integrity_block");
                 return false;
             }
 
             return true;
+        }
+
+        private void LogFinalReject(string code, string detail, EntryContext ctx = null)
+        {
+            GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId($"[DECISION][REJECT_FINAL][CODE={code}] detail={detail}", ctx));
         }
 
         private double ResolveExecutionRiskPercent(EntryEvaluation selected, EntryContext ctx)

--- a/Core/TradeRouter.cs
+++ b/Core/TradeRouter.cs
@@ -55,7 +55,7 @@ namespace GeminiV26.Core
 
             if (executable.Count == 0)
             {
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[ROUTER][RANK_ONLY][NO_WINNER] reason=NO_EXECUTABLE_CANDIDATE", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[ROUTER][RANK_ONLY][NO_WINNER][CODE=ROUTER_NO_EXECUTABLE_CANDIDATE] detail=no_executable_candidate", entryContext));
                 return null;
             }
 
@@ -66,7 +66,7 @@ namespace GeminiV26.Core
 
             if (winner == null)
             {
-                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[ROUTER][RANK_ONLY][NO_WINNER] reason=EMPTY_AFTER_RANK", entryContext));
+                GlobalLogger.Log(_bot, TradeLogIdentity.WithTempId("[ROUTER][RANK_ONLY][NO_WINNER][CODE=ROUTER_EMPTY_AFTER_RANK] detail=empty_after_rank", entryContext));
                 return null;
             }
 

--- a/EntryTypes/CRYPTO/CryptoFlagEntryBase.cs
+++ b/EntryTypes/CRYPTO/CryptoFlagEntryBase.cs
@@ -93,30 +93,32 @@ namespace GeminiV26.EntryTypes.Crypto
 
         private TradeDirection ResolveDirection(EntryContext ctx)
         {
-            TradeDirection inputFinal = ctx?.FinalDirection ?? TradeDirection.None;
-            TradeDirection inputLogic = ctx?.LogicBiasDirection ?? TradeDirection.None;
-            ctx?.Log?.Invoke($"[DIR][CRYPTO_ENTRY][INPUT] symbol={ctx?.Symbol} final={inputFinal} logic={inputLogic}");
+            TradeDirection preFinalDirection = ctx?.LogicBiasDirection ?? TradeDirection.None;
+            TradeDirection routedDirection = ctx?.RoutedDirection ?? TradeDirection.None;
+            TradeDirection observedFinalDirection = ctx?.FinalDirection ?? TradeDirection.None;
 
-            if (inputFinal == TradeDirection.None && inputLogic == TradeDirection.None)
-                return TradeDirection.None;
-
-            if (inputFinal != TradeDirection.None)
+            if (preFinalDirection == TradeDirection.None)
             {
-                if (inputLogic != TradeDirection.None && inputLogic != inputFinal)
-                    ctx?.Log?.Invoke($"[DIR][CRYPTO_ENTRY][MISMATCH_WARN] symbol={ctx?.Symbol} final={inputFinal} logic={inputLogic}");
-
-                ctx?.Log?.Invoke($"[DIR][CRYPTO_ENTRY][FINAL_OK] symbol={ctx?.Symbol} source=FinalDirection dir={inputFinal}");
-                return inputFinal;
+                ctx?.Log?.Invoke(
+                    $"[DIR][CRYPTO][EVAL_NONE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
+                return TradeDirection.None;
             }
 
-            ctx?.Log?.Invoke($"[DIR][CRYPTO_ENTRY][MISMATCH_WARN] symbol={ctx?.Symbol} final=None logic={inputLogic} mode=advisory_fallback");
-            ctx?.Log?.Invoke($"[DIR][CRYPTO_ENTRY][FINAL_OK] symbol={ctx?.Symbol} source=LogicBiasDirectionFallback dir={inputLogic}");
-            return inputLogic;
+            if (observedFinalDirection != TradeDirection.None && observedFinalDirection != preFinalDirection)
+            {
+                ctx?.Log?.Invoke(
+                    $"[DIR][CRYPTO][EVAL_MISMATCH_WARN] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
+            }
+
+            ctx?.Log?.Invoke(
+                $"[DIR][CRYPTO][EVAL_SOURCE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
+            return preFinalDirection;
         }
 
         protected EntryEvaluation Reject(EntryContext ctx, TradeDirection dir, string reason)
         {
-            ctx?.Log?.Invoke($"[ENTRY][CRYPTO_FLAG][BLOCK] symbol={ctx?.Symbol} dir={dir} reason={reason}");
+            string canonicalCode = CanonicalRejectCode(reason);
+            ctx?.Log?.Invoke($"[ENTRY][CRYPTO_FLAG][BLOCK][CODE={canonicalCode}] symbol={ctx?.Symbol} dir={dir} detail={reason}");
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
@@ -124,7 +126,22 @@ namespace GeminiV26.EntryTypes.Crypto
                 Direction = dir,
                 IsValid = false,
                 Score = 0,
-                Reason = reason
+                Reason = canonicalCode,
+                RejectReason = canonicalCode
+            };
+        }
+
+        private static string CanonicalRejectCode(string reason)
+        {
+            return reason switch
+            {
+                "CTX_NOT_READY" => "CONTEXT_NOT_READY",
+                "NO_VALID_DIRECTION" => "CONTEXT_DIRECTION_NONE",
+                "NO_RECENT_IMPULSE" => "ENTRY_NO_IMPULSE",
+                "LATE_FLAG" => "ENTRY_TOO_LATE",
+                "INVALID_STRUCTURE" => "ENTRY_INVALID_FLAG",
+                "FAKE_BREAKOUT" => "TRIGGER_FAKE_BREAKOUT",
+                _ => "ENTRY_REJECT_UNSPECIFIED"
             };
         }
     }

--- a/EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs
+++ b/EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs
@@ -109,30 +109,32 @@ namespace GeminiV26.EntryTypes.Crypto
 
         private TradeDirection ResolveDirection(EntryContext ctx)
         {
-            TradeDirection inputFinal = ctx?.FinalDirection ?? TradeDirection.None;
-            TradeDirection inputLogic = ctx?.LogicBiasDirection ?? TradeDirection.None;
-            ctx?.Log?.Invoke($"[DIR][CRYPTO_ENTRY][INPUT] symbol={ctx?.Symbol} final={inputFinal} logic={inputLogic}");
+            TradeDirection preFinalDirection = ctx?.LogicBiasDirection ?? TradeDirection.None;
+            TradeDirection routedDirection = ctx?.RoutedDirection ?? TradeDirection.None;
+            TradeDirection observedFinalDirection = ctx?.FinalDirection ?? TradeDirection.None;
 
-            if (inputFinal == TradeDirection.None && inputLogic == TradeDirection.None)
-                return TradeDirection.None;
-
-            if (inputFinal != TradeDirection.None)
+            if (preFinalDirection == TradeDirection.None)
             {
-                if (inputLogic != TradeDirection.None && inputLogic != inputFinal)
-                    ctx?.Log?.Invoke($"[DIR][CRYPTO_ENTRY][MISMATCH_WARN] symbol={ctx?.Symbol} final={inputFinal} logic={inputLogic}");
-
-                ctx?.Log?.Invoke($"[DIR][CRYPTO_ENTRY][FINAL_OK] symbol={ctx?.Symbol} source=FinalDirection dir={inputFinal}");
-                return inputFinal;
+                ctx?.Log?.Invoke(
+                    $"[DIR][CRYPTO][EVAL_NONE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
+                return TradeDirection.None;
             }
 
-            ctx?.Log?.Invoke($"[DIR][CRYPTO_ENTRY][MISMATCH_WARN] symbol={ctx?.Symbol} final=None logic={inputLogic} mode=advisory_fallback");
-            ctx?.Log?.Invoke($"[DIR][CRYPTO_ENTRY][FINAL_OK] symbol={ctx?.Symbol} source=LogicBiasDirectionFallback dir={inputLogic}");
-            return inputLogic;
+            if (observedFinalDirection != TradeDirection.None && observedFinalDirection != preFinalDirection)
+            {
+                ctx?.Log?.Invoke(
+                    $"[DIR][CRYPTO][EVAL_MISMATCH_WARN] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
+            }
+
+            ctx?.Log?.Invoke(
+                $"[DIR][CRYPTO][EVAL_SOURCE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
+            return preFinalDirection;
         }
 
         protected EntryEvaluation Reject(EntryContext ctx, TradeDirection dir, string reason)
         {
-            ctx?.Log?.Invoke($"[ENTRY][CRYPTO_PB][BLOCK] symbol={ctx?.Symbol} dir={dir} reason={reason}");
+            string canonicalCode = CanonicalRejectCode(reason);
+            ctx?.Log?.Invoke($"[ENTRY][CRYPTO_PB][BLOCK][CODE={canonicalCode}] symbol={ctx?.Symbol} dir={dir} detail={reason}");
             return new EntryEvaluation
             {
                 Symbol = ctx?.Symbol,
@@ -140,7 +142,28 @@ namespace GeminiV26.EntryTypes.Crypto
                 Direction = dir,
                 IsValid = false,
                 Score = 0,
-                Reason = reason
+                Reason = canonicalCode,
+                RejectReason = canonicalCode
+            };
+        }
+
+        private static string CanonicalRejectCode(string reason)
+        {
+            return reason switch
+            {
+                "CTX_NOT_READY" => "CONTEXT_NOT_READY",
+                "NO_VALID_DIRECTION" => "CONTEXT_DIRECTION_NONE",
+                "NO_PULLBACK_STRUCTURE" => "ENTRY_NO_PULLBACK",
+                "REFIRE_BLOCK" => "QUAL_REFIRE_BLOCK",
+                "STALE_PULLBACK" => "QUAL_TOO_LATE",
+                "IMPULSE_LOCK_IMMEDIATE_COUNTER" => "QUAL_IMPULSE_DIRECTION_LOCK",
+                "CRYPTO_PULLBACK_NO_FUEL" => "ENTRY_NO_FUEL",
+                "VOL_TRANSITION_BLOCK" => "CONTEXT_VOLATILITY_BLOCK",
+                "PULLBACK_NOT_MATURE" => "QUAL_PULLBACK_NOT_MATURE",
+                "NO_DIRECTIONAL_CONTINUATION_BREAK" => "TRIGGER_NO_DIRECTIONAL_BREAK",
+                "OVERLAP_STACK_BLOCK" => "QUAL_OVERLAP_STACK_BLOCK",
+                "PULLBACK_DEPTH_INVALID" => "ENTRY_INVALID_PULLBACK_DEPTH",
+                _ => "ENTRY_REJECT_UNSPECIFIED"
             };
         }
     }


### PR DESCRIPTION
### Motivation
- Make crypto entry-evaluation direction usage stage-correct and explicit so entries do not imply FinalDirection authority before finalization.
- Replace brittle reflection/type-string ETH entry registration with direct compile-time type references for runtime stability.
- Unify scattered reject/abort reason strings on active runtime paths into a single canonical code scheme to improve diagnostics and aggregation.

### Description
- Crypto direction: `CryptoFlagEntryBase` and `CryptoPullbackEntryBase` now use `ctx.LogicBiasDirection` as the explicit pre-final direction source during entry evaluation and no longer treat `FinalDirection` as authoritative at that stage, and they emit the required diagnosability logs `[DIR][CRYPTO][EVAL_SOURCE]`, `[DIR][CRYPTO][EVAL_NONE]`, and `[DIR][CRYPTO][EVAL_MISMATCH_WARN]` with symbol, entry type, chosen source and available direction fields.
- ETH registration: removed reflection-based `TryAddCryptoEntryType(...)` usage for ETH in `TradeCore` and replaced it with direct registration using `new ETH_FlagEntry()` and `new ETH_PullbackEntry()`, while preserving BTC behavior and adding richer registration print logs that include raw symbol, normalized symbol, resolved class and concrete entry type names.
- Reject taxonomy: introduced canonical reject-code emission on active decision and execution paths by adding `[DECISION][REJECT_FINAL][CODE=...]` and `[EXEC][ABORT][CODE=...]` style logs in `TradeCore`, unified router no-winner logs to `[ROUTER][RANK_ONLY][NO_WINNER][CODE=...]` in `TradeRouter`, changed unsupported symbol resolver skip to `[RESOLVER][SKIP][CODE=SYMBOL_UNSUPPORTED]`, and mapped crypto entry base internal reasons to canonical codes stored in `EntryEvaluation.Reason` and `RejectReason` while preserving the human-readable detail.
- Files changed: `EntryTypes/CRYPTO/CryptoFlagEntryBase.cs`, `EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs`, `Core/TradeCore.cs`, `Core/TradeRouter.cs`, and `Core/RuntimeSymbolResolver.cs` (small, narrow edits only; no threshold, risk, exit, or broad architecture changes).

### Testing
- Verified no reflection-based ETH registration remains by searching for `TryAddCryptoEntryType`/`Type.GetType` patterns in `Core/TradeCore.cs` (code search succeeded).
- Verified crypto evaluation log markers are present by searching for the new `[DIR][CRYPTO][EVAL_*]` markers in the two crypto base files (code search succeeded).
- Ran `git diff --check` and repository consistency checks to ensure no trivial whitespace/diff issues (succeeded).
- No behavioral unit/integration tests were added; changes are intentionally minimal and focused on logging/registration and canonical reject codes to be validated during smoke log/replay runs in staging (recommended next step).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7aa7f0008328b8e28cf744662f12)