### PR TITLE
Respect structure direction authority and improve direction resolution logging across entry types

### DIFF
--- a/EntryTypes/CRYPTO/CryptoFlagEntryBase.cs
+++ b/EntryTypes/CRYPTO/CryptoFlagEntryBase.cs
@@ -132,12 +132,24 @@ namespace GeminiV26.EntryTypes.Crypto
 
         private TradeDirection ResolveDirection(EntryContext ctx)
         {
+            TradeDirection strictDirection = ctx?.Structure?.StructureDirection ?? TradeDirection.None;
+            bool structureDirStrict = strictDirection == TradeDirection.Long || strictDirection == TradeDirection.Short;
+            if (structureDirStrict)
+            {
+                ctx?.LogStructureAuthority("CryptoFlagEntryBase", "DIR_OK", "StructureDirection", "StructureDirection",
+                    $"source={ctx?.Structure?.DirectionSource ?? "NA"} resolvedDir={strictDirection} strict=true");
+                return strictDirection;
+            }
+
+            bool structureDirAuthority = ctx?.IsStructureDirectionAuthoritative() == true;
             TradeDirection preFinalDirection = ctx?.LogicBiasDirection ?? TradeDirection.None;
             TradeDirection routedDirection = ctx?.RoutedDirection ?? TradeDirection.None;
             TradeDirection observedFinalDirection = ctx?.FinalDirection ?? TradeDirection.None;
 
-            if (preFinalDirection == TradeDirection.None)
+            if (!structureDirAuthority || preFinalDirection == TradeDirection.None)
             {
+                ctx?.LogStructureAuthority("CryptoFlagEntryBase", "STILL_FAIL", "StructureDirection", "NONE",
+                    $"reason=NO_DIRECTION source={ctx?.Structure?.DirectionSource ?? "NA"} structureAuthority={structureDirAuthority.ToString().ToLowerInvariant()}");
                 ctx?.Log?.Invoke(
                     $"[DIR][CRYPTO][EVAL_NONE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
                 return TradeDirection.None;
@@ -149,6 +161,10 @@ namespace GeminiV26.EntryTypes.Crypto
                     $"[DIR][CRYPTO][EVAL_MISMATCH_WARN] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
             }
 
+            ctx?.LogStructureAuthority("CryptoFlagEntryBase", "DIR_OK", "StructureDirection", "LogicBiasDirection",
+                $"source={ctx?.Structure?.DirectionSource ?? "NA"} resolvedDir={preFinalDirection}");
+            ctx?.LogStructureAuthority("CryptoFlagEntryBase", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
+                $"resolvedDir={preFinalDirection}");
             ctx?.Log?.Invoke(
                 $"[DIR][CRYPTO][EVAL_SOURCE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
             return preFinalDirection;

--- a/EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs
+++ b/EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs
@@ -151,12 +151,24 @@ namespace GeminiV26.EntryTypes.Crypto
 
         private TradeDirection ResolveDirection(EntryContext ctx)
         {
+            TradeDirection strictDirection = ctx?.Structure?.StructureDirection ?? TradeDirection.None;
+            bool structureDirStrict = strictDirection == TradeDirection.Long || strictDirection == TradeDirection.Short;
+            if (structureDirStrict)
+            {
+                ctx?.LogStructureAuthority("CryptoPullbackEntryBase", "DIR_OK", "StructureDirection", "StructureDirection",
+                    $"source={ctx?.Structure?.DirectionSource ?? "NA"} resolvedDir={strictDirection} strict=true");
+                return strictDirection;
+            }
+
+            bool structureDirAuthority = ctx?.IsStructureDirectionAuthoritative() == true;
             TradeDirection preFinalDirection = ctx?.LogicBiasDirection ?? TradeDirection.None;
             TradeDirection routedDirection = ctx?.RoutedDirection ?? TradeDirection.None;
             TradeDirection observedFinalDirection = ctx?.FinalDirection ?? TradeDirection.None;
 
-            if (preFinalDirection == TradeDirection.None)
+            if (!structureDirAuthority || preFinalDirection == TradeDirection.None)
             {
+                ctx?.LogStructureAuthority("CryptoPullbackEntryBase", "STILL_FAIL", "StructureDirection", "NONE",
+                    $"reason=NO_DIRECTION source={ctx?.Structure?.DirectionSource ?? "NA"} structureAuthority={structureDirAuthority.ToString().ToLowerInvariant()}");
                 ctx?.Log?.Invoke(
                     $"[DIR][CRYPTO][EVAL_NONE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
                 return TradeDirection.None;
@@ -168,6 +180,10 @@ namespace GeminiV26.EntryTypes.Crypto
                     $"[DIR][CRYPTO][EVAL_MISMATCH_WARN] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
             }
 
+            ctx?.LogStructureAuthority("CryptoPullbackEntryBase", "DIR_OK", "StructureDirection", "LogicBiasDirection",
+                $"source={ctx?.Structure?.DirectionSource ?? "NA"} resolvedDir={preFinalDirection}");
+            ctx?.LogStructureAuthority("CryptoPullbackEntryBase", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
+                $"resolvedDir={preFinalDirection}");
             ctx?.Log?.Invoke(
                 $"[DIR][CRYPTO][EVAL_SOURCE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
             return preFinalDirection;

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -21,6 +21,8 @@ namespace GeminiV26.EntryTypes.FX
             bool hasPullback = ctx.Structure?.HasPullback == true;
             bool hasFlag = ctx.Structure?.HasFlag == true;
             var direction = ctx.Structure?.StructureDirection ?? TradeDirection.None;
+            bool structureDirStrict = direction == TradeDirection.Long || direction == TradeDirection.Short;
+            bool structureDirAuthority = ctx.IsStructureDirectionAuthoritative();
             bool impulseStrict = hasImpulse;
             bool pullbackStrict = hasPullback;
             bool flagStrict = hasFlag;
@@ -50,6 +52,7 @@ namespace GeminiV26.EntryTypes.FX
             {
                 var logicDirection = ctx.LogicBiasDirection;
                 bool canUseLogicDirection =
+                    structureDirAuthority &&
                     (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
                     hasContinuationSignal &&
                     trendFollowThrough;
@@ -70,6 +73,11 @@ namespace GeminiV26.EntryTypes.FX
                 barsSinceImpulse = ctx.GetBarsSinceImpulse(direction);
                 hasRecentDirectionalImpulse = barsSinceImpulse >= 0 && barsSinceImpulse <= 12;
                 ctx.Log?.Invoke($"[ENTRY][FX_FLAG][WIDEN_ALLOW] code=DIRECTION_FROM_LOGIC_BIAS direction={direction}");
+            }
+            else if (structureDirStrict)
+            {
+                ctx.LogStructureAuthority("FX_FlagContinuationEntry", "DIR_OK", "StructureDirection", "StructureDirection",
+                    $"source={ctx.Structure?.DirectionSource ?? "NA"} resolvedDir={direction} strict=true");
             }
 
             bool impulseOk = hasImpulse || hasRecentDirectionalImpulse || ctx.IsStructureImpulseAuthoritative();

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -18,6 +18,8 @@ namespace GeminiV26.EntryTypes.FX
             LogStructure(ctx);
 
             var structureDirection = ctx.Structure?.StructureDirection ?? TradeDirection.None;
+            bool structureDirStrict = structureDirection == TradeDirection.Long || structureDirection == TradeDirection.Short;
+            bool structureDirAuthority = ctx.IsStructureDirectionAuthoritative();
 
             bool hasImpulse = ctx.Structure?.HasImpulse == true;
             bool hasPullback = ctx.Structure?.HasPullback == true;
@@ -39,6 +41,7 @@ namespace GeminiV26.EntryTypes.FX
             {
                 var logicDirection = ctx.LogicBiasDirection;
                 bool canUseLogicDirection =
+                    structureDirAuthority &&
                     (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
                     (early || confirmed) &&
                     trendFollowThrough;
@@ -61,6 +64,11 @@ namespace GeminiV26.EntryTypes.FX
                     barsSinceImpulse <= 14 &&
                     (ctx.Structure?.ImpulseStrength ?? 0.0) >= 0.45;
                 ctx.Log?.Invoke($"[ENTRY][FX_IMPULSE][WIDEN_ALLOW] code=DIRECTION_FROM_LOGIC_BIAS direction={structureDirection}");
+            }
+            else if (structureDirStrict)
+            {
+                ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "DIR_OK", "StructureDirection", "StructureDirection",
+                    $"source={ctx.Structure?.DirectionSource ?? "NA"} resolvedDir={structureDirection} strict=true");
             }
 
             ctx.Log?.Invoke(

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -21,11 +21,14 @@ namespace GeminiV26.EntryTypes.INDEX
                 return Reject(ctx, "CTX_NOT_READY", 0, TradeDirection.None);
 
             var direction = ctx.Structure.StructureDirection;
+            bool structureDirStrict = direction == TradeDirection.Long || direction == TradeDirection.Short;
+            bool structureDirAuthority = ctx.IsStructureDirectionAuthoritative();
             bool trendFollowThrough = ctx.LastClosedBarInTrendDirection || ctx.M1TriggerInTrendDirection || ctx.HasReactionCandle_M5;
             if (direction == TradeDirection.None)
             {
                 var logicDirection = ctx.LogicBiasDirection;
                 bool canUseLogicDirection =
+                    structureDirAuthority &&
                     (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
                     (ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal) &&
                     trendFollowThrough;
@@ -43,6 +46,11 @@ namespace GeminiV26.EntryTypes.INDEX
                 ctx.LogStructureAuthority("Index_FlagEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
                     $"resolvedDir={direction}");
                 ctx.Log?.Invoke($"[ENTRY][INDEX_FLAG][WIDEN_ALLOW] code=DIRECTION_FROM_LOGIC_BIAS direction={direction}");
+            }
+            else if (structureDirStrict)
+            {
+                ctx.LogStructureAuthority("Index_FlagEntry", "DIR_OK", "StructureDirection", "StructureDirection",
+                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={direction} strict=true");
             }
 
             int barsSinceImpulse = ctx.GetBarsSinceImpulse(direction);

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -22,11 +22,13 @@ namespace GeminiV26.EntryTypes.INDEX
 
             var direction = ctx.Structure.StructureDirection;
             bool strictDirection = direction == TradeDirection.Long || direction == TradeDirection.Short;
+            bool structureDirAuthority = ctx.IsStructureDirectionAuthoritative();
             bool trendFollowThrough = ctx.LastClosedBarInTrendDirection || ctx.M1TriggerInTrendDirection || ctx.HasReactionCandle_M5;
             if (direction == TradeDirection.None)
             {
                 var logicDirection = ctx.LogicBiasDirection;
                 bool canUseLogicDirection =
+                    structureDirAuthority &&
                     (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
                     (ctx.Structure.PullbackEarlySignal || ctx.Structure.PullbackConfirmedSignal || ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal) &&
                     trendFollowThrough;
@@ -46,6 +48,11 @@ namespace GeminiV26.EntryTypes.INDEX
                         $"resolvedDir={direction}");
                 }
                 ctx.Log?.Invoke($"[ENTRY][INDEX_PB][WIDEN_ALLOW] code=DIRECTION_FROM_LOGIC_BIAS direction={direction}");
+            }
+            else if (strictDirection)
+            {
+                ctx.LogStructureAuthority("Index_PullbackEntry", "DIR_OK", "StructureDirection", "StructureDirection",
+                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={direction} strict=true");
             }
 
             int barsSinceImpulse = ctx.GetBarsSinceImpulse(direction);

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -27,9 +27,34 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < MinBars)
                 return Reject(ctx, TradeDirection.None, "CTX_NOT_READY", "[ENTRY][XAU_FLAG][BLOCK_CTX]");
 
-            var dir = ctx.LogicBiasDirection;
-            if (dir == TradeDirection.None)
-                return Reject(ctx, TradeDirection.None, "NO_LOGIC_BIAS", "[ENTRY][XAU_FLAG][BLOCK_DIR]");
+            TradeDirection dir = ctx.Structure.StructureDirection;
+            bool structureDirStrict = dir == TradeDirection.Long || dir == TradeDirection.Short;
+            bool structureDirAuthority = ctx.IsStructureDirectionAuthoritative();
+            if (!structureDirStrict)
+            {
+                var logicDirection = ctx.LogicBiasDirection;
+                bool canUseLogicDirection =
+                    structureDirAuthority &&
+                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
+                    (ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal || ctx.LastClosedBarInTrendDirection || ctx.M1TriggerInTrendDirection);
+                if (!canUseLogicDirection)
+                {
+                    ctx.LogStructureAuthority("XAU_FlagEntry", "STILL_FAIL", "StructureDirection", "NONE",
+                        $"reason=NO_DIRECTION source={ctx.Structure.DirectionSource ?? "NA"}");
+                    return Reject(ctx, TradeDirection.None, "NO_LOGIC_BIAS", "[ENTRY][XAU_FLAG][BLOCK_DIR]");
+                }
+
+                dir = logicDirection;
+                ctx.LogStructureAuthority("XAU_FlagEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
+                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={dir}");
+                ctx.LogStructureAuthority("XAU_FlagEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
+                    $"resolvedDir={dir}");
+            }
+            else
+            {
+                ctx.LogStructureAuthority("XAU_FlagEntry", "DIR_OK", "StructureDirection", "StructureDirection",
+                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={dir} strict=true");
+            }
 
             int barsSinceImpulse = dir == TradeDirection.Long ? ctx.BarsSinceImpulseLong : ctx.BarsSinceImpulseShort;
             bool recentImpulseWidened =

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -25,9 +25,34 @@ namespace GeminiV26.EntryTypes.METAL
             if (ctx == null || !ctx.IsReady || ctx.M5 == null || ctx.M5.Count < MinBars)
                 return Reject(ctx, TradeDirection.None, "CTX_NOT_READY", "[ENTRY][XAU_PB][BLOCK_CTX]");
 
-            var dir = ctx.LogicBiasDirection;
-            if (dir == TradeDirection.None)
-                return Reject(ctx, TradeDirection.None, "NO_LOGIC_BIAS", "[ENTRY][XAU_PB][BLOCK_DIR]");
+            TradeDirection dir = ctx.Structure.StructureDirection;
+            bool structureDirStrict = dir == TradeDirection.Long || dir == TradeDirection.Short;
+            bool structureDirAuthority = ctx.IsStructureDirectionAuthoritative();
+            if (!structureDirStrict)
+            {
+                var logicDirection = ctx.LogicBiasDirection;
+                bool canUseLogicDirection =
+                    structureDirAuthority &&
+                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
+                    (ctx.Structure.PullbackEarlySignal || ctx.Structure.PullbackConfirmedSignal || ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal || ctx.LastClosedBarInTrendDirection);
+                if (!canUseLogicDirection)
+                {
+                    ctx.LogStructureAuthority("XAU_PullbackEntry", "STILL_FAIL", "StructureDirection", "NONE",
+                        $"reason=NO_DIRECTION source={ctx.Structure.DirectionSource ?? "NA"}");
+                    return Reject(ctx, TradeDirection.None, "NO_LOGIC_BIAS", "[ENTRY][XAU_PB][BLOCK_DIR]");
+                }
+
+                dir = logicDirection;
+                ctx.LogStructureAuthority("XAU_PullbackEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
+                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={dir}");
+                ctx.LogStructureAuthority("XAU_PullbackEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
+                    $"resolvedDir={dir}");
+            }
+            else
+            {
+                ctx.LogStructureAuthority("XAU_PullbackEntry", "DIR_OK", "StructureDirection", "StructureDirection",
+                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={dir} strict=true");
+            }
 
             int barsSinceImpulse = dir == TradeDirection.Long ? ctx.BarsSinceImpulseLong : ctx.BarsSinceImpulseShort;
             bool recentImpulseWidened =


### PR DESCRIPTION
### Motivation

- Ensure strict `StructureDirection` is honored and used immediately when present to avoid incorrect direction widening.
- Require structural authority before allowing direction widening from `LogicBiasDirection` to prevent false positives.  
- Improve diagnostics by adding `LogStructureAuthority` calls so direction and authority decisions are auditable.

### Description

- Add local `structureDirStrict` and `structureDirAuthority` checks (via `IsStructureDirectionAuthoritative()`) and prefer returning `StructureDirection` when strict in crypto `ResolveDirection` implementations.  
- Guard use of `LogicBiasDirection` behind the `structureDirAuthority` check and only allow widening when authoritative; otherwise block or return `TradeDirection.None`.  
- Add `ctx.LogStructureAuthority` calls and `ALT_PATH_USED`/`DIR_OK`/`STILL_FAIL` diagnostics across multiple entry types including `CryptoFlagEntryBase`, `CryptoPullbackEntryBase`, `FX_FlagContinuationEntry`, `FX_ImpulseContinuationEntry`, `Index_FlagEntry`, `Index_PullbackEntry`, `XAU_FlagEntry`, and `XAU_PullbackEntry`.  
- Adjusted flow for handling resolved direction, updated related computed variables (e.g. `barsSinceImpulse`, `alignedBreakout`) when direction is sourced from `LogicBiasDirection`, and tightened logging messages for mismatch and widening cases.

### Testing

- Built the solution with `dotnet build` to validate compilation and confirm no build errors.  
- Executed the automated unit test suite with `dotnet test` and local tests completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb294472c8328b1064ce7d64bb751)