### PR TITLE
Port daily drawdown global risk guard wiring into 03.27 TradeCore

### DIFF
--- a/Core/TradeCore.cs
+++ b/Core/TradeCore.cs
@@ -65,6 +65,7 @@ using GeminiV26.Core.Matrix;
 using GeminiV26.Core.Context;
 using GeminiV26.Core.Analytics;
 using GeminiV26.Core.Memory;
+using GeminiV26.Core.Risk;
 using GeminiV26.Core.Runtime;
 using System.Linq;
 
@@ -261,6 +262,7 @@ namespace GeminiV26.Core
         private bool isIndexSymbol;
 
         private GlobalSessionGate _globalSessionGate;
+        private readonly GlobalRiskGuard _globalRiskGuard;
         private SessionMatrix _sessionMatrix;
 
         private EntryContext _ctx;
@@ -386,6 +388,9 @@ namespace GeminiV26.Core
             _memoryEngine = new MarketMemoryEngine(safePrint);
             _contextBuilder = new EntryContextBuilder(bot, _memoryEngine);
             _globalSessionGate = new GlobalSessionGate(_bot);
+            _globalRiskGuard = new GlobalRiskGuard(
+                new GeminiRiskConfig(),
+                message => GeminiV26.Core.Logging.GlobalLogger.Log(_bot, message));
             _sessionMatrix = new SessionMatrix(new SessionMatrixProvider());
 
             _xauEntryLogic = new XauEntryLogic(_bot);
@@ -883,6 +888,12 @@ namespace GeminiV26.Core
             {
                 GeminiV26.Core.Logging.GlobalLogger.Log(_bot, "[DEBUG] HasOpenGeminiPosition = TRUE");
                 GeminiV26.Core.Logging.GlobalLogger.Log(_bot, "BLOCK: existing Gemini position open");
+                return;
+            }
+
+            if (!(_globalRiskGuard?.CanTrade(_bot.Account.Equity, _bot.Server.Time) ?? true))
+            {
+                GeminiV26.Core.Logging.GlobalLogger.Log(_bot, "[TC] BLOCKED: GlobalRiskGuard daily drawdown");
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Port the existing daily drawdown (DD) global risk guard into the 03.27 baseline with minimal, non-invasive wiring so entry/trade selection behaviour remains unchanged.

### Description
- Added `using GeminiV26.Core.Risk`, a `private readonly GlobalRiskGuard _globalRiskGuard` field, and initialized it with `new GeminiRiskConfig()` and the `GlobalLogger` callback in `TradeCore` constructor.
- Added a single `OnBar` callsite that blocks the new-entry flow when `_globalRiskGuard.CanTrade(_bot.Account.Equity, _bot.Server.Time)` returns `false` and logs the block message.
- Reused the existing `Core/Risk/GeminiRiskConfig.cs` and `Core/Risk/GlobalRiskGuard.cs` as-is and made no changes to entry scoring, routing, veto, qualification, runtime, logging, analytics, or instrument executor/exit manager files.

### Testing
- Verified the working tree and committed the change with `git diff --name-only`, which showed only `Core/TradeCore.cs` was modified, and the commit succeeded.
- Ran a forbidden-scope diff check using `rg` to ensure no files under `Core/Entry/*`, `EntryTypes/*`, instrument executors/exits, `Core/TradeRouter.cs`, `Core/TradeViabilityMonitor.cs`, `Core/DirectionGuard.cs`, `Core/Runtime/*`, `Core/Logging/*`, `Core/Analytics/*` or instrument executors/exit managers were modified, and the check passed.
- Inspected `Core/Risk/GeminiRiskConfig.cs` and `Core/Risk/GlobalRiskGuard.cs` to confirm their logic is present and was reused unchanged.
- Did not run a full build because no `.sln`/`.csproj` files were present in this checkout; this was noted and no build errors were attempted to be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfe61170c483288cc0f7f637267a0a)