### PR TITLE
Wire composite structure authority into strict kill points

### DIFF
--- a/Core/Entry/EntryContextBuilder.cs
+++ b/Core/Entry/EntryContextBuilder.cs
@@ -849,22 +849,62 @@ namespace GeminiV26.Core.Entry
             DetectFlagBreakout(ctx);
             MapStructureContinuationSignals(ctx);
 
+            bool directionAuthorityOk = ctx.IsStructureDirectionAuthoritative();
+            bool impulseAuthorityOk = ctx.IsStructureImpulseAuthoritative();
+            bool pullbackAuthorityOk = ctx.IsStructurePullbackAuthoritative();
+            bool flagAuthorityOk = ctx.IsStructureFlagAuthoritative();
+
             bool primaryChainOk =
-                ctx.Structure.HasImpulse &&
+                directionAuthorityOk &&
+                impulseAuthorityOk &&
                 ctx.Structure.PullbackStandardOk &&
                 ctx.Structure.FlagStandardOk;
 
             bool altChainOk =
-                ctx.Structure.HasImpulse &&
-                (ctx.Structure.PullbackShallowOk || ctx.Structure.HasMicroPullback) &&
-                ctx.Structure.FlagMessyOk;
+                directionAuthorityOk &&
+                impulseAuthorityOk &&
+                (ctx.Structure.PullbackShallowOk || ctx.Structure.HasMicroPullback || ctx.Structure.PullbackStandardOk) &&
+                (ctx.Structure.FlagMessyOk || ctx.Structure.FlagStandardOk);
+
+            bool compositeChainOk =
+                directionAuthorityOk &&
+                impulseAuthorityOk &&
+                pullbackAuthorityOk &&
+                flagAuthorityOk;
+
+            if (!primaryChainOk && compositeChainOk)
+            {
+                if (!ctx.Structure.HasImpulse && impulseAuthorityOk)
+                {
+                    GlobalLogger.Log(_bot,
+                        $"[STRUCT][AUTH][IMPULSE_OK] symbol={ctx.Symbol ?? "NA"} recent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()} age={ctx.Structure.ImpulseAgeBars}");
+                }
+                if (!ctx.Structure.HasPullback && pullbackAuthorityOk)
+                {
+                    string pbMode = ctx.Structure.PullbackStandardOk ? "standard" : "shallow";
+                    GlobalLogger.Log(_bot,
+                        $"[STRUCT][AUTH][PULLBACK_OK] symbol={ctx.Symbol ?? "NA"} mode={pbMode}");
+                }
+                if (!ctx.Structure.HasFlag && flagAuthorityOk)
+                {
+                    string flagMode = ctx.Structure.FlagStandardOk ? "standard" : "messy";
+                    GlobalLogger.Log(_bot,
+                        $"[STRUCT][AUTH][FLAG_OK] symbol={ctx.Symbol ?? "NA"} mode={flagMode}");
+                }
+                if (ctx.Structure.ImpulseRecentOk && !ctx.Structure.HasImpulse)
+                    GlobalLogger.Log(_bot, $"[STRUCT][AUTH][ALT_PATH_USED] symbol={ctx.Symbol ?? "NA"} alt=recent_impulse");
+                if ((ctx.Structure.PullbackShallowOk || ctx.Structure.HasMicroPullback) && !ctx.Structure.PullbackStandardOk)
+                    GlobalLogger.Log(_bot, $"[STRUCT][AUTH][ALT_PATH_USED] symbol={ctx.Symbol ?? "NA"} alt=shallow_pullback");
+                if (ctx.Structure.FlagMessyOk && !ctx.Structure.FlagStandardOk)
+                    GlobalLogger.Log(_bot, $"[STRUCT][AUTH][ALT_PATH_USED] symbol={ctx.Symbol ?? "NA"} alt=messy_flag");
+            }
 
             if (!primaryChainOk && altChainOk)
             {
                 GlobalLogger.Log(_bot,
                     $"[STRUCT][CHAIN][PRIMARY_FAIL_ALT_OK] dir={ctx.Structure.StructureDirection} impulseRecent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()} impulseAge={ctx.Structure.ImpulseAgeBars} pbDepth={ctx.Structure.PullbackDepth:0.00} pbBars={ctx.Structure.PullbackBars} flagBars={ctx.Structure.FlagBars} comp={ctx.Structure.FlagCompression:0.00}");
             }
-            else if (!primaryChainOk && !altChainOk)
+            else if (!primaryChainOk && !altChainOk && !compositeChainOk)
             {
                 GlobalLogger.Log(_bot,
                     $"[STRUCT][CHAIN][FULL_FAIL] dir={ctx.Structure.StructureDirection} source={ctx.Structure.DirectionSource ?? "NA"} impulse={ctx.Structure.HasImpulse.ToString().ToLowerInvariant()} impulseRecent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()} impulseAge={ctx.Structure.ImpulseAgeBars} pb={ctx.Structure.HasPullback.ToString().ToLowerInvariant()} pbDepth={ctx.Structure.PullbackDepth:0.00} pbBars={ctx.Structure.PullbackBars} flag={ctx.Structure.HasFlag.ToString().ToLowerInvariant()} flagBars={ctx.Structure.FlagBars} comp={ctx.Structure.FlagCompression:0.00}");
@@ -1069,6 +1109,17 @@ namespace GeminiV26.Core.Entry
 
             if (direction == TradeDirection.None)
             {
+                if (ctx.IsStructureDirectionAuthoritative() && (ctx.LogicBiasDirection == TradeDirection.Long || ctx.LogicBiasDirection == TradeDirection.Short))
+                {
+                    direction = ctx.LogicBiasDirection;
+                    ctx.Structure.StructureDirection = direction;
+                    GlobalLogger.Log(_bot,
+                        $"[STRUCT][AUTH][DIR_OK] symbol={ctx.Symbol ?? "NA"} dir={direction} source={ctx.Structure.DirectionSource ?? "NA"}");
+                }
+            }
+
+            if (direction == TradeDirection.None)
+            {
                 ctx.Structure.HasImpulse = false;
                 ctx.Structure.ImpulseRecentOk = false;
                 ctx.Structure.ImpulseAgeBars = ctx.BarsSinceImpulse_M5;
@@ -1170,6 +1221,13 @@ namespace GeminiV26.Core.Entry
 
             TradeDirection direction = ctx.Structure.StructureDirection;
             bool impulseOk = ctx.Structure.HasImpulse || ctx.Structure.ImpulseRecentOk;
+            if (!ctx.Structure.HasImpulse && impulseOk)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][AUTH][IMPULSE_OK] symbol={ctx.Symbol ?? "NA"} recent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()} age={ctx.Structure.ImpulseAgeBars}");
+                if (ctx.Structure.ImpulseRecentOk)
+                    GlobalLogger.Log(_bot, $"[STRUCT][AUTH][ALT_PATH_USED] symbol={ctx.Symbol ?? "NA"} alt=recent_impulse");
+            }
             if (!impulseOk)
             {
                 GlobalLogger.Log(_bot,
@@ -1246,6 +1304,14 @@ namespace GeminiV26.Core.Entry
 
             TradeDirection direction = ctx.Structure.StructureDirection;
             bool pullbackOk = ctx.Structure.HasPullback || ctx.Structure.PullbackShallowOk || ctx.Structure.HasMicroPullback;
+            if (!ctx.Structure.HasPullback && pullbackOk)
+            {
+                string mode = ctx.Structure.PullbackStandardOk ? "standard" : "shallow";
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][AUTH][PULLBACK_OK] symbol={ctx.Symbol ?? "NA"} mode={mode}");
+                if ((ctx.Structure.PullbackShallowOk || ctx.Structure.HasMicroPullback) && !ctx.Structure.PullbackStandardOk)
+                    GlobalLogger.Log(_bot, $"[STRUCT][AUTH][ALT_PATH_USED] symbol={ctx.Symbol ?? "NA"} alt=shallow_pullback");
+            }
             if (!pullbackOk)
             {
                 GlobalLogger.Log(_bot,
@@ -1296,6 +1362,12 @@ namespace GeminiV26.Core.Entry
             ctx.Structure.FlagStandardOk = standardOk;
             ctx.Structure.FlagMessyOk = messyOk;
             ctx.Structure.HasFlag = standardOk || messyOk;
+            if (!ctx.Structure.FlagStandardOk && ctx.Structure.FlagMessyOk)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][AUTH][FLAG_OK] symbol={ctx.Symbol ?? "NA"} mode=messy");
+                GlobalLogger.Log(_bot, $"[STRUCT][AUTH][ALT_PATH_USED] symbol={ctx.Symbol ?? "NA"} alt=messy_flag");
+            }
 
             if (!ctx.Structure.HasFlag)
             {

--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -3310,7 +3310,9 @@ namespace GeminiV26.Core
             if (IsFlagEntryType(candidate.Type))
             {
                 int flagBars = GetFlagBarsForCandidate(ctx, candidate, transition);
+                bool flagAuthorityOk = ctx.IsStructureFlagAuthoritative();
                 bool hasValidFlagContext = transition.HasFlag ||
+                                           flagAuthorityOk ||
                                            transition.FlagBars > 0 ||
                                            (ctx.FlagHigh > ctx.FlagLow) ||
                                            ctx.FlagAtr_M5 > 0 ||
@@ -3320,6 +3322,15 @@ namespace GeminiV26.Core
                     bool shouldHardBlock = flagBars == 0 || !hasValidFlagContext;
                     GlobalLogger.Log(_bot,
                         $"[INDEX][FLAG_CHECK] flagBars={flagBars} action={(shouldHardBlock ? "block" : "penalty")}");
+
+                    if (shouldHardBlock && flagAuthorityOk)
+                    {
+                        shouldHardBlock = false;
+                        GlobalLogger.Log(_bot,
+                            $"[STRUCT][AUTH][FLAG_OK] symbol={instrument} mode={(ctx.Structure.FlagStandardOk ? "standard" : "messy")}");
+                        if (!ctx.Structure.FlagStandardOk && ctx.Structure.FlagMessyOk)
+                            GlobalLogger.Log(_bot, $"[STRUCT][AUTH][ALT_PATH_USED] symbol={instrument} alt=messy_flag");
+                    }
 
                     if (shouldHardBlock)
                     {
@@ -3345,7 +3356,8 @@ namespace GeminiV26.Core
                 }
             }
 
-            if (!transition.HasImpulse)
+            bool impulseAuthorityOk = ctx.IsStructureImpulseAuthoritative();
+            if (!transition.HasImpulse && !impulseAuthorityOk)
             {
                 if (instrumentClass == InstrumentClass.CRYPTO)
                 {
@@ -3375,6 +3387,13 @@ namespace GeminiV26.Core
                 GlobalLogger.Log(_bot,
                     $"[ENTRY][FILTER][NO_IMPULSE] instrument={instrumentClass} entryType={candidate.Type} action=penalty score={impulseScoreBefore}->{candidate.Score} penalty={penalty}");
                 return true;
+            }
+            else if (!transition.HasImpulse && impulseAuthorityOk)
+            {
+                GlobalLogger.Log(_bot,
+                    $"[STRUCT][AUTH][IMPULSE_OK] symbol={instrument} recent={ctx.Structure.ImpulseRecentOk.ToString().ToLowerInvariant()} age={ctx.Structure.ImpulseAgeBars}");
+                if (ctx.Structure.ImpulseRecentOk && !ctx.Structure.HasImpulse)
+                    GlobalLogger.Log(_bot, $"[STRUCT][AUTH][ALT_PATH_USED] symbol={instrument} alt=recent_impulse");
             }
 
             bool weakStructure =


### PR DESCRIPTION
### Motivation
- Runtime audits showed upstream structure fields and `[STRUCT][*]` logs present while downstream decision points still used legacy strict booleans and produced `NO_VALID_PULLBACK`, `FLAG_PREREQ_NO_PULLBACK` and `CHAIN FULL_FAIL` without rescue.
- The intent is to let a deterministic composite structure authority override legacy strict rejects so valid upstream structure (direction/impulse/pullback/flag) can unblock downstream entry evaluation.

### Description
- Introduced composite authority gating and explicit authority logs in `Core/Entry/EntryContextBuilder.cs` so chain verdicts consider `IsStructureDirectionAuthoritative`, `IsStructureImpulseAuthoritative`, `IsStructurePullbackAuthoritative`, and `IsStructureFlagAuthoritative` before emitting `FULL_FAIL` or prereq fails.
- Added direction override using `LogicBiasDirection` when `IsStructureDirectionAuthoritative()` is true and emitted `[STRUCT][AUTH][DIR_OK]` accordingly in `EntryContextBuilder` during direction resolution.
- Emitted authoritative rescue logs at prereq points: `[STRUCT][AUTH][IMPULSE_OK]`, `[STRUCT][AUTH][PULLBACK_OK]`, `[STRUCT][AUTH][FLAG_OK]`, and `[STRUCT][AUTH][ALT_PATH_USED]` (recent_impulse | shallow_pullback | messy_flag) where they have actual decision impact.
- Updated `Core/TradeCore.cs` weak-structure filtering to consult `IsStructureFlagAuthoritative()` and `IsStructureImpulseAuthoritative()` so flag hard-blocks and NO_IMPULSE blocks/penalties can be bypassed when composite authority is valid.
- Files changed: `Core/Entry/EntryContextBuilder.cs` and `Core/TradeCore.cs` and associated logging strings added/adjusted; no session/HTF/risk/executor logic or architecture redesign performed.

### Testing
- Ran `git diff --check` which reported no whitespace/diff errors and the changes were committed successfully (commit message: `Wire composite structure authority into strict kill points`).
- Verified presence of the added authority log patterns with `rg`/`rg -n` searches for the new `[STRUCT][AUTH][...]` tags and found the inserted log lines in the modified files.
- Attempted a full compile/test run but the repository contains no `.csproj`/`.sln` files so a build/integration test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf900f0ec48328b3d7ceebc3cc2ba5)