### PR TITLE
Narrow P2 cleanup: confidence semantics, analytics schema safety, legacy enum cleanup

### DIFF
--- a/Core/Analytics/TradeAnalyticsRecord.cs
+++ b/Core/Analytics/TradeAnalyticsRecord.cs
@@ -8,11 +8,14 @@ namespace GeminiV26.Core.Analytics
         public string PositionId;
         public string SetupType;
         public string EntryType;
+        public string InstrumentClass;
         public string MarketRegime;
         public double MfeR;
         public double MaeR;
         public double RMultiple;
         public double TransitionQuality;
+        // Backward-compatible alias column; authoritative value is FinalConfidence.
+        public double FinalConfidence;
         public double Confidence;
         public double Profit;
         public DateTime OpenTimeUtc;

--- a/Core/Analytics/TradeStatsTracker.cs
+++ b/Core/Analytics/TradeStatsTracker.cs
@@ -49,6 +49,7 @@ namespace GeminiV26.Core.Analytics
             public int? Confidence;
             public string SetupType;
             public string EntryType;
+            public string InstrumentClass;
             public string MarketRegime;
             public double MfeR;
             public double MaeR;
@@ -152,6 +153,7 @@ namespace GeminiV26.Core.Analytics
                 Confidence = null,
                 SetupType = string.Empty,
                 EntryType = string.Empty,
+                InstrumentClass = string.Empty,
                 MarketRegime = string.Empty,
                 MfeR = 0,
                 MaeR = 0,
@@ -326,17 +328,21 @@ namespace GeminiV26.Core.Analytics
 
             try
             {
+                // Active analytics SSOT path:
+                // TradeStatsTracker -> UnifiedAnalyticsWriter.
                 var record = new TradeAnalyticsRecord
                 {
                     Symbol = snapshot.Symbol.Trim(),
                     PositionId = string.IsNullOrWhiteSpace(snapshot.PositionId) ? "UNKNOWN" : snapshot.PositionId,
                     SetupType = snapshot.SetupType ?? string.Empty,
                     EntryType = snapshot.EntryType ?? string.Empty,
+                    InstrumentClass = snapshot.InstrumentClass ?? string.Empty,
                     MarketRegime = snapshot.MarketRegime ?? string.Empty,
                     MfeR = snapshot.MfeR,
                     MaeR = snapshot.MaeR,
                     RMultiple = snapshot.RMultiple,
                     TransitionQuality = snapshot.TransitionQuality,
+                    FinalConfidence = snapshot.Confidence ?? 0,
                     Confidence = snapshot.Confidence ?? 0,
                     Profit = snapshot.Profit,
                     OpenTimeUtc = snapshot.OpenTimeUtc,

--- a/Core/Analytics/UnifiedAnalyticsWriter.cs
+++ b/Core/Analytics/UnifiedAnalyticsWriter.cs
@@ -9,8 +9,10 @@ namespace GeminiV26.Core.Analytics
     public static class UnifiedAnalyticsWriter
     {
         private static readonly ConcurrentDictionary<string, object> _locks = new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-        private const string Header = "Symbol,PositionId,SetupType,EntryType,MarketRegime,MfeR,MaeR,RMultiple,TransitionQuality,Confidence,Profit,OpenTimeUtc,CloseTimeUtc";
-        private const string FallbackHeader = "Symbol,PositionId,SetupType,EntryType,MarketRegime,MfeR,MaeR,RMultiple,TransitionQuality,Confidence,Profit,OpenTimeUtc,CloseTimeUtc,FailureReason";
+        // Active analytics SSOT schema.
+        // Confidence column kept as backward-compatible alias for downstream readers.
+        private const string Header = "Symbol,PositionId,SetupType,EntryType,InstrumentClass,MarketRegime,MfeR,MaeR,RMultiple,TransitionQuality,FinalConfidence,Confidence,Profit,OpenTimeUtc,CloseTimeUtc";
+        private const string FallbackHeader = "Symbol,PositionId,SetupType,EntryType,InstrumentClass,MarketRegime,MfeR,MaeR,RMultiple,TransitionQuality,FinalConfidence,Confidence,Profit,OpenTimeUtc,CloseTimeUtc,FailureReason";
         private static int _degradedState;
 
         public static bool IsDegraded => _degradedState == 1;
@@ -52,11 +54,13 @@ namespace GeminiV26.Core.Analytics
                             Csv(resolvedPositionId),
                             Csv(record.SetupType),
                             Csv(record.EntryType),
+                            Csv(record.InstrumentClass),
                             Csv(record.MarketRegime),
                             record.MfeR.ToString("0.####", CultureInfo.InvariantCulture),
                             record.MaeR.ToString("0.####", CultureInfo.InvariantCulture),
                             record.RMultiple.ToString("0.####", CultureInfo.InvariantCulture),
                             record.TransitionQuality.ToString("0.####", CultureInfo.InvariantCulture),
+                            record.FinalConfidence.ToString("0.####", CultureInfo.InvariantCulture),
                             record.Confidence.ToString("0.####", CultureInfo.InvariantCulture),
                             record.Profit.ToString(CultureInfo.InvariantCulture),
                             record.OpenTimeUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
@@ -105,11 +109,13 @@ namespace GeminiV26.Core.Analytics
                             Csv(resolvedPositionId),
                             Csv(record.SetupType),
                             Csv(record.EntryType),
+                            Csv(record.InstrumentClass),
                             Csv(record.MarketRegime),
                             record.MfeR.ToString("0.####", CultureInfo.InvariantCulture),
                             record.MaeR.ToString("0.####", CultureInfo.InvariantCulture),
                             record.RMultiple.ToString("0.####", CultureInfo.InvariantCulture),
                             record.TransitionQuality.ToString("0.####", CultureInfo.InvariantCulture),
+                            record.FinalConfidence.ToString("0.####", CultureInfo.InvariantCulture),
                             record.Confidence.ToString("0.####", CultureInfo.InvariantCulture),
                             record.Profit.ToString(CultureInfo.InvariantCulture),
                             record.OpenTimeUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
@@ -136,7 +142,13 @@ namespace GeminiV26.Core.Analytics
 
         private static string Csv(string value)
         {
-            return value ?? string.Empty;
+            if (string.IsNullOrEmpty(value))
+                return string.Empty;
+
+            if (value.IndexOfAny(new[] { ',', '"', '\n', '\r' }) >= 0)
+                return "\"" + value.Replace("\"", "\"\"") + "\"";
+
+            return value;
         }
     }
 }

--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -308,7 +308,8 @@ namespace GeminiV26.Core.Entry
         public bool DirectionDebugLogged { get; set; }
         public string LastLoggedStateFingerprint { get; set; }
 
-        // Finalized snapshot fields (read-only source for audit snapshot generation)
+        // Pre-exec snapshot fields (audit only).
+        // Authoritative owner of FinalConfidence is PositionContext after position creation.
         public int EntryScore { get; set; }
         public int FinalConfidence { get; set; }
         public int RiskConfidence { get; set; }

--- a/Core/Entry/EntryType.cs
+++ b/Core/Entry/EntryType.cs
@@ -3,7 +3,7 @@
     public enum EntryType
     {
         // ===== METAL =====
-        XAU_Pullback,   // ⭐ EZ HIÁNYZIK
+        XAU_Pullback,
         XAU_Impulse,
         XAU_Flag,
         XAU_Reversal,
@@ -29,7 +29,7 @@
         Crypto_Pullback,
         Crypto_RangeBreakout,
 
-        // ===== LEGACY =====
+        // ===== LEGACY (compiled for compatibility, not part of active runtime routing) =====
         TC_Flag,
         TC_Pullback,
         BR_RangeBreakout,

--- a/Core/Logging/CsvAnalyticsLogger.cs
+++ b/Core/Logging/CsvAnalyticsLogger.cs
@@ -6,6 +6,8 @@ using System.IO;
 
 namespace GeminiV26.Core.Logging
 {
+    // INACTIVE: retained for backward compatibility only.
+    // Active analytics output is UnifiedAnalyticsWriter.
     public sealed class CsvAnalyticsLogger : ITradeLogger
     {
         private static readonly string[] Header =
@@ -38,7 +40,7 @@ namespace GeminiV26.Core.Logging
 
         public void OnTradeClosed(TradeLogContext context, Position position, TradeLogResult result)
         {
-            // SSOT ENFORCEMENT: disabled duplicate analytics writer
+            // Deprecated path: disabled duplicate analytics writer.
             return;
 
             if (context == null)

--- a/Core/Logging/CsvTradeLogger.cs
+++ b/Core/Logging/CsvTradeLogger.cs
@@ -6,6 +6,8 @@ using System.IO;
 
 namespace GeminiV26.Core.Logging
 {
+    // INACTIVE: retained only for legacy diagnostics/reference.
+    // Active analytics writer is Core.Analytics.UnifiedAnalyticsWriter via TradeStatsTracker.
     public sealed class CsvTradeLogger : ITradeLogger
     {
         private static readonly string[] Header =
@@ -42,8 +44,7 @@ namespace GeminiV26.Core.Logging
 
         public void OnTradeClosed(TradeLogContext context, Position position, TradeLogResult result)
         {
-            // NOTE: this logger is NOT part of analytics SSOT
-            // SSOT ENFORCEMENT: disabled duplicate analytics/trade CSV writer
+            // Deprecated path: disabled duplicate CSV writer.
             return;
 
             if (context == null)

--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -66,7 +66,7 @@ namespace GeminiV26.Core.Logging
                    $"finalConfidence={ctx.FinalConfidence}\n" +
                    "statePenalty=0\n" +
                    $"adjustedRiskConfidence={ctx.RiskConfidence}\n" +
-                   $"riskFinal={ctx.RiskConfidence}\n" +
+                   $"riskConfidence={ctx.RiskConfidence}\n" +
                    $"atr={ctx?.AtrM5 ?? 0:0.#####}\n" +
                    $"adx={ctx?.Adx_M5 ?? 0:0.##}\n" +
                    $"htfDirection={htfDirection}\n" +

--- a/Core/PositionContext.cs
+++ b/Core/PositionContext.cs
@@ -91,6 +91,10 @@ namespace GeminiV26.Core
         /// </summary>
         public int FinalConfidence { get; private set; }
 
+        /// <summary>
+        /// Risk-engine confidence input derived from FinalConfidence.
+        /// This is a post-compute risk staging value, not an alternative confidence owner.
+        /// </summary>
         public int AdjustedRiskConfidence { get; set; }
 
         private bool _isFinalConfidenceComputed;
@@ -348,7 +352,7 @@ namespace GeminiV26.Core
             }
             else if (AdjustedRiskConfidence <= 0)
             {
-                // Failsafe fallback – MUST be visible
+                // Failsafe fallback – keep risk staging aligned with authoritative FinalConfidence.
                 AdjustedRiskConfidence = FinalConfidence;
 
                 GlobalLogger.Log(Bot, "[CONF][ADJUSTED_FALLBACK] using FinalConfidence");

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -10,7 +10,7 @@
 //
 // TradeCore NEM:
 // - score-ol
-// - confidence-et számol
+// - autoritatív confidence-et számol
 // - stratégia között dönt
 // - EntryLogic-ra hallgat veto-ként
 //
@@ -18,6 +18,7 @@
 // - EntryType → EntryScore
 // - EntryLogic → LogicConfidence (csak info)
 // - PositionContext → FinalConfidence (single source of truth)
+// - EntryContext confidence mezők = pre-exec staging snapshot (audit)
 //
 // GATE SZABÁLY:
 // - Session / Impulse gate az egyetlen HARD STOP
@@ -1646,6 +1647,9 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot, $"[DIR] logic={logicDir} eval={evalDir} routed={routedDir} final={finalDir}");
                 _ctx.EntryScore = PositionContext.ClampRiskConfidence(selected.Score);
                 _ctx.LogicBiasConfidence = PositionContext.ClampRiskConfidence(Math.Max(0, _ctx.LogicBiasConfidence));
+                // PRE-EXEC STAGING SNAPSHOT ONLY:
+                // EntryContext.FinalConfidence/RiskConfidence are transient audit fields.
+                // Authoritative FinalConfidence owner remains PositionContext.
                 _ctx.FinalConfidence = PositionContext.ComputeFinalConfidenceValue(_ctx.EntryScore, _ctx.LogicBiasConfidence);
                 _ctx.RiskConfidence = PositionContext.ClampRiskConfidence(_ctx.FinalConfidence);
                 LogHtfFlowStage(_ctx, selected, "FINAL_DECISION", "DirectionSet");
@@ -2306,14 +2310,12 @@ namespace GeminiV26.Core
                 case EntryType.FX_FlagContinuation:
                 case EntryType.Index_Flag:
                 case EntryType.Crypto_Flag:
-                case EntryType.TC_Flag:
                 case EntryType.XAU_Flag:
                     return maxBonus;
 
                 case EntryType.FX_Pullback:
                 case EntryType.Index_Pullback:
                 case EntryType.Crypto_Pullback:
-                case EntryType.TC_Pullback:
                 case EntryType.XAU_Pullback:
                     return Math.Min(maxBonus, 8);
 
@@ -2330,14 +2332,12 @@ namespace GeminiV26.Core
                 case EntryType.FX_FlagContinuation:
                 case EntryType.Index_Flag:
                 case EntryType.Crypto_Flag:
-                case EntryType.TC_Flag:
                 case EntryType.XAU_Flag:
                     return maxBonus;
 
                 case EntryType.FX_Pullback:
                 case EntryType.Index_Pullback:
                 case EntryType.Crypto_Pullback:
-                case EntryType.TC_Pullback:
                 case EntryType.XAU_Pullback:
                     return Math.Min(maxBonus, 8);
 
@@ -3069,10 +3069,10 @@ namespace GeminiV26.Core
                 case EntryType.Crypto_RangeBreakout:
                 case EntryType.XAU_Flag:
                 case EntryType.XAU_Impulse:
-                case EntryType.TC_Flag:
                     return true;
 
                 default:
+                    // Legacy enum families are intentionally excluded from active trigger management.
                     return false;
             }
         }
@@ -4054,6 +4054,7 @@ namespace GeminiV26.Core
                     Confidence = ctx?.FinalConfidence ?? meta?.EntryScore,
                     SetupType = ResolveSetupType(meta?.EntryType),
                     EntryType = meta?.EntryType ?? ctx?.EntryType ?? "UNKNOWN",
+                    InstrumentClass = ResolveInstrumentClass(pos.SymbolName),
                     MarketRegime = ResolveMarketRegime(entryCtx),
                     MfeR = ctx?.MfeR ?? 0.0,
                     MaeR = ctx != null ? -Math.Abs(ctx.MaeR) : 0.0,
@@ -4353,6 +4354,7 @@ namespace GeminiV26.Core
 
             var setup = entryType.Trim();
 
+            // Compatibility note: Expectancy tooling groups by this high-level family.
             if (setup.IndexOf("MicroContinuation", StringComparison.OrdinalIgnoreCase) >= 0)
                 return "MicroContinuation";
             if (setup.IndexOf("Flag", StringComparison.OrdinalIgnoreCase) >= 0)


### PR DESCRIPTION
### Motivation
- Remove semantic ambiguity around where confidence is authoritative so audits and logs are unambiguous.  
- Harden analytics output and schema so downstream expectancy tooling can trust CSV rows (escaping, clear columns).  
- Stop legacy enum/switch entries from polluting active routing/boost/trigger maps while keeping compatibility.

### Description
- Clarified confidence ownership: marked `EntryContext` confidence fields as pre-exec / staging/audit-only and documented `PositionContext` as the authoritative FinalConfidence owner, added inline comments at the snapshot point in `TradeCore`, and clarified `AdjustedRiskConfidence` docs in `PositionContext`.  
- Resolved confusing audit naming by replacing `riskFinal` alias with `riskConfidence` in the audit snapshot to reduce duplicate vocabulary.  
- Analytics/schema: added additive columns `InstrumentClass` and `FinalConfidence` (kept `Confidence` as compatibility alias), propagated them through `TradeCloseSnapshot -> TradeAnalyticsRecord -> TradeStatsTracker -> UnifiedAnalyticsWriter`, and made `UnifiedAnalyticsWriter.Csv()` robust to commas/quotes/newlines.  
- Marked legacy CSV loggers as inactive/deprecated in comments (`CsvTradeLogger`, `CsvAnalyticsLogger`) and documented that the active SSOT analytics path is `TradeStatsTracker -> UnifiedAnalyticsWriter`.  
- Legacy cleanup: removed legacy `TC_*` entries from active boost and trigger-managed maps and annotated legacy block in `EntryType` enum as compiled-for-compatibility only (no removal of enum values).  
- Cosmetic clarifications only; no intentional changes to thresholds, selection, risk formulas, exit behavior, or execution semantics.

### Testing
- Attempted build with `dotnet build -v minimal` in the container but it failed because `dotnet` is not installed in this environment (error: `/bin/bash: dotnet: command not found`).  
- Verified diffs and committed the patch (`git add` / `git commit`); inspected the unified diff and file contents (`git show`, `git status`) to confirm intended edits were applied.  
- Performed code searches/inspections to confirm removed legacy entries from active maps and propagation of analytics fields; no unit or integration tests were executed due to missing dotnet runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7dc021188328a50371885ce6c52b)