### PR TITLE
Enforce composite structure authority over strict entry invalidation

### DIFF
--- a/Core/Entry/EntryContext.cs
+++ b/Core/Entry/EntryContext.cs
@@ -457,8 +457,17 @@ namespace GeminiV26.Core.Entry
 
         public void LogStructureAuthority(string entryFamily, string tag, string strictFieldFailed, string rescueField, string details = null)
         {
+            bool strictDir = IsStructureDirectionStrict();
+            bool strictImpulse = Structure?.HasImpulse == true;
+            bool strictPullback = Structure?.HasPullback == true;
+            bool strictFlag = Structure?.HasFlag == true;
+            bool dirAuth = IsStructureDirectionAuthoritative();
+            bool impulseAuth = IsStructureImpulseAuthoritative();
+            bool pullbackAuth = IsStructurePullbackAuthoritative();
+            bool flagAuth = IsStructureFlagAuthoritative();
+            bool finalValid = !string.Equals(tag, "STILL_FAIL", StringComparison.OrdinalIgnoreCase);
             Log?.Invoke(
-                $"[STRUCT][AUTH][{tag}] symbol={Symbol} entry={entryFamily} strictFailed={strictFieldFailed} rescue={rescueField} {details ?? "details=NA"}");
+                $"[STRUCT][AUTH][{tag}] symbol={Symbol} entry={entryFamily} strictFailed={strictFieldFailed} rescue={rescueField} strictState=dir:{strictDir.ToString().ToLowerInvariant()}|impulse:{strictImpulse.ToString().ToLowerInvariant()}|pullback:{strictPullback.ToString().ToLowerInvariant()}|flag:{strictFlag.ToString().ToLowerInvariant()} compositeState=dir:{dirAuth.ToString().ToLowerInvariant()}|impulse:{impulseAuth.ToString().ToLowerInvariant()}|pullback:{pullbackAuth.ToString().ToLowerInvariant()}|flag:{flagAuth.ToString().ToLowerInvariant()} finalValid={finalValid.ToString().ToLowerInvariant()} {details ?? "details=NA"}");
         }
 
         public bool HasDirectionalPullback(TradeDirection direction)

--- a/EntryTypes/CRYPTO/CryptoFlagEntryBase.cs
+++ b/EntryTypes/CRYPTO/CryptoFlagEntryBase.cs
@@ -28,7 +28,7 @@ namespace GeminiV26.EntryTypes.Crypto
                 return Reject(ctx, TradeDirection.None, "NO_VALID_DIRECTION");
 
             int barsSinceImpulse = dir == TradeDirection.Long ? ctx.BarsSinceImpulseLong : ctx.BarsSinceImpulseShort;
-            if (barsSinceImpulse < 0)
+            if (barsSinceImpulse < 0 && !ctx.IsStructureImpulseAuthoritative())
                 return Reject(ctx, dir, "NO_RECENT_IMPULSE");
             bool trendFollowThrough = ctx.LastClosedBarInTrendDirection || ctx.HasReactionCandle_M5 || ctx.M1TriggerInTrendDirection;
             bool recentImpulseWidened =
@@ -145,29 +145,32 @@ namespace GeminiV26.EntryTypes.Crypto
             TradeDirection preFinalDirection = ctx?.LogicBiasDirection ?? TradeDirection.None;
             TradeDirection routedDirection = ctx?.RoutedDirection ?? TradeDirection.None;
             TradeDirection observedFinalDirection = ctx?.FinalDirection ?? TradeDirection.None;
+            TradeDirection resolvedDirection = preFinalDirection != TradeDirection.None
+                ? preFinalDirection
+                : (routedDirection != TradeDirection.None ? routedDirection : observedFinalDirection);
 
-            if (!structureDirAuthority || preFinalDirection == TradeDirection.None)
+            if (!structureDirAuthority || resolvedDirection == TradeDirection.None)
             {
                 ctx?.LogStructureAuthority("CryptoFlagEntryBase", "STILL_FAIL", "StructureDirection", "NONE",
-                    $"reason=NO_DIRECTION source={ctx?.Structure?.DirectionSource ?? "NA"} structureAuthority={structureDirAuthority.ToString().ToLowerInvariant()}");
+                    $"reason=NO_DIRECTION source={ctx?.Structure?.DirectionSource ?? "NA"} structureAuthority={structureDirAuthority.ToString().ToLowerInvariant()} finalValid=false");
                 ctx?.Log?.Invoke(
                     $"[DIR][CRYPTO][EVAL_NONE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
                 return TradeDirection.None;
             }
 
-            if (observedFinalDirection != TradeDirection.None && observedFinalDirection != preFinalDirection)
+            if (observedFinalDirection != TradeDirection.None && observedFinalDirection != resolvedDirection)
             {
                 ctx?.Log?.Invoke(
-                    $"[DIR][CRYPTO][EVAL_MISMATCH_WARN] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
+                    $"[DIR][CRYPTO][EVAL_MISMATCH_WARN] symbol={ctx?.Symbol} entryType={Type} source=CompositeDirection chosen={resolvedDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
             }
 
             ctx?.LogStructureAuthority("CryptoFlagEntryBase", "DIR_OK", "StructureDirection", "LogicBiasDirection",
-                $"source={ctx?.Structure?.DirectionSource ?? "NA"} resolvedDir={preFinalDirection}");
+                $"source={ctx?.Structure?.DirectionSource ?? "NA"} resolvedDir={resolvedDirection} finalValid=true");
             ctx?.LogStructureAuthority("CryptoFlagEntryBase", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
-                $"resolvedDir={preFinalDirection}");
+                $"resolvedDir={resolvedDirection}");
             ctx?.Log?.Invoke(
-                $"[DIR][CRYPTO][EVAL_SOURCE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
-            return preFinalDirection;
+                $"[DIR][CRYPTO][EVAL_SOURCE] symbol={ctx?.Symbol} entryType={Type} source=CompositeDirection chosen={resolvedDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
+            return resolvedDirection;
         }
 
         protected EntryEvaluation Reject(EntryContext ctx, TradeDirection dir, string reason)

--- a/EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs
+++ b/EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs
@@ -164,29 +164,32 @@ namespace GeminiV26.EntryTypes.Crypto
             TradeDirection preFinalDirection = ctx?.LogicBiasDirection ?? TradeDirection.None;
             TradeDirection routedDirection = ctx?.RoutedDirection ?? TradeDirection.None;
             TradeDirection observedFinalDirection = ctx?.FinalDirection ?? TradeDirection.None;
+            TradeDirection resolvedDirection = preFinalDirection != TradeDirection.None
+                ? preFinalDirection
+                : (routedDirection != TradeDirection.None ? routedDirection : observedFinalDirection);
 
-            if (!structureDirAuthority || preFinalDirection == TradeDirection.None)
+            if (!structureDirAuthority || resolvedDirection == TradeDirection.None)
             {
                 ctx?.LogStructureAuthority("CryptoPullbackEntryBase", "STILL_FAIL", "StructureDirection", "NONE",
-                    $"reason=NO_DIRECTION source={ctx?.Structure?.DirectionSource ?? "NA"} structureAuthority={structureDirAuthority.ToString().ToLowerInvariant()}");
+                    $"reason=NO_DIRECTION source={ctx?.Structure?.DirectionSource ?? "NA"} structureAuthority={structureDirAuthority.ToString().ToLowerInvariant()} finalValid=false");
                 ctx?.Log?.Invoke(
                     $"[DIR][CRYPTO][EVAL_NONE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
                 return TradeDirection.None;
             }
 
-            if (observedFinalDirection != TradeDirection.None && observedFinalDirection != preFinalDirection)
+            if (observedFinalDirection != TradeDirection.None && observedFinalDirection != resolvedDirection)
             {
                 ctx?.Log?.Invoke(
-                    $"[DIR][CRYPTO][EVAL_MISMATCH_WARN] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
+                    $"[DIR][CRYPTO][EVAL_MISMATCH_WARN] symbol={ctx?.Symbol} entryType={Type} source=CompositeDirection chosen={resolvedDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
             }
 
             ctx?.LogStructureAuthority("CryptoPullbackEntryBase", "DIR_OK", "StructureDirection", "LogicBiasDirection",
-                $"source={ctx?.Structure?.DirectionSource ?? "NA"} resolvedDir={preFinalDirection}");
+                $"source={ctx?.Structure?.DirectionSource ?? "NA"} resolvedDir={resolvedDirection} finalValid=true");
             ctx?.LogStructureAuthority("CryptoPullbackEntryBase", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
-                $"resolvedDir={preFinalDirection}");
+                $"resolvedDir={resolvedDirection}");
             ctx?.Log?.Invoke(
-                $"[DIR][CRYPTO][EVAL_SOURCE] symbol={ctx?.Symbol} entryType={Type} source=LogicBiasDirection chosen={preFinalDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
-            return preFinalDirection;
+                $"[DIR][CRYPTO][EVAL_SOURCE] symbol={ctx?.Symbol} entryType={Type} source=CompositeDirection chosen={resolvedDirection} logic={preFinalDirection} routed={routedDirection} final={observedFinalDirection}");
+            return resolvedDirection;
         }
 
         protected EntryEvaluation Reject(EntryContext ctx, TradeDirection dir, string reason)

--- a/EntryTypes/FX/FX_FlagContinuationEntry.cs
+++ b/EntryTypes/FX/FX_FlagContinuationEntry.cs
@@ -53,19 +53,17 @@ namespace GeminiV26.EntryTypes.FX
                 var logicDirection = ctx.LogicBiasDirection;
                 bool canUseLogicDirection =
                     structureDirAuthority &&
-                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
-                    hasContinuationSignal &&
-                    trendFollowThrough;
+                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short);
                 if (!canUseLogicDirection)
                 {
                     ctx.LogStructureAuthority("FX_FlagContinuationEntry", "STILL_FAIL", "StructureDirection", "NONE",
-                        $"reason=NO_DIRECTION source={ctx.Structure?.DirectionSource ?? "NA"}");
+                        $"reason=NO_DIRECTION source={ctx.Structure?.DirectionSource ?? "NA"} finalValid=false");
                     return Block(ctx, "NO_DIRECTION");
                 }
 
                 direction = logicDirection;
                 ctx.LogStructureAuthority("FX_FlagContinuationEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
-                    $"source={ctx.Structure?.DirectionSource ?? "NA"} resolvedDir={direction}");
+                    $"source={ctx.Structure?.DirectionSource ?? "NA"} resolvedDir={direction} finalValid=true");
                 ctx.LogStructureAuthority("FX_FlagContinuationEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
                     $"resolvedDir={direction}");
                 alignedBreakout = direction == TradeDirection.Long ? breakoutUp : breakoutDown;
@@ -84,7 +82,7 @@ namespace GeminiV26.EntryTypes.FX
             if (!impulseStrict && impulseOk)
             {
                 ctx.LogStructureAuthority("FX_FlagContinuationEntry", "IMPULSE_OK", "HasImpulse", "ImpulseRecentOk",
-                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure?.ImpulseRecentOk.ToString().ToLowerInvariant()}");
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={ctx.Structure?.ImpulseRecentOk.ToString().ToLowerInvariant()} finalValid=true");
                 ctx.LogStructureAuthority("FX_FlagContinuationEntry", "ALT_PATH_USED", "HasImpulse", "ImpulseRecentOk",
                     $"barsSinceImpulse={barsSinceImpulse}");
             }
@@ -106,7 +104,7 @@ namespace GeminiV26.EntryTypes.FX
             if (!pullbackStrict && pullbackOk)
             {
                 ctx.LogStructureAuthority("FX_FlagContinuationEntry", "PULLBACK_OK", "HasPullback", "PullbackShallowOk|HasMicroPullback",
-                    $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00} shallow={(ctx.Structure?.PullbackShallowOk ?? false).ToString().ToLowerInvariant()} micro={(ctx.Structure?.HasMicroPullback ?? false).ToString().ToLowerInvariant()}");
+                    $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00} shallow={(ctx.Structure?.PullbackShallowOk ?? false).ToString().ToLowerInvariant()} micro={(ctx.Structure?.HasMicroPullback ?? false).ToString().ToLowerInvariant()} finalValid=true");
                 ctx.LogStructureAuthority("FX_FlagContinuationEntry", "ALT_PATH_USED", "HasPullback", "PullbackShallowOk|HasMicroPullback",
                     $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00}");
             }
@@ -124,7 +122,7 @@ namespace GeminiV26.EntryTypes.FX
             if (!flagStrict && flagOk)
             {
                 ctx.LogStructureAuthority("FX_FlagContinuationEntry", "FLAG_OK", "HasFlag", "FlagMessyOk",
-                    $"flagBars={ctx.Structure?.FlagBars ?? 0} compression={(ctx.Structure?.FlagCompression ?? 0.0):0.00} messy={(ctx.Structure?.FlagMessyOk ?? false).ToString().ToLowerInvariant()}");
+                    $"flagBars={ctx.Structure?.FlagBars ?? 0} compression={(ctx.Structure?.FlagCompression ?? 0.0):0.00} messy={(ctx.Structure?.FlagMessyOk ?? false).ToString().ToLowerInvariant()} finalValid=true");
                 ctx.LogStructureAuthority("FX_FlagContinuationEntry", "ALT_PATH_USED", "HasFlag", "FlagMessyOk",
                     $"flagBars={ctx.Structure?.FlagBars ?? 0}");
             }

--- a/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
+++ b/EntryTypes/FX/FX_ImpulseContinuationEntry.cs
@@ -42,19 +42,17 @@ namespace GeminiV26.EntryTypes.FX
                 var logicDirection = ctx.LogicBiasDirection;
                 bool canUseLogicDirection =
                     structureDirAuthority &&
-                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
-                    (early || confirmed) &&
-                    trendFollowThrough;
+                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short);
                 if (!canUseLogicDirection)
                 {
                     ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "STILL_FAIL", "StructureDirection", "NONE",
-                        $"reason=NO_DIRECTION source={ctx.Structure?.DirectionSource ?? "NA"}");
+                        $"reason=NO_DIRECTION source={ctx.Structure?.DirectionSource ?? "NA"} finalValid=false");
                     return Block(ctx, "NO_DIRECTION");
                 }
 
                 structureDirection = logicDirection;
                 ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
-                    $"source={ctx.Structure?.DirectionSource ?? "NA"} resolvedDir={structureDirection}");
+                    $"source={ctx.Structure?.DirectionSource ?? "NA"} resolvedDir={structureDirection} finalValid=true");
                 ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
                     $"resolvedDir={structureDirection}");
                 barsSinceImpulse = ctx.GetBarsSinceImpulse(structureDirection);
@@ -78,7 +76,7 @@ namespace GeminiV26.EntryTypes.FX
             if (!impulseStrict && impulseOk)
             {
                 ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "IMPULSE_OK", "HasImpulse", "ImpulseRecentOk",
-                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={(ctx.Structure?.ImpulseRecentOk ?? false).ToString().ToLowerInvariant()}");
+                    $"barsSinceImpulse={barsSinceImpulse} impulseRecent={(ctx.Structure?.ImpulseRecentOk ?? false).ToString().ToLowerInvariant()} finalValid=true");
                 ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "ALT_PATH_USED", "HasImpulse", "ImpulseRecentOk",
                     $"barsSinceImpulse={barsSinceImpulse}");
             }
@@ -101,7 +99,7 @@ namespace GeminiV26.EntryTypes.FX
             if (!pullbackStrict && pullbackOk)
             {
                 ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "PULLBACK_OK", "HasPullback", "PullbackShallowOk|HasMicroPullback",
-                    $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00} shallow={(ctx.Structure?.PullbackShallowOk ?? false).ToString().ToLowerInvariant()}");
+                    $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00} shallow={(ctx.Structure?.PullbackShallowOk ?? false).ToString().ToLowerInvariant()} finalValid=true");
                 ctx.LogStructureAuthority("FX_ImpulseContinuationEntry", "ALT_PATH_USED", "HasPullback", "PullbackShallowOk|HasMicroPullback",
                     $"depth={(ctx.Structure?.PullbackDepth ?? 0.0):0.00}");
             }

--- a/EntryTypes/INDEX/Index_FlagEntry.cs
+++ b/EntryTypes/INDEX/Index_FlagEntry.cs
@@ -29,20 +29,18 @@ namespace GeminiV26.EntryTypes.INDEX
                 var logicDirection = ctx.LogicBiasDirection;
                 bool canUseLogicDirection =
                     structureDirAuthority &&
-                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
-                    (ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal) &&
-                    trendFollowThrough;
+                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short);
                 if (!canUseLogicDirection)
                 {
                     ctx.LogStructureAuthority("Index_FlagEntry", "STILL_FAIL", "StructureDirection", "NONE",
-                        $"reason=NO_DIRECTION source={ctx.Structure.DirectionSource ?? "NA"}");
+                        $"reason=NO_DIRECTION source={ctx.Structure.DirectionSource ?? "NA"} finalValid=false");
                     ctx.Log?.Invoke("[ENTRY][INDEX_FLAG][BLOCK][CODE=NO_DIRECTION]");
                     return Reject(ctx, "NO_DIRECTION", 0, TradeDirection.None);
                 }
 
                 direction = logicDirection;
                 ctx.LogStructureAuthority("Index_FlagEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
-                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={direction}");
+                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={direction} finalValid=true");
                 ctx.LogStructureAuthority("Index_FlagEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
                     $"resolvedDir={direction}");
                 ctx.Log?.Invoke($"[ENTRY][INDEX_FLAG][WIDEN_ALLOW] code=DIRECTION_FROM_LOGIC_BIAS direction={direction}");

--- a/EntryTypes/INDEX/Index_PullbackEntry.cs
+++ b/EntryTypes/INDEX/Index_PullbackEntry.cs
@@ -29,13 +29,11 @@ namespace GeminiV26.EntryTypes.INDEX
                 var logicDirection = ctx.LogicBiasDirection;
                 bool canUseLogicDirection =
                     structureDirAuthority &&
-                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
-                    (ctx.Structure.PullbackEarlySignal || ctx.Structure.PullbackConfirmedSignal || ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal) &&
-                    trendFollowThrough;
+                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short);
                 if (!canUseLogicDirection)
                 {
                     ctx.LogStructureAuthority("Index_PullbackEntry", "STILL_FAIL", "StructureDirection", "NONE",
-                        $"reason=structure_direction_missing source={ctx.Structure.DirectionSource ?? "NA"}");
+                        $"reason=structure_direction_missing source={ctx.Structure.DirectionSource ?? "NA"} finalValid=false");
                     return Reject(ctx, TradeDirection.None, 0, "structure_direction_missing");
                 }
 
@@ -43,7 +41,7 @@ namespace GeminiV26.EntryTypes.INDEX
                 if (!strictDirection)
                 {
                     ctx.LogStructureAuthority("Index_PullbackEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
-                        $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={direction}");
+                        $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={direction} finalValid=true");
                     ctx.LogStructureAuthority("Index_PullbackEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
                         $"resolvedDir={direction}");
                 }

--- a/EntryTypes/METAL/XAU_FlagEntry.cs
+++ b/EntryTypes/METAL/XAU_FlagEntry.cs
@@ -35,18 +35,17 @@ namespace GeminiV26.EntryTypes.METAL
                 var logicDirection = ctx.LogicBiasDirection;
                 bool canUseLogicDirection =
                     structureDirAuthority &&
-                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
-                    (ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal || ctx.LastClosedBarInTrendDirection || ctx.M1TriggerInTrendDirection);
+                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short);
                 if (!canUseLogicDirection)
                 {
                     ctx.LogStructureAuthority("XAU_FlagEntry", "STILL_FAIL", "StructureDirection", "NONE",
-                        $"reason=NO_DIRECTION source={ctx.Structure.DirectionSource ?? "NA"}");
+                        $"reason=NO_DIRECTION source={ctx.Structure.DirectionSource ?? "NA"} finalValid=false");
                     return Reject(ctx, TradeDirection.None, "NO_LOGIC_BIAS", "[ENTRY][XAU_FLAG][BLOCK_DIR]");
                 }
 
                 dir = logicDirection;
                 ctx.LogStructureAuthority("XAU_FlagEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
-                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={dir}");
+                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={dir} finalValid=true");
                 ctx.LogStructureAuthority("XAU_FlagEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
                     $"resolvedDir={dir}");
             }

--- a/EntryTypes/METAL/XAU_PullbackEntry.cs
+++ b/EntryTypes/METAL/XAU_PullbackEntry.cs
@@ -33,18 +33,17 @@ namespace GeminiV26.EntryTypes.METAL
                 var logicDirection = ctx.LogicBiasDirection;
                 bool canUseLogicDirection =
                     structureDirAuthority &&
-                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short) &&
-                    (ctx.Structure.PullbackEarlySignal || ctx.Structure.PullbackConfirmedSignal || ctx.Structure.ContinuationEarlySignal || ctx.Structure.ContinuationConfirmedSignal || ctx.LastClosedBarInTrendDirection);
+                    (logicDirection == TradeDirection.Long || logicDirection == TradeDirection.Short);
                 if (!canUseLogicDirection)
                 {
                     ctx.LogStructureAuthority("XAU_PullbackEntry", "STILL_FAIL", "StructureDirection", "NONE",
-                        $"reason=NO_DIRECTION source={ctx.Structure.DirectionSource ?? "NA"}");
+                        $"reason=NO_DIRECTION source={ctx.Structure.DirectionSource ?? "NA"} finalValid=false");
                     return Reject(ctx, TradeDirection.None, "NO_LOGIC_BIAS", "[ENTRY][XAU_PB][BLOCK_DIR]");
                 }
 
                 dir = logicDirection;
                 ctx.LogStructureAuthority("XAU_PullbackEntry", "DIR_OK", "StructureDirection", "LogicBiasDirection",
-                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={dir}");
+                    $"source={ctx.Structure.DirectionSource ?? "NA"} resolvedDir={dir} finalValid=true");
                 ctx.LogStructureAuthority("XAU_PullbackEntry", "ALT_PATH_USED", "StructureDirection", "LogicBiasDirection",
                     $"resolvedDir={dir}");
             }


### PR DESCRIPTION
### Motivation
- Upstream composite structure signals are now available at runtime but legacy strict booleans still caused entries to be rejected before those alternate paths could rescue a setup.
- The change must be minimal and production-safe: let composite authority (direction/impulse/pullback/flag) actually override old strict invalidation when upstream indicates a valid alternate path while preserving existing safety gates.  

### Description
- Enriched structure-authority logging in `Core/Entry/EntryContext.cs` so every `[STRUCT][AUTH][...]` message includes strict-state booleans, composite-state booleans, and an inferred `finalValid=true|false` flag.  
- Relaxed direction-fallback gating in FX/INDEX/XAU entry families so `LogicBiasDirection` can be used when `IsStructureDirectionAuthoritative()` is true (removed extra continuation/trend preconditions that previously blocked the authority path).  
- For crypto families, implemented a composite direction resolution chain (`LogicBiasDirection -> RoutedDirection -> FinalDirection`) and returned that resolved direction when authority permits.  
- Prevented crypto flag from auto-failing `NO_RECENT_IMPULSE` when `IsStructureImpulseAuthoritative()` is true, and preserved all existing family-local widen/validation checks (impulse/pullback/flag wideners, fake-break and chop protections).  
- No router files or risk/exit/TP/confidence/analytics subsystems were modified; changes are constrained to entry-evaluation and logging code only.  

### Testing
- Static inspection and diffs were reviewed locally to confirm the targeted changes applied to the intended files and log sites.  
- Attempted an automated build with `dotnet build -v minimal` in this environment but the .NET SDK is not installed, so compilation could not be verified here.  
- No runtime integration tests were run in this container; behavior should be validated in a staging runtime to confirm runtime log lines (`[STRUCT][AUTH][DIR_OK|IMPULSE_OK|PULLBACK_OK|FLAG_OK|ALT_PATH_USED|STILL_FAIL]`) and to ensure rescued setups are no longer immediately re-killed by legacy strict reason codes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cec23a3cac8328adf9f2fe65694240)