### PR TITLE
Port GlobalLogging analytics/audit layer to 03.27 baseline

### DIFF
--- a/Core/Analytics/UnifiedAnalyticsWriter.cs
+++ b/Core/Analytics/UnifiedAnalyticsWriter.cs
@@ -9,8 +9,10 @@ namespace GeminiV26.Core.Analytics
     public static class UnifiedAnalyticsWriter
     {
         private static readonly ConcurrentDictionary<string, object> _locks = new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-        private const string Header = "Symbol,PositionId,SetupType,EntryType,MarketRegime,MfeR,MaeR,RMultiple,TransitionQuality,Confidence,Profit,OpenTimeUtc,CloseTimeUtc";
-        private const string FallbackHeader = "Symbol,PositionId,SetupType,EntryType,MarketRegime,MfeR,MaeR,RMultiple,TransitionQuality,Confidence,Profit,OpenTimeUtc,CloseTimeUtc,FailureReason";
+        // Active analytics SSOT schema.
+        // Confidence column kept as backward-compatible alias for downstream readers.
+        private const string Header = "Symbol,PositionId,SetupType,EntryType,InstrumentClass,MarketRegime,MfeR,MaeR,RMultiple,TransitionQuality,FinalConfidence,Confidence,Profit,OpenTimeUtc,CloseTimeUtc";
+        private const string FallbackHeader = "Symbol,PositionId,SetupType,EntryType,InstrumentClass,MarketRegime,MfeR,MaeR,RMultiple,TransitionQuality,FinalConfidence,Confidence,Profit,OpenTimeUtc,CloseTimeUtc,FailureReason";
         private static int _degradedState;
 
         public static bool IsDegraded => _degradedState == 1;
@@ -52,11 +54,13 @@ namespace GeminiV26.Core.Analytics
                             Csv(resolvedPositionId),
                             Csv(record.SetupType),
                             Csv(record.EntryType),
+                            Csv(record.InstrumentClass),
                             Csv(record.MarketRegime),
                             record.MfeR.ToString("0.####", CultureInfo.InvariantCulture),
                             record.MaeR.ToString("0.####", CultureInfo.InvariantCulture),
                             record.RMultiple.ToString("0.####", CultureInfo.InvariantCulture),
                             record.TransitionQuality.ToString("0.####", CultureInfo.InvariantCulture),
+                            record.FinalConfidence.ToString("0.####", CultureInfo.InvariantCulture),
                             record.Confidence.ToString("0.####", CultureInfo.InvariantCulture),
                             record.Profit.ToString(CultureInfo.InvariantCulture),
                             record.OpenTimeUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
@@ -105,11 +109,13 @@ namespace GeminiV26.Core.Analytics
                             Csv(resolvedPositionId),
                             Csv(record.SetupType),
                             Csv(record.EntryType),
+                            Csv(record.InstrumentClass),
                             Csv(record.MarketRegime),
                             record.MfeR.ToString("0.####", CultureInfo.InvariantCulture),
                             record.MaeR.ToString("0.####", CultureInfo.InvariantCulture),
                             record.RMultiple.ToString("0.####", CultureInfo.InvariantCulture),
                             record.TransitionQuality.ToString("0.####", CultureInfo.InvariantCulture),
+                            record.FinalConfidence.ToString("0.####", CultureInfo.InvariantCulture),
                             record.Confidence.ToString("0.####", CultureInfo.InvariantCulture),
                             record.Profit.ToString(CultureInfo.InvariantCulture),
                             record.OpenTimeUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
@@ -136,7 +142,13 @@ namespace GeminiV26.Core.Analytics
 
         private static string Csv(string value)
         {
-            return value ?? string.Empty;
+            if (string.IsNullOrEmpty(value))
+                return string.Empty;
+
+            if (value.IndexOfAny(new[] { ',', '"', '\n', '\r' }) >= 0)
+                return "\"" + value.Replace("\"", "\"\"") + "\"";
+
+            return value;
         }
     }
 }

--- a/Core/Logging/TradeAuditLog.cs
+++ b/Core/Logging/TradeAuditLog.cs
@@ -66,7 +66,7 @@ namespace GeminiV26.Core.Logging
                    $"finalConfidence={ctx.FinalConfidence}\n" +
                    "statePenalty=0\n" +
                    $"adjustedRiskConfidence={ctx.RiskConfidence}\n" +
-                   $"riskFinal={ctx.RiskConfidence}\n" +
+                   $"riskConfidence={ctx.RiskConfidence}\n" +
                    $"atr={ctx?.AtrM5 ?? 0:0.#####}\n" +
                    $"adx={ctx?.Adx_M5 ?? 0:0.##}\n" +
                    $"htfDirection={htfDirection}\n" +


### PR DESCRIPTION
### Motivation
- Restore the GlobalLogging analytics/audit layer from the donor branch into the 03.27 baseline to improve observability while keeping runtime/entry behavior unchanged.
- Only the logging/analytics surface should change so that entry decisioning, scoring, routing, qualification, FA, and runtime behavior remain identical to the baseline.

### Description
- Reinstated analytics SSOT schema and fallback schema in `Core/Analytics/UnifiedAnalyticsWriter.cs`, reintroducing the `InstrumentClass` and `FinalConfidence` columns and restoring robust CSV escaping and fallback write behavior.
- Restored the entry snapshot field naming in `Core/Logging/TradeAuditLog.cs` to use `riskConfidence` (reverting the donor-to-baseline name mismatch that produced `riskFinal`).
- No other files or business logic were modified and no entry pipeline, scoring, routing, risk, FA, qualification, rehydrate, TVM/trailing, direction, or runtime algorithms were touched.

### Testing
- Performed a repository-wide usage scan with `rg` to confirm logging call-sites and ensure analytics wiring is localized to the analytics/logging layer and that no behavioral callsites were altered.
- Verified changed files with `git diff --cached --name-only` and confirmed only `Core/Analytics/UnifiedAnalyticsWriter.cs` and `Core/Logging/TradeAuditLog.cs` are in scope and forbidden scopes remained untouched by running a targeted diff for those directories.
- Ran a patch formatting/whitespace validation with `git diff --cached --check` and found no formatting errors.
- All automated checks completed successfully and indicate the port is limited to the logging/analytics scope described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfcba391d88328af74b700069c1b33)