### PR TITLE
Add authoritative-structure checks and detailed structure logging across entries

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -421,6 +421,46 @@ namespace GeminiV26.Core.Entry
             };
         }
 
+        public bool IsStructureDirectionStrict()
+            => Structure?.StructureDirection == TradeDirection.Long ||
+               Structure?.StructureDirection == TradeDirection.Short;
+
+        public bool IsStructureDirectionAuthoritative()
+        {
+            if (IsStructureDirectionStrict())
+                return true;
+
+            bool hasResolvedSource =
+                !string.IsNullOrWhiteSpace(Structure?.DirectionSource) &&
+                !string.Equals(Structure.DirectionSource, "NONE", StringComparison.OrdinalIgnoreCase);
+
+            bool hasBroaderDirection =
+                LogicBiasDirection == TradeDirection.Long ||
+                LogicBiasDirection == TradeDirection.Short;
+
+            return hasResolvedSource && hasBroaderDirection;
+        }
+
+        public bool IsStructureImpulseAuthoritative()
+            => (Structure?.HasImpulse == true) || (Structure?.ImpulseRecentOk == true);
+
+        public bool IsStructurePullbackAuthoritative()
+            => (Structure?.HasPullback == true) ||
+               (Structure?.PullbackStandardOk == true) ||
+               (Structure?.PullbackShallowOk == true) ||
+               (Structure?.HasMicroPullback == true);
+
+        public bool IsStructureFlagAuthoritative()
+            => (Structure?.HasFlag == true) ||
+               (Structure?.FlagStandardOk == true) ||
+               (Structure?.FlagMessyOk == true);
+
+        public void LogStructureAuthority(string entryFamily, string tag, string strictFieldFailed, string rescueField, string details = null)
+        {
+            Log?.Invoke(
+                $"[STRUCT][AUTH][{tag}] symbol={Symbol} entry={entryFamily} strictFailed={strictFieldFailed} rescue={rescueField} {details ?? "details=NA"}");
+        }
+
         public bool HasDirectionalPullback(TradeDirection direction)
         {
             return direction switch

--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -1042,13 +1042,40 @@ namespace GeminiV26.Core.Entry
 
         private void BuildImpulseAnchor(EntryContext ctx)
         {
-            if (ctx == null || ctx.M5 == null || ctx.M5.Count < 3 || ctx.AtrM5 <= 0)
+            if (ctx == null)
+            {
+                GlobalLogger.Log(_bot, "[STRUCT][IMPULSE][FAIL] symbol=NA dir=None code=CONTEXT_NOT_READY");
                 return;
+            }
+
+            if (ctx.M5 == null || ctx.M5.Count < 3)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][IMPULSE][FAIL] symbol={ctx.Symbol ?? "NA"} dir={ctx.Structure?.StructureDirection ?? TradeDirection.None} code=CONTEXT_NOT_READY m5Count={(ctx.M5?.Count ?? 0)}");
+                return;
+            }
+
+            if (ctx.AtrM5 <= 0)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][IMPULSE][FAIL] symbol={ctx.Symbol ?? "NA"} dir={ctx.Structure?.StructureDirection ?? TradeDirection.None} code=ATR_INVALID atrM5={ctx.AtrM5:0.00000}");
+                return;
+            }
 
             TradeDirection direction = ResolveStructureDirection(ctx);
             ctx.Structure.StructureDirection = direction;
             GlobalLogger.Log(_bot,
-                $"[STRUCT][DIR][SOURCE] dir={direction} source={ctx.Structure.DirectionSource ?? "NA"} trend={ctx.TrendDirection} diSpread={ctx.DiSpread_M5:0.00} slopeM5={ctx.Ema21Slope_M5:0.00000} slopeM15={ctx.Ema21Slope_M15:0.00000}");
+                $"[STRUCT][DIR][SOURCE] symbol={ctx.Symbol ?? "NA"} dir={direction} source={ctx.Structure.DirectionSource ?? "NA"} trend={ctx.TrendDirection} diSpread={ctx.DiSpread_M5:0.00} slopeM5={ctx.Ema21Slope_M5:0.00000} slopeM15={ctx.Ema21Slope_M15:0.00000}");
+
+            if (direction == TradeDirection.None)
+            {
+                ctx.Structure.HasImpulse = false;
+                ctx.Structure.ImpulseRecentOk = false;
+                ctx.Structure.ImpulseAgeBars = ctx.BarsSinceImpulse_M5;
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][IMPULSE][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} source={ctx.Structure.DirectionSource ?? "NA"} code=DIRECTION_UNRESOLVED age={ctx.BarsSinceImpulse_M5} adx={ctx.Adx_M5:0.0}");
+                return;
+            }
 
             int m5Idx = ctx.M5.Count - 2;
             double body = Math.Abs(ctx.M5.ClosePrices[m5Idx] - ctx.M5.OpenPrices[m5Idx]);
@@ -1113,7 +1140,7 @@ namespace GeminiV26.Core.Entry
             if (!ctx.Structure.HasImpulse)
             {
                 GlobalLogger.Log(_bot,
-                    $"[STRUCT][IMPULSE][FAIL] dir={direction} source={ctx.Structure.DirectionSource ?? "NA"} age={bars} bodyAtr={move:0.00} rangeAtr={(ctx.AtrM5 > 0 ? range / ctx.AtrM5 : 0):0.00} adx={ctx.Adx_M5:0.0}");
+                    $"[STRUCT][IMPULSE][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} source={ctx.Structure.DirectionSource ?? "NA"} code=NO_RECENT_IMPULSE age={bars} bodyAtr={move:0.00} rangeAtr={(ctx.AtrM5 > 0 ? range / ctx.AtrM5 : 0):0.00} adx={ctx.Adx_M5:0.0}");
                 return;
             }
 
@@ -1135,8 +1162,20 @@ namespace GeminiV26.Core.Entry
 
         private void BuildPullback(EntryContext ctx)
         {
-            if (ctx == null || !ctx.Structure.HasImpulse)
+            if (ctx == null)
+            {
+                GlobalLogger.Log(_bot, "[STRUCT][PULLBACK][FAIL] symbol=NA dir=None code=CONTEXT_NOT_READY");
                 return;
+            }
+
+            TradeDirection direction = ctx.Structure.StructureDirection;
+            bool impulseOk = ctx.Structure.HasImpulse || ctx.Structure.ImpulseRecentOk;
+            if (!impulseOk)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][PULLBACK][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} code=PULLBACK_PREREQ_NO_IMPULSE impulse={ctx.Structure.HasImpulse.ToString().ToLowerInvariant()} impulseRecent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()} age={ctx.Structure.ImpulseAgeBars}");
+                return;
+            }
 
             double retrace = ctx.PullbackDepthAtr_M5;
             int bars = ctx.PullbackBars_M5;
@@ -1154,12 +1193,27 @@ namespace GeminiV26.Core.Entry
                 ctx.M1TriggerInTrendDirection;
             bool shallowOk = !standardOk && shallowDepth && shallowBars && directionalPressure;
 
+            if (!validDepth && !shallowDepth)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][PULLBACK][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} code=PULLBACK_DEPTH_INVALID depth={retrace:0.00} bars={bars} shallowDepth={shallowDepth.ToString().ToLowerInvariant()}");
+            }
+            if (!notTooLong && !shallowBars)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][PULLBACK][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} code=PULLBACK_BARS_INVALID depth={retrace:0.00} bars={bars} notTooLong={notTooLong.ToString().ToLowerInvariant()} shallowBars={shallowBars.ToString().ToLowerInvariant()}");
+            }
+
             ctx.Structure.PullbackStandardOk = standardOk;
             ctx.Structure.PullbackShallowOk = shallowOk;
             ctx.Structure.HasPullback = standardOk || shallowOk;
 
             if (!ctx.Structure.HasPullback)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][PULLBACK][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} code=NO_VALID_PULLBACK depth={retrace:0.00} bars={bars} pressure={directionalPressure.ToString().ToLowerInvariant()}");
                 return;
+            }
 
             ctx.Structure.HasMicroPullback =
                 retrace >= 0.08 &&
@@ -1184,8 +1238,27 @@ namespace GeminiV26.Core.Entry
 
         private void BuildFlag(EntryContext ctx)
         {
-            if (ctx == null || !ctx.Structure.HasPullback || ctx.AtrM5 <= 0)
+            if (ctx == null)
+            {
+                GlobalLogger.Log(_bot, "[STRUCT][FLAG][FAIL] symbol=NA dir=None code=CONTEXT_NOT_READY");
                 return;
+            }
+
+            TradeDirection direction = ctx.Structure.StructureDirection;
+            bool pullbackOk = ctx.Structure.HasPullback || ctx.Structure.PullbackShallowOk || ctx.Structure.HasMicroPullback;
+            if (!pullbackOk)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][FLAG][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} code=FLAG_PREREQ_NO_PULLBACK pullback={ctx.Structure.HasPullback.ToString().ToLowerInvariant()} shallow={ctx.Structure.PullbackShallowOk.ToString().ToLowerInvariant()} micro={ctx.Structure.HasMicroPullback.ToString().ToLowerInvariant()}");
+                return;
+            }
+
+            if (ctx.AtrM5 <= 0)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][FLAG][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} code=ATR_INVALID atrM5={ctx.AtrM5:0.00000}");
+                return;
+            }
 
             int bars = Math.Max(ctx.FlagBarsLong_M5, ctx.FlagBarsShort_M5);
             if (bars <= 0 && (ctx.HasFlagLong_M5 || ctx.HasFlagShort_M5))
@@ -1209,12 +1282,27 @@ namespace GeminiV26.Core.Entry
                 ctx.IsPullbackDecelerating_M5;
             bool messyOk = !standardOk && messyCompression && messyBars && directionalPressure;
 
+            if (!(shortFlag || messyBars))
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][FLAG][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} code=FLAG_BARS_INVALID bars={bars} short={shortFlag.ToString().ToLowerInvariant()} messyBars={messyBars.ToString().ToLowerInvariant()}");
+            }
+            if (!(tight || messyCompression))
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][FLAG][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} code=FLAG_COMPRESSION_INVALID compression={compression:0.00} tight={tight.ToString().ToLowerInvariant()} messyCompression={messyCompression.ToString().ToLowerInvariant()}");
+            }
+
             ctx.Structure.FlagStandardOk = standardOk;
             ctx.Structure.FlagMessyOk = messyOk;
             ctx.Structure.HasFlag = standardOk || messyOk;
 
             if (!ctx.Structure.HasFlag)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][FLAG][FAIL] symbol={ctx.Symbol ?? "NA"} dir={direction} code=NO_VALID_FLAG bars={bars} compression={compression:0.00} pressure={directionalPressure.ToString().ToLowerInvariant()}");
                 return;
+            }
 
             ctx.Structure.FlagCompression = compression;
             ctx.Structure.FlagBars = bars;

--- a/EntryTypes/CRYPTO/CryptoFlagEntryBase.cs
+++ b/EntryTypes/CRYPTO/CryptoFlagEntryBase.cs
@@ -36,13 +36,33 @@ namespace GeminiV26.EntryTypes.Crypto
                 barsSinceImpulse >= 0 &&
                 barsSinceImpulse <= MaxImpulseMemoryBars + 2 &&
                 (ctx.Structure.ImpulseStrength >= (MinImpulseStrength - 0.05) || ctx.IsAtrExpanding_M5);
+            bool impulseOk = ctx.Structure.HasImpulse || recentImpulseWidened || ctx.IsStructureImpulseAuthoritative();
             bool flagShapeWidened =
                 !ctx.Structure.HasFlag &&
                 ctx.Structure.FlagBars >= 2 &&
                 ctx.Structure.FlagCompression <= 0.78 &&
                 (ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal || trendFollowThrough);
-            if ((!ctx.Structure.HasImpulse && !recentImpulseWidened) || (!ctx.Structure.HasFlag && !flagShapeWidened))
+            bool flagOk = ctx.Structure.HasFlag || flagShapeWidened || ctx.IsStructureFlagAuthoritative();
+            if (!ctx.Structure.HasImpulse && impulseOk)
+            {
+                ctx.LogStructureAuthority("CryptoFlagEntryBase", "IMPULSE_OK", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("CryptoFlagEntryBase", "ALT_PATH_USED", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse}");
+            }
+            if (!ctx.Structure.HasFlag && flagOk)
+            {
+                ctx.LogStructureAuthority("CryptoFlagEntryBase", "FLAG_OK", "HasFlag", "FlagMessyOk",
+                    $"flagBars={ctx.Structure.FlagBars} compression={ctx.Structure.FlagCompression:0.00} messy={ctx.Structure.FlagMessyOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("CryptoFlagEntryBase", "ALT_PATH_USED", "HasFlag", "FlagMessyOk",
+                    $"flagBars={ctx.Structure.FlagBars}");
+            }
+            if (!impulseOk || !flagOk)
+            {
+                ctx.LogStructureAuthority("CryptoFlagEntryBase", "STILL_FAIL", "HasImpulse|HasFlag", "NONE",
+                    $"impulseOk={impulseOk.ToString().ToLowerInvariant()} flagOk={flagOk.ToString().ToLowerInvariant()} barsSinceImpulse={barsSinceImpulse}");
                 return Reject(ctx, dir, "INVALID_STRUCTURE");
+            }
             if (recentImpulseWidened)
                 ctx.Log?.Invoke($"[ENTRY][CRYPTO_FLAG][WIDEN_ALLOW] symbol={ctx.Symbol} code=RECENT_IMPULSE barsSinceImpulse={barsSinceImpulse}");
             if (flagShapeWidened)

--- a/EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs
+++ b/EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs
@@ -37,12 +37,32 @@ namespace GeminiV26.EntryTypes.Crypto
                 barsSinceImpulse >= 0 &&
                 barsSinceImpulse <= MaxBarsSinceImpulse + 2 &&
                 (ctx.Structure.ImpulseStrength >= (MinFuelImpulseStrength - 0.04) || ctx.IsAtrExpanding_M5);
+            bool impulseOk = ctx.Structure.HasImpulse || recentImpulseWidened || ctx.IsStructureImpulseAuthoritative();
             bool shallowPullbackWidened =
                 !ctx.Structure.HasPullback &&
                 (ctx.Structure.HasMicroPullback || (ctx.Structure.PullbackDepth >= 0.03 && ctx.Structure.PullbackDepth <= 0.20 && ctx.Structure.PullbackBars <= 3)) &&
                 (ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal || trendFollowThrough);
-            if ((!ctx.Structure.HasImpulse && !recentImpulseWidened) || (!ctx.Structure.HasPullback && !shallowPullbackWidened))
+            bool pullbackOk = ctx.Structure.HasPullback || shallowPullbackWidened || ctx.IsStructurePullbackAuthoritative();
+            if (!ctx.Structure.HasImpulse && impulseOk)
+            {
+                ctx.LogStructureAuthority("CryptoPullbackEntryBase", "IMPULSE_OK", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("CryptoPullbackEntryBase", "ALT_PATH_USED", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse}");
+            }
+            if (!ctx.Structure.HasPullback && pullbackOk)
+            {
+                ctx.LogStructureAuthority("CryptoPullbackEntryBase", "PULLBACK_OK", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={ctx.Structure.PullbackDepth:0.00} shallow={ctx.Structure.PullbackShallowOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("CryptoPullbackEntryBase", "ALT_PATH_USED", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={ctx.Structure.PullbackDepth:0.00}");
+            }
+            if (!impulseOk || !pullbackOk)
+            {
+                ctx.LogStructureAuthority("CryptoPullbackEntryBase", "STILL_FAIL", "HasImpulse|HasPullback", "NONE",
+                    $"impulseOk={impulseOk.ToString().ToLowerInvariant()} pullbackOk={pullbackOk.ToString().ToLowerInvariant()} barsSinceImpulse={barsSinceImpulse}");
                 return Reject(ctx, dir, "NO_PULLBACK_STRUCTURE");
+            }
             if (recentImpulseWidened)
                 ctx.Log?.Invoke($"[ENTRY][CRYPTO_PB][WIDEN_ALLOW] symbol={ctx.Symbol} code=RECENT_IMPULSE barsSinceImpulse={barsSinceImpulse}");
             if (shallowPullbackWidened)

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -21,6 +21,9 @@ namespace GeminiV26.EntryTypes.FX
             bool hasPullback = ctx.Structure?.HasPullback == true;
             bool hasFlag = ctx.Structure?.HasFlag == true;
             var direction = ctx.Structure?.StructureDirection ?? TradeDirection.None;
+            bool impulseStrict = hasImpulse;
+            bool pullbackStrict = hasPullback;
+            bool flagStrict = hasFlag;
             bool breakoutUp = ctx.Structure?.FlagBreakoutUp == true;
             bool breakoutDown = ctx.Structure?.FlagBreakoutDown == true;
             bool alignedBreakout = direction == TradeDirection.Long ? breakoutUp : breakoutDown;
@@ -51,14 +54,31 @@ namespace GeminiV26.EntryTypes.FX
                     hasContinuationSignal &&
                     trendFollowThrough;
                 if (!canUseLogicDirection)
+                {
+                    ctx.LogStructureAuthority("FX_FlagContinuationEntry", "STILL_FAIL", "StructureDirection", "NONE",
+                        $"reason=NO_DIRECTION source={ctx.Structure?.DirectionSource ?? "NA"}");
                     return Block(ctx, "NO_DIRECTION");
+                }
 
                 direction = logicDirection;
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
+                    $"source={ctx.Structure?.DirectionSource ?? "NA"} resolvedDir={direction}");
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
+                    $"resolvedDir={direction}");
                 alignedBreakout = direction == TradeDirection.Long ? breakoutUp : breakoutDown;
                 opposingBreakout = direction == TradeDirection.Long ? breakoutDown : breakoutUp;
                 barsSinceImpulse = ctx.GetBarsSinceImpulse(direction);
                 hasRecentDirectionalImpulse = barsSinceImpulse >= 0 && barsSinceImpulse <= 12;
                 ctx.Log?.Invoke($"[ENTRY][FX_FLAG][WIDEN_ALLOW] code=DIRECTION_FROM_LOGIC_BIAS direction={direction}");
+            }
+
+            bool impulseOk = hasImpulse || hasRecentDirectionalImpulse || ctx.IsStructureImpulseAuthoritative();
+            if (!impulseStrict && impulseOk)
+            {
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "IMPULSE_OK", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure?.ImpulseRecentOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "ALT_PATH_USED", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse}");
             }
 
             bool localAuthority =
@@ -67,16 +87,46 @@ namespace GeminiV26.EntryTypes.FX
                 hasContinuationSignal &&
                 (alignedBreakout || !opposingBreakout);
 
-            if (!hasImpulse && !hasRecentDirectionalImpulse)
+            if (!impulseOk)
+            {
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "STILL_FAIL", "HasImpulse", "NONE",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure?.ImpulseRecentOk.ToString().ToLowerInvariant()}");
                 return Block(ctx, "NO_IMPULSE");
+            }
 
-            if (!hasPullback && !shallowPullbackWidened)
+            bool pullbackOk = hasPullback || shallowPullbackWidened || ctx.IsStructurePullbackAuthoritative();
+            if (!pullbackStrict && pullbackOk)
+            {
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "PULLBACK_OK", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00} shallow={(ctx.Structure?.PullbackShallowOk ?? false).ToString().ToLowerInvariant()} micro={(ctx.Structure?.HasMicroPullback ?? false).ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "ALT_PATH_USED", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00}");
+            }
+
+            if (!pullbackOk)
+            {
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "STILL_FAIL", "HasPullback", "NONE",
+                    $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00}");
                 return Block(ctx, "NO_PULLBACK");
+            }
             if (shallowPullbackWidened)
                 ctx.Log?.Invoke($"[ENTRY][FX_FLAG][WIDEN_ALLOW] code=SHALLOW_PULLBACK depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00}");
 
-            if (!hasFlag && !weakFlagWidened)
+            bool flagOk = hasFlag || weakFlagWidened || ctx.IsStructureFlagAuthoritative();
+            if (!flagStrict && flagOk)
+            {
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "FLAG_OK", "HasFlag", "FlagMessyOk",
+                    $"flagBars={ctx.Structure?.FlagBars ?? 0} compression={(ctx.Structure?.FlagCompression ?? 0.0):0.00} messy={(ctx.Structure?.FlagMessyOk ?? false).ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "ALT_PATH_USED", "HasFlag", "FlagMessyOk",
+                    $"flagBars={ctx.Structure?.FlagBars ?? 0}");
+            }
+
+            if (!flagOk)
+            {
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "STILL_FAIL", "HasFlag", "NONE",
+                    $"flagBars={ctx.Structure?.FlagBars ?? 0} compression={(ctx.Structure?.FlagCompression ?? 0.0):0.00}");
                 return Block(ctx, "INVALID_FLAG");
+            }
             if (weakFlagWidened)
                 ctx.Log?.Invoke($"[ENTRY][FX_FLAG][WIDEN_ALLOW] code=WEAK_FLAG flagBars={ctx.Structure?.FlagBars ?? 0} compression={(ctx.Structure?.FlagCompression ?? 0.0):0.00}");
 

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -22,6 +22,8 @@ namespace GeminiV26.EntryTypes.FX
             bool hasImpulse = ctx.Structure?.HasImpulse == true;
             bool hasPullback = ctx.Structure?.HasPullback == true;
             bool hasMicroPullback = ctx.Structure?.HasMicroPullback == true;
+            bool impulseStrict = hasImpulse;
+            bool pullbackStrict = hasPullback;
             bool early = ctx.Structure?.ContinuationEarlySignal == true;
             bool confirmed = ctx.Structure?.ContinuationConfirmedSignal == true;
             bool trendFollowThrough = ctx.LastClosedBarInTrendDirection || ctx.M1TriggerInTrendDirection || ctx.HasReactionCandle_M5;
@@ -41,9 +43,17 @@ namespace GeminiV26.EntryTypes.FX
                     (early || confirmed) &&
                     trendFollowThrough;
                 if (!canUseLogicDirection)
+                {
+                    ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "STILL_FAIL", "StructureDirection", "NONE",
+                        $"reason=NO_DIRECTION source={ctx.Structure?.DirectionSource ?? "NA"}");
                     return Block(ctx, "NO_DIRECTION");
+                }
 
                 structureDirection = logicDirection;
+                ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
+                    $"source={ctx.Structure?.DirectionSource ?? "NA"} resolvedDir={structureDirection}");
+                ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
+                    $"resolvedDir={structureDirection}");
                 barsSinceImpulse = ctx.GetBarsSinceImpulse(structureDirection);
                 recentImpulseWidened =
                     !hasImpulse &&
@@ -56,8 +66,20 @@ namespace GeminiV26.EntryTypes.FX
             ctx.Log?.Invoke(
                 $"[FX][IMPULSE_CHECK] impulse={hasImpulse.ToString().ToLowerInvariant()} micro_pullback={hasMicroPullback.ToString().ToLowerInvariant()} direction={structureDirection} early={early.ToString().ToLowerInvariant()} confirmed={confirmed.ToString().ToLowerInvariant()}");
 
-            if (!hasImpulse && !recentImpulseWidened)
+            bool impulseOk = hasImpulse || recentImpulseWidened || ctx.IsStructureImpulseAuthoritative();
+            if (!impulseStrict && impulseOk)
+            {
+                ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "IMPULSE_OK", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={(ctx.Structure?.ImpulseRecentOk ?? false).ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "ALT_PATH_USED", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse}");
+            }
+            if (!impulseOk)
+            {
+                ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "STILL_FAIL", "HasImpulse", "NONE",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={(ctx.Structure?.ImpulseRecentOk ?? false).ToString().ToLowerInvariant()}");
                 return Block(ctx, "NO_IMPULSE");
+            }
             if (recentImpulseWidened)
                 ctx.Log?.Invoke($"[ENTRY][FX_IMPULSE][WIDEN_ALLOW] code=RECENT_IMPULSE barsSinceImpulse={barsSinceImpulse}");
 
@@ -67,8 +89,20 @@ namespace GeminiV26.EntryTypes.FX
                 (early || confirmed) &&
                 trendFollowThrough &&
                 (ctx.Structure?.PullbackDepth ?? 0.0) <= 0.20;
-            if (!hasPullback && !shallowPullbackWidened)
+            bool pullbackOk = hasPullback || shallowPullbackWidened || ctx.IsStructurePullbackAuthoritative();
+            if (!pullbackStrict && pullbackOk)
+            {
+                ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "PULLBACK_OK", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00} shallow={(ctx.Structure?.PullbackShallowOk ?? false).ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "ALT_PATH_USED", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00}");
+            }
+            if (!pullbackOk)
+            {
+                ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "STILL_FAIL", "HasPullback", "NONE",
+                    $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00}");
                 return Block(ctx, "NO_PULLBACK");
+            }
             if (shallowPullbackWidened)
                 ctx.Log?.Invoke($"[ENTRY][FX_IMPULSE][WIDEN_ALLOW] code=SHALLOW_PULLBACK depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00}");
 

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -31,19 +31,34 @@ namespace GeminiV26.EntryTypes.INDEX
                     trendFollowThrough;
                 if (!canUseLogicDirection)
                 {
+                    ctx.LogStructureAuthority("Index_FlagEntry", "STILL_FAIL", "StructureDirection", "NONE",
+                        $"reason=NO_DIRECTION source={ctx.Structure.DirectionSource ?? "NA"}");
                     ctx.Log?.Invoke("[ENTRY][INDEX_FLAG][BLOCK][CODE=NO_DIRECTION]");
                     return Reject(ctx, "NO_DIRECTION", 0, TradeDirection.None);
                 }
 
                 direction = logicDirection;
+                ctx.LogStructureAuthority("Index_FlagEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
+                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={direction}");
+                ctx.LogStructureAuthority("Index_FlagEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
+                    $"resolvedDir={direction}");
                 ctx.Log?.Invoke($"[ENTRY][INDEX_FLAG][WIDEN_ALLOW] code=DIRECTION_FROM_LOGIC_BIAS direction={direction}");
             }
 
             int barsSinceImpulse = ctx.GetBarsSinceImpulse(direction);
             bool recentDirectionalImpulse = barsSinceImpulse >= 0 && barsSinceImpulse <= 14;
-            bool hasImpulse = ctx.Structure.HasImpulse || recentDirectionalImpulse;
+            bool hasImpulse = ctx.Structure.HasImpulse || recentDirectionalImpulse || ctx.IsStructureImpulseAuthoritative();
+            if (!ctx.Structure.HasImpulse && hasImpulse)
+            {
+                ctx.LogStructureAuthority("Index_FlagEntry", "IMPULSE_OK", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("Index_FlagEntry", "ALT_PATH_USED", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse}");
+            }
             if (!hasImpulse)
             {
+                ctx.LogStructureAuthority("Index_FlagEntry", "STILL_FAIL", "HasImpulse", "NONE",
+                    $"barsSinceImpulse={barsSinceImpulse}");
                 ctx.Log?.Invoke("[ENTRY][INDEX_FLAG][BLOCK] reason=NO_IMPULSE");
                 return Reject(ctx, "NO_IMPULSE", 0, TradeDirection.None);
             }
@@ -54,21 +69,40 @@ namespace GeminiV26.EntryTypes.INDEX
                 ctx.Structure.PullbackDepth <= 0.22 &&
                 ctx.Structure.ImpulseStrength >= 0.45 &&
                 (ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal || trendFollowThrough);
-            if (!ctx.Structure.HasPullback && !shallowPullbackWidened)
+            bool pullbackOk = ctx.Structure.HasPullback || shallowPullbackWidened || ctx.IsStructurePullbackAuthoritative();
+            if (!ctx.Structure.HasPullback && pullbackOk)
             {
+                ctx.LogStructureAuthority("Index_FlagEntry", "PULLBACK_OK", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={ctx.Structure.PullbackDepth:0.00} shallow={ctx.Structure.PullbackShallowOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("Index_FlagEntry", "ALT_PATH_USED", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={ctx.Structure.PullbackDepth:0.00}");
+            }
+            if (!pullbackOk)
+            {
+                ctx.LogStructureAuthority("Index_FlagEntry", "STILL_FAIL", "HasPullback", "NONE",
+                    $"depth={ctx.Structure.PullbackDepth:0.00}");
                 ctx.Log?.Invoke("[ENTRY][INDEX_FLAG][BLOCK][CODE=NO_PULLBACK]");
                 return Reject(ctx, "NO_PULLBACK", 0, TradeDirection.None);
             }
             if (shallowPullbackWidened)
                 ctx.Log?.Invoke($"[ENTRY][INDEX_FLAG][WIDEN_ALLOW] code=SHALLOW_PULLBACK depth={ctx.Structure.PullbackDepth:0.00}");
 
-            bool hasFlag = ctx.Structure.HasFlag;
+            bool hasFlag = ctx.Structure.HasFlag || ctx.IsStructureFlagAuthoritative();
             bool weakButUsableFlag =
                 ctx.Structure.FlagBars >= 2 &&
                 ctx.Structure.PullbackDepth <= 0.72 &&
                 ctx.Structure.FlagCompression <= 0.80;
+            if (!ctx.Structure.HasFlag && hasFlag)
+            {
+                ctx.LogStructureAuthority("Index_FlagEntry", "FLAG_OK", "HasFlag", "FlagMessyOk",
+                    $"flagBars={ctx.Structure.FlagBars} compression={ctx.Structure.FlagCompression:0.00} messy={ctx.Structure.FlagMessyOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("Index_FlagEntry", "ALT_PATH_USED", "HasFlag", "FlagMessyOk",
+                    $"flagBars={ctx.Structure.FlagBars}");
+            }
             if (!hasFlag && !weakButUsableFlag)
             {
+                ctx.LogStructureAuthority("Index_FlagEntry", "STILL_FAIL", "HasFlag", "NONE",
+                    $"flagBars={ctx.Structure.FlagBars} compression={ctx.Structure.FlagCompression:0.00}");
                 ctx.Log?.Invoke($"[ENTRY][INDEX_FLAG][BLOCK][CODE=INVALID_FLAG] flagBars={ctx.Structure.FlagBars} pullbackDepth={ctx.Structure.PullbackDepth:0.00} compression={ctx.Structure.FlagCompression:0.00}");
                 return Reject(ctx, "INVALID_FLAG", 0, TradeDirection.None);
             }

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -21,6 +21,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 return Reject(ctx, TradeDirection.None, 0, "CTX_NOT_READY");
 
             var direction = ctx.Structure.StructureDirection;
+            bool strictDirection = direction == TradeDirection.Long || direction == TradeDirection.Short;
             bool trendFollowThrough = ctx.LastClosedBarInTrendDirection || ctx.M1TriggerInTrendDirection || ctx.HasReactionCandle_M5;
             if (direction == TradeDirection.None)
             {
@@ -30,16 +31,37 @@ namespace GeminiV26.EntryTypes.INDEX
                     (ctx.Structure.PullbackEarlySignal || ctx.Structure.PullbackConfirmedSignal || ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal) &&
                     trendFollowThrough;
                 if (!canUseLogicDirection)
+                {
+                    ctx.LogStructureAuthority("Index_PullbackEntry", "STILL_FAIL", "StructureDirection", "NONE",
+                        $"reason=structure_direction_missing source={ctx.Structure.DirectionSource ?? "NA"}");
                     return Reject(ctx, TradeDirection.None, 0, "structure_direction_missing");
+                }
 
                 direction = logicDirection;
+                if (!strictDirection)
+                {
+                    ctx.LogStructureAuthority("Index_PullbackEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
+                        $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={direction}");
+                    ctx.LogStructureAuthority("Index_PullbackEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
+                        $"resolvedDir={direction}");
+                }
                 ctx.Log?.Invoke($"[ENTRY][INDEX_PB][WIDEN_ALLOW] code=DIRECTION_FROM_LOGIC_BIAS direction={direction}");
             }
 
             int barsSinceImpulse = ctx.GetBarsSinceImpulse(direction);
             bool recentImpulseWidened = !ctx.Structure.HasImpulse && barsSinceImpulse >= 0 && barsSinceImpulse <= 14;
-            if (!ctx.Structure.HasImpulse && !recentImpulseWidened)
+            bool impulseOk = ctx.Structure.HasImpulse || recentImpulseWidened || ctx.IsStructureImpulseAuthoritative();
+            if (!ctx.Structure.HasImpulse && impulseOk)
             {
+                ctx.LogStructureAuthority("Index_PullbackEntry", "IMPULSE_OK", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("Index_PullbackEntry", "ALT_PATH_USED", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse}");
+            }
+            if (!impulseOk)
+            {
+                ctx.LogStructureAuthority("Index_PullbackEntry", "STILL_FAIL", "HasImpulse", "NONE",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()}");
                 ctx.Log?.Invoke("[ENTRY][PULLBACK][STRUCTURE_ERROR] violation=no_trade_without_impulse");
                 return Reject(ctx, TradeDirection.None, 0, "no_impulse");
             }
@@ -51,8 +73,18 @@ namespace GeminiV26.EntryTypes.INDEX
                 ctx.Structure.HasMicroPullback &&
                 ctx.Structure.PullbackDepth <= 0.20 &&
                 (ctx.Structure.PullbackEarlySignal || ctx.Structure.ContinuationEarlySignal || trendFollowThrough);
-            if (!ctx.Structure.HasPullback && !shallowPullbackWidened)
+            bool pullbackOk = ctx.Structure.HasPullback || shallowPullbackWidened || ctx.IsStructurePullbackAuthoritative();
+            if (!ctx.Structure.HasPullback && pullbackOk)
             {
+                ctx.LogStructureAuthority("Index_PullbackEntry", "PULLBACK_OK", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={ctx.Structure.PullbackDepth:0.00} shallow={ctx.Structure.PullbackShallowOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("Index_PullbackEntry", "ALT_PATH_USED", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={ctx.Structure.PullbackDepth:0.00}");
+            }
+            if (!pullbackOk)
+            {
+                ctx.LogStructureAuthority("Index_PullbackEntry", "STILL_FAIL", "HasPullback", "NONE",
+                    $"depth={ctx.Structure.PullbackDepth:0.00}");
                 ctx.Log?.Invoke("[ENTRY][PULLBACK][STRUCTURE_ERROR] violation=no_pullback_entry_without_retrace");
                 return Reject(ctx, TradeDirection.None, 0, "no_pullback");
             }

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -37,12 +37,32 @@ namespace GeminiV26.EntryTypes.METAL
                 barsSinceImpulse >= 0 &&
                 barsSinceImpulse <= 10 &&
                 ctx.Structure.ImpulseStrength >= 0.50;
+            bool impulseOk = ctx.Structure.HasImpulse || recentImpulseWidened || ctx.IsStructureImpulseAuthoritative();
             bool flagShapeWidened =
                 !ctx.Structure.HasFlag &&
                 ctx.Structure.FlagBars >= 2 &&
                 (ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal || ctx.HasReactionCandle_M5);
-            if ((!ctx.Structure.HasImpulse && !recentImpulseWidened) || (!ctx.Structure.HasFlag && !flagShapeWidened))
+            bool flagOk = ctx.Structure.HasFlag || flagShapeWidened || ctx.IsStructureFlagAuthoritative();
+            if (!ctx.Structure.HasImpulse && impulseOk)
+            {
+                ctx.LogStructureAuthority("XAU_FlagEntry", "IMPULSE_OK", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("XAU_FlagEntry", "ALT_PATH_USED", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse}");
+            }
+            if (!ctx.Structure.HasFlag && flagOk)
+            {
+                ctx.LogStructureAuthority("XAU_FlagEntry", "FLAG_OK", "HasFlag", "FlagMessyOk",
+                    $"flagBars={ctx.Structure.FlagBars} compression={ctx.Structure.FlagCompression:0.00} messy={ctx.Structure.FlagMessyOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("XAU_FlagEntry", "ALT_PATH_USED", "HasFlag", "FlagMessyOk",
+                    $"flagBars={ctx.Structure.FlagBars}");
+            }
+            if (!impulseOk || !flagOk)
+            {
+                ctx.LogStructureAuthority("XAU_FlagEntry", "STILL_FAIL", "HasImpulse|HasFlag", "NONE",
+                    $"impulseOk={impulseOk.ToString().ToLowerInvariant()} flagOk={flagOk.ToString().ToLowerInvariant()} barsSinceImpulse={barsSinceImpulse}");
                 return Reject(ctx, dir, "NO_STRUCTURE", "[ENTRY][XAU_FLAG][WIDEN_STILL_BLOCK][CODE=NO_STRUCTURE]");
+            }
             if (recentImpulseWidened)
                 ctx.Log?.Invoke($"[ENTRY][XAU_FLAG][WIDEN_ALLOW] code=RECENT_IMPULSE barsSinceImpulse={barsSinceImpulse}");
             if (flagShapeWidened)

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -35,14 +35,34 @@ namespace GeminiV26.EntryTypes.METAL
                 barsSinceImpulse >= 0 &&
                 barsSinceImpulse <= 8 &&
                 ctx.Structure.ImpulseStrength >= 0.50;
+            bool impulseOk = ctx.Structure.HasImpulse || recentImpulseWidened || ctx.IsStructureImpulseAuthoritative();
             bool shallowPullbackWidened =
                 !ctx.Structure.HasPullback &&
                 ctx.Structure.HasMicroPullback &&
                 ctx.Structure.PullbackDepth >= 0.06 &&
                 ctx.Structure.PullbackDepth <= 0.24 &&
                 (ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal || ctx.HasReactionCandle_M5);
-            if ((!ctx.Structure.HasImpulse && !recentImpulseWidened) || (!ctx.Structure.HasPullback && !shallowPullbackWidened))
+            bool pullbackOk = ctx.Structure.HasPullback || shallowPullbackWidened || ctx.IsStructurePullbackAuthoritative();
+            if (!ctx.Structure.HasImpulse && impulseOk)
+            {
+                ctx.LogStructureAuthority("XAU_PullbackEntry", "IMPULSE_OK", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("XAU_PullbackEntry", "ALT_PATH_USED", "HasImpulse", "ImpulseRecentOk",
+                    $"barsSinceImpulse={barsSinceImpulse}");
+            }
+            if (!ctx.Structure.HasPullback && pullbackOk)
+            {
+                ctx.LogStructureAuthority("XAU_PullbackEntry", "PULLBACK_OK", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={ctx.Structure.PullbackDepth:0.00} shallow={ctx.Structure.PullbackShallowOk.ToString().ToLowerInvariant()}");
+                ctx.LogStructureAuthority("XAU_PullbackEntry", "ALT_PATH_USED", "HasPullback", "PullbackShallowOk|HasMicroPullback",
+                    $"depth={ctx.Structure.PullbackDepth:0.00}");
+            }
+            if (!impulseOk || !pullbackOk)
+            {
+                ctx.LogStructureAuthority("XAU_PullbackEntry", "STILL_FAIL", "HasImpulse|HasPullback", "NONE",
+                    $"impulseOk={impulseOk.ToString().ToLowerInvariant()} pullbackOk={pullbackOk.ToString().ToLowerInvariant()} barsSinceImpulse={barsSinceImpulse}");
                 return Reject(ctx, dir, "NO_IMPULSE_PULLBACK_STRUCTURE", "[ENTRY][XAU_PB][WIDEN_STILL_BLOCK][CODE=NO_IMPULSE_PULLBACK_STRUCTURE]");
+            }
             if (recentImpulseWidened)
                 ctx.Log?.Invoke($"[ENTRY][XAU_PB][WIDEN_ALLOW] code=RECENT_IMPULSE barsSinceImpulse={barsSinceImpulse}");
             if (shallowPullbackWidened)


### PR DESCRIPTION
### Motivation
- Introduce a unified notion of "authority" for structure-derived fields so entry logic can accept authoritative proxies when strict fields are absent.
- Improve diagnostics and early-return handling in structure building routines by adding context/ATR checks and richer log messages that include `symbol` and failure `code` details.
- Reduce duplicated ad-hoc fallback logic across entry types by centralizing checks on the `EntryContext` and standardizing authority logs.

### Description
- Added helper predicates and logging on `EntryContext`: `IsStructureDirectionStrict`, `IsStructureDirectionAuthoritative`, `IsStructureImpulseAuthoritative`, `IsStructurePullbackAuthoritative`, `IsStructureFlagAuthoritative`, and `LogStructureAuthority` to encapsulate authority and diagnostic messages.
- Hardened `EntryContextBuilder` (`BuildImpulseAnchor`, `BuildPullback`, `BuildFlag`) with null/ATR checks, early returns with coded logs (including `symbol` and `code`), and clearer handling for unresolved `StructureDirection` and no-impulse cases.
- Updated multiple entry implementations (crypto, FX, index, metal, etc.) to consult the new `IsStructure*Authoritative` helpers and to compute and use `impulseOk`/`pullbackOk`/`flagOk` fallbacks; added calls to `LogStructureAuthority` where alternative paths are taken or still failing.
- Standardized many log messages to include `symbol` and structured failure codes and added informative log entries when alternate acceptance paths are used.

### Testing
- Built the solution to verify compilation after API and call-site changes and the build completed successfully. 
- Ran the entry evaluation unit tests and CI entry-type test suite that exercise `Crypto`, `FX`, `Index`, and `Metal` entry paths, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea3ccbd3883289d00db89f126da8a)