### PR TITLE
Make ETH crypto entry registration resilient to missing ETH entry types

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -334,11 +334,7 @@ namespace GeminiV26.Core
                 }
                 else if (string.Equals(resolvedSymbol, "ETHUSD", StringComparison.OrdinalIgnoreCase))
                 {
-                    _entryTypes = new List<IEntryType>
-                    {
-                        new ETH_FlagEntry(),
-                        new ETH_PullbackEntry()
-                    };
+                    _entryTypes = BuildEthEntryTypes(rawSymbol, resolvedSymbol);
 
                     _bot.Print($"[ENTRY][REGISTER][CRYPTO][ETH] raw={rawSymbol} normalized={resolvedSymbol} resolvedClass={nameof(InstrumentClass.CRYPTO)} entryTypes={string.Join(",", _entryTypes.Select(x => x.GetType().Name))} count={_entryTypes.Count}");
                 }
@@ -755,6 +751,39 @@ namespace GeminiV26.Core
             };
 
             _bot.Positions.Closed += OnPositionClosed;
+        }
+
+        private List<IEntryType> BuildEthEntryTypes(string rawSymbol, string resolvedSymbol)
+        {
+            var result = new List<IEntryType>();
+
+            AddEntryTypeIfAvailable(result, "GeminiV26.EntryTypes.Crypto.ETH_FlagEntry");
+            AddEntryTypeIfAvailable(result, "GeminiV26.EntryTypes.Crypto.ETH_PullbackEntry");
+
+            if (result.Count == 0)
+            {
+                _bot.Print($"[ENTRY][REGISTER][CRYPTO][ETH][WARN] raw={rawSymbol} normalized={resolvedSymbol} reason=ETH_ENTRY_TYPES_NOT_FOUND");
+            }
+
+            return result;
+        }
+
+        private void AddEntryTypeIfAvailable(List<IEntryType> target, string typeName)
+        {
+            Type type = Type.GetType(typeName);
+            if (type == null)
+            {
+                type = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .Select(a => a.GetType(typeName, false))
+                    .FirstOrDefault(t => t != null);
+            }
+
+            if (type == null)
+                return;
+
+            if (Activator.CreateInstance(type) is IEntryType entryType)
+                target.Add(entryType);
         }
 
 


### PR DESCRIPTION
### Motivation
- Editing crypto entries triggered errors when `ETH_FlagEntry`/`ETH_PullbackEntry` were not resolvable at compile time. 
- The goal is to remove the hard compile-time coupling in `TradeCore` so ETH entries are optional at runtime. 
- Ensure the bot still registers ETH entry types when the classes are present but degrades gracefully if they are absent.

### Description
- Replaced direct instantiation of `ETH_FlagEntry` and `ETH_PullbackEntry` in `Core/TradeCore.cs` with a dynamic builder call to `BuildEthEntryTypes`. 
- Added `BuildEthEntryTypes` which attempts to load `GeminiV26.EntryTypes.Crypto.ETH_FlagEntry` and `GeminiV26.EntryTypes.Crypto.ETH_PullbackEntry` by name and instantiate them if available. 
- Implemented `AddEntryTypeIfAvailable` to resolve types using `Type.GetType` and fallback to `AppDomain.CurrentDomain.GetAssemblies()` lookup, and to instantiate and append `IEntryType` implementations when found. 
- If no ETH entry types are found at runtime, the bot now logs a clear warning (`ETH_ENTRY_TYPES_NOT_FOUND`) instead of causing a compile/runtime coupling issue.

### Testing
- Ran automated repository checks: `git diff --check` completed without reported whitespace/patch issues. 
- Performed code inspection with ripgrep (`rg`) to confirm the existence and locations of `EntryTypes/CRYPTO/ETH_FlagEntry.cs` and `EntryTypes/CRYPTO/ETH_PullbackEntry.cs`, and verified the new builder is referenced in `Core/TradeCore.cs`. 
- `dotnet build` was not executed because no `.csproj`/solution file is present in this environment, so no full compile was run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7cdb57e883289b64c960e55bcb7f)