### PR TITLE
Add Gemini V26 controlled rescue mix plan document

### DIFF
--- a/MIX_PLAN_2026-04-03.md
+++ b/MIX_PLAN_2026-04-03.md
@@ -1,0 +1,197 @@
+# Gemini V26 Rescue Mix Plan (Current shell + 03.27 entry baseline)
+
+## 1. OVERALL MIX VERDICT
+- **Jó irány**.
+- A repository állapota alapján a legkisebb kockázatú út: **entry stack visszaemelése 03.27 baseline-ra**, miközben a mai lifecycle/infra/risk/logging/rehydrate ág érintetlen marad.
+- A legfőbb regresszió-forrás most a post-03.27 entry-végi kill layer: FinalAcceptance/Qualification + structural authority hard-veto kombináció.
+
+---
+
+## 2. ENTRY TRANSPLANT MAP (03.27-ből visszahozandó)
+
+### A) Entry pipeline core (fájl szinten)
+1. `Core/TradeCore.cs`
+   - **Entry type registry blokk** (FX/INDEX/METAL/CRYPTO + fallback) vissza 03.27 szerinti széles runtime készletre.
+   - **Entry selection utáni acceptance flow** 03.27 logikára: a jelenlegi `PassFinalAcceptance(...)` előtti/utáni hard-veto szakasz megszüntetése.
+   - 03.27-es fallback entry branch vissza (`TC_*`, `BR_*`, `TR_*`).
+2. `Core/Entry/EntryContextBuilder.cs`
+   - A composite structure authority/rework blokkok 03.27 verziójára vissza.
+3. `Core/Entry/EntryContext.cs`
+   - Entry-oldali strukturális authority helper/logging vissza 03.27 állapotra (vagy teljes kivétel, ahol a 03.27 nem használta).
+4. `Core/Entry/TransitionDetector.cs`
+   - 03.27 transition scoring/selection viselkedés vissza (a mai shell interfészek megtartásával).
+5. `Core/Entry/EntryEvaluation.cs`, `Core/Entry/EntryType.cs`, `Core/Entry/EntryRouter.cs`
+   - 03.27 kompatibilis entry routing/enum reasoning visszaállítás.
+
+### B) Entry types (03.27 source vissza)
+- FX:
+  - `EntryTypes/FX/FX_FlagEntry.cs`
+  - `EntryTypes/FX/FX_FlagContinuationEntry.cs`
+  - `EntryTypes/FX/FX_MicroStructureEntry.cs`
+  - `EntryTypes/FX/FX_MicroContinuationEntry.cs`
+  - `EntryTypes/FX/FX_ImpulseContinuationEntry.cs`
+  - `EntryTypes/FX/FX_PullbackEntry.cs`
+  - `EntryTypes/FX/FX_RangeBreakoutEntry.cs`
+  - `EntryTypes/FX/FX_ReversalEntry.cs`
+- INDEX:
+  - `EntryTypes/INDEX/Index_PullbackEntry.cs`
+  - `EntryTypes/INDEX/Index_BreakoutEntry.cs`
+  - `EntryTypes/INDEX/Index_FlagEntry.cs`
+- METAL:
+  - `EntryTypes/METAL/XAU_FlagEntry.cs`
+  - `EntryTypes/METAL/XAU_PullbackEntry.cs`
+  - `EntryTypes/METAL/XAU_ReversalEntry.cs`
+  - `EntryTypes/METAL/XAU_ImpulseEntry.cs`
+- CRYPTO:
+  - `EntryTypes/CRYPTO/BTC_PullbackEntry.cs`
+  - `EntryTypes/CRYPTO/BTC_FlagEntry.cs`
+  - `EntryTypes/CRYPTO/BTC_RangeBreakoutEntry.cs`
+  - `EntryTypes/CRYPTO/Crypto_ImpulseEntry.cs`
+- fallback/shared:
+  - `EntryTypes/TC_PullbackEntry.cs`
+  - `EntryTypes/TC_FlagEntry.cs`
+  - `EntryTypes/BR_RangeBreakoutEntry.cs`
+  - `EntryTypes/TR_ReversalEntry.cs`
+
+### C) Instrument entry logic bekötések
+- `Instruments/*/*EntryLogic.cs` fájlok csak annyiban igazítandók, hogy a 03.27 entry routinggal konzisztensen adjanak bias/score inputot; lifecycle/risk/exit részek **nem** transplantálandók.
+
+---
+
+## 3. CURRENT SHELL RETAIN MAP (mai verzióból megtartandó)
+
+### KÖTELEZŐ retain (explicit célok)
+1. **Rehydrate full**
+   - `Core/Runtime/RehydrateService.cs`
+   - `Core/Runtime/BotRestartState.cs`
+   - `Core/RuntimeSymbolResolver.cs`
+   - instrument exit managerek rehydrate recovery logikája (`Instruments/*/*ExitManager.cs`)
+2. **FX router fix / symbol normalization**
+   - `Core/SymbolRouting.cs`
+   - `Core/RuntimeSymbolResolver.cs`
+3. **Direction internal guard**
+   - `Core/DirectionGuard.cs`
+   - direction consistency hívások a `Core/TradeCore.cs` + instrument executorokban
+4. **HTF mismatch soft kezelés (nem hard block)**
+   - HTF soft mismatch kezelés a mai entry type-okban, ahol már soft penalty működik
+5. **TVM / TTM / trailing fejlettebb ág**
+   - `Core/TradeViabilityMonitor.cs`
+   - `Core/TradeManagement/TrendTradeManager.cs`
+   - `Core/TradeManagement/AdaptiveTrailingEngine.cs`
+   - `Core/TradeManagement/TrailingProfiles.cs`
+   - instrument exit managerek TP1 smart/advanced trailing részei
+6. **Daily DD limit ~3%**
+   - `Core/Risk/GeminiRiskConfig.cs` (jelenleg 2.9%)
+   - `Core/Risk/GlobalRiskGuard.cs`
+   - `Core/TradeCore.cs` daily DD gate hívás
+7. **Global logging stack**
+   - `Core/Logging/GlobalLogger.cs`
+   - `Core/Logging/RuntimeFileLogger.cs`
+   - `Core/Logging/TradeAuditLog.cs`
+   - `Core/Analytics/UnifiedAnalyticsWriter.cs`
+8. **Instrument-specific modern fixek**
+   - instrument executor/exit manager javítások a jelenlegi állapotból maradjanak (különösen resolver, safe modify, runtime logging, post-TP1 viselkedés).
+
+---
+
+## 4. REMOVE MAP (kivágandó FA / Qualification / structural rework)
+
+### A) Final Acceptance / Qualification kill layer
+1. `Core/TradeCore.cs`
+   - `PassFinalAcceptance(...)` teljes kivágás.
+   - `PassIndexPullbackQualification(...)` teljes kivágás.
+   - minden olyan callsite kivágása, ami `BLOCK: final acceptance gate` útvonalat hoz.
+2. `Core/Entry/Qualification/EntryStateEvaluator.cs`
+   - teljes réteg törlése.
+3. `Core/Entry/EntryContext.cs`
+   - `QualificationState` property törlése.
+   - Qualificationhez kötött DTO/reference tisztítás.
+4. Qualification referenciák törlése:
+   - `Core/TradeCore.cs` (`ctx.QualificationState?.*` használatok)
+   - `EntryTypes/METAL/XAU_PullbackEntry.cs` (`QualificationState?.HasTrend`)
+
+### B) Failed structural authority rework (post-03.27)
+1. `Core/Entry/EntryContextBuilder.cs`
+   - composite authority chain és rescue override blokkok eltávolítása.
+2. `Core/Entry/EntryContext.cs`
+   - structural authority-specifikus helper/log instrumentation eltávolítása vagy 03.27 állapotra vissza.
+3. Entry type fájlokból törlendő a hard-veto jellegű authority-reliance:
+   - `EntryTypes/FX/FX_FlagContinuationEntry.cs`
+   - `EntryTypes/FX/FX_ImpulseContinuationEntry.cs`
+   - `EntryTypes/INDEX/Index_FlagEntry.cs`
+   - `EntryTypes/INDEX/Index_PullbackEntry.cs`
+   - `EntryTypes/METAL/XAU_FlagEntry.cs`
+   - `EntryTypes/METAL/XAU_PullbackEntry.cs`
+   - `EntryTypes/CRYPTO/CryptoFlagEntryBase.cs`
+   - `EntryTypes/CRYPTO/CryptoPullbackEntryBase.cs`
+4. `Core/TradeCore.cs`
+   - continuation authority jellegű extra post-selection veto (`HasContinuationAuthority`-alapú block) eltávolítás / 03.27 baseline-ra húzás.
+
+---
+
+## 5. OLD ENTRY TYPES RESTORE MAP
+
+### A) Mi hiányzik a mai runtime-ból (fájl létezik, de nincs regisztrálva)
+1. **FX-ből hiányzik runtime-ból**:
+   - `FX_FlagEntry`
+   - `FX_MicroStructureEntry`
+   - `FX_MicroContinuationEntry`
+   - `FX_PullbackEntry`
+   - `FX_RangeBreakoutEntry`
+   - `FX_ReversalEntry`
+2. **INDEX-ből hiányzik runtime-ból**:
+   - `Index_BreakoutEntry`
+3. **METAL-ból hiányzik runtime-ból**:
+   - `XAU_ReversalEntry`
+   - `XAU_ImpulseEntry`
+4. **CRYPTO-ból hiányzik runtime-ból**:
+   - `BTC_RangeBreakoutEntry`
+5. **Fallback branch teljesen inaktív**:
+   - `TC_PullbackEntry`, `TC_FlagEntry`, `BR_RangeBreakoutEntry`, `TR_ReversalEntry`
+
+### B) Registry/router bekötési pontok
+1. `Core/TradeCore.cs` constructor entry registration blokk:
+   - FX/INDEX/METAL/CRYPTO listák 03.27 szerinti bővítése.
+   - unknown/fallback branch újra aktiválása.
+2. `Core/Entry/EntryRouter.cs`
+   - további módosítás nem kell, ha a registry lista visszaáll.
+3. `Core/Entry/EntryType.cs`
+   - enum érintettség validálása a visszahozott típusokhoz.
+4. `EntryTypes/IEntryType.cs`
+   - interface kompatibilitás validálása (signature drift ellenőrzés).
+
+---
+
+## 6. CONFLICT HOTSPOTS (mixed responsibility, kézi figyelem kell)
+1. `Core/TradeCore.cs`
+   - egyszerre: entry orchestration + risk gate + lifecycle + dispatch + logging.
+   - legnagyobb merge-kockázat.
+2. `Core/Entry/EntryContextBuilder.cs`
+   - entry struct + authority + HTF + score előkészítés egyben.
+3. `Core/Entry/EntryContext.cs`
+   - shared state object: entry + execution + exit + audit mezők.
+4. `EntryTypes/METAL/XAU_PullbackEntry.cs`
+   - entry jel + qualification dependency + authority override együtt.
+5. `EntryTypes/CRYPTO/CryptoFlagEntryBase.cs` és `CryptoPullbackEntryBase.cs`
+   - új bázisosztályosítás (ETH/BTC megosztott logika) + authority layer összefonódás.
+6. `Core/TradeViabilityMonitor.cs` / `Instruments/*/*ExitManager.cs`
+   - entry pipeline változás impactelheti a tvm/ttm trigger mintázatot, de ezen fájlokat nem szabad visszarántani 03.27-re.
+
+---
+
+## 7. RECOMMENDED IMPLEMENTATION ORDER
+1. **Guardrail snapshot + branch prep**
+   - freeze current shell (rehydrate/risk/logging/exit) ellenőrző checklist.
+2. **Hard remove phase**
+   - FA/Qualification + structural authority hard-veto elemek kivágása (`TradeCore`, `EntryContext`, `EntryContextBuilder`, Qualification fájl).
+3. **Entry registry restore**
+   - `TradeCore` entry listák vissza 03.27-re (FX/INDEX/METAL/CRYPTO/fallback).
+4. **Entry type transplant**
+   - 03.27 verziójú entry type implementációk visszahozása célzottan.
+5. **Pipeline reconciliation**
+   - `EntryContextBuilder`, `TransitionDetector`, `EntryEvaluation` összehangolása a mai shell interfésszel.
+6. **Safety retain verification**
+   - rehydrate full, direction guard, HTF soft mismatch, TVM/TTM/trailing, DD 3%, GlobalLogging, instrument fixek regresszióteszt.
+7. **Runtime smoke + log audit**
+   - symbolonként ellenőrzés: van jelölés, nincs extra entry-végi kill, viszont risk/lifecycle/logging marad.
+


### PR DESCRIPTION
### Motivation
- Provide a concrete, non-code rollback plan to transplant the 03.27 entry pipeline into the current stable shell while preserving lifecycle/infra/risk/logging/rehydrate improvements.
- Capture exact files, transplant scope, removal targets, conflict hotspots and an ordered implementation plan so engineers can perform the controlled MIX without ad-hoc changes.

### Description
- Add `MIX_PLAN_2026-04-03.md` at repository root containing the full rescue mix plan (overall verdict, entry transplant map, current-shell retain map, remove map, old entry types restore map, conflict hotspots and recommended implementation order).
- The document enumerates precise files to restore from 03.27 (entry pipeline and entry types), files/behaviour to retain from the current shell (rehydrate, direction guard, HTF soft handling, TVM/TTM/trailing, DD limit ~3%, global logging and instrument fixes) and qualification/authority elements to remove.
- The change is committed with the message `Add controlled rescue mix plan for 03.27 entry transplant` and does not modify runtime code or behavior.

### Testing
- Ran `git status --short` to confirm staged/untracked changes and the repository state, which completed successfully.
- Ran `git show --stat --oneline HEAD` to verify the commit and file addition, which reported the new file `MIX_PLAN_2026-04-03.md` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa1797f1c8328bf0484132deb8cea)